### PR TITLE
ci: build the latest Android test APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,149 @@
+name: Android
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: sdkmanager "platforms;android-37" "build-tools;37.0.0"
+
+      - name: Run unit tests and lint
+        run: ./gradlew --no-daemon testDebugUnitTest lintDebug
+
+      - name: Validate Compose screenshots
+        run: ./gradlew --no-daemon validateDebugScreenshotTest
+
+      - name: Verify debug packaging on pull requests
+        if: github.event_name == 'pull_request'
+        run: ./gradlew --no-daemon assembleDebug
+
+  publish-test-apk:
+    name: Publish latest test APK
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: sdkmanager "platforms;android-37" "build-tools;37.0.0"
+
+      - name: Build debug APK
+        env:
+          CELESTE_TEST_KEYSTORE_BASE64: ${{ secrets.CELESTE_TEST_KEYSTORE_BASE64 }}
+          CELESTE_TEST_KEYSTORE_PASSWORD: ${{ secrets.CELESTE_TEST_KEYSTORE_PASSWORD }}
+          CELESTE_TEST_KEY_ALIAS: ${{ secrets.CELESTE_TEST_KEY_ALIAS }}
+          CELESTE_TEST_KEYSTORE_PATH: ${{ runner.temp }}/celeste-test.jks
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$CELESTE_TEST_KEYSTORE_BASE64" || -z "$CELESTE_TEST_KEYSTORE_PASSWORD" || -z "$CELESTE_TEST_KEY_ALIAS" ]]; then
+            echo "The test-build signing secrets are not configured." >&2
+            exit 1
+          fi
+          printf '%s' "$CELESTE_TEST_KEYSTORE_BASE64" | base64 --decode > "$CELESTE_TEST_KEYSTORE_PATH"
+          chmod 600 "$CELESTE_TEST_KEYSTORE_PATH"
+          ./gradlew --no-daemon assembleDebug
+
+      - name: Prepare APK
+        shell: bash
+        run: cp app/build/outputs/apk/debug/app-debug.apk Hermes-Celeste-latest.apk
+
+      - name: Upload latest APK
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: Hermes-Celeste-latest.apk
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+          archive: false
+
+      - name: Remove superseded APK artifacts
+        env:
+          CURRENT_ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r artifact_id; do
+            if [[ -n "$artifact_id" && "$artifact_id" != "$CURRENT_ARTIFACT_ID" ]]; then
+              gh api --method DELETE \
+                "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+            fi
+          done < <(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=Hermes-Celeste-latest.apk&per_page=100" \
+              --jq '.artifacts[].id'
+          )
+
+          mapfile -t remaining_ids < <(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=Hermes-Celeste-latest.apk&per_page=100" \
+              --jq '.artifacts[].id'
+          )
+          if [[ "${#remaining_ids[@]}" -ne 1 || "${remaining_ids[0]}" != "$CURRENT_ARTIFACT_ID" ]]; then
+            echo "Expected only the newly uploaded APK artifact to remain." >&2
+            exit 1
+          fi
+
+      - name: Link test APK
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        shell: bash
+        run: |
+          {
+            echo "## Hermes Celeste test APK"
+            echo
+            echo "[Download the latest successful debug build](${ARTIFACT_URL})"
+            echo
+            echo "Built from \`${GITHUB_SHA}\`. GitHub sign-in is required."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove test keystore
+        if: always()
+        env:
+          CELESTE_TEST_KEYSTORE_PATH: ${{ runner.temp }}/celeste-test.jks
+        shell: bash
+        run: rm -f "$CELESTE_TEST_KEYSTORE_PATH"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: |
           "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
-            "platforms;android-37" \
+            "platforms;android-37.0" \
             "build-tools;37.0.0"
 
       - name: Run unit tests and lint
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
-            "platforms;android-37" \
+            "platforms;android-37.0" \
             "build-tools;37.0.0"
 
       - name: Build debug APK

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,10 @@ jobs:
 
       - name: Install Android SDK packages
         shell: bash
-        run: sdkmanager "platforms;android-37" "build-tools;37.0.0"
+        run: |
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            "platforms;android-37" \
+            "build-tools;37.0.0"
 
       - name: Run unit tests and lint
         run: ./gradlew --no-daemon testDebugUnitTest lintDebug
@@ -67,7 +70,10 @@ jobs:
 
       - name: Install Android SDK packages
         shell: bash
-        run: sdkmanager "platforms;android-37" "build-tools;37.0.0"
+        run: |
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
+            "platforms;android-37" \
+            "build-tools;37.0.0"
 
       - name: Build debug APK
         env:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 
+val testKeystorePath = providers.environmentVariable("CELESTE_TEST_KEYSTORE_PATH").orNull
+
 android {
     namespace = "dev.hazydreams.hermesceleste"
     compileSdk = 37
@@ -27,6 +29,23 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    signingConfigs {
+        if (testKeystorePath != null) {
+            create("ciTest") {
+                storeFile = file(testKeystorePath)
+                storePassword = providers.environmentVariable("CELESTE_TEST_KEYSTORE_PASSWORD").get()
+                keyAlias = providers.environmentVariable("CELESTE_TEST_KEY_ALIAS").get()
+                keyPassword = providers.environmentVariable("CELESTE_TEST_KEYSTORE_PASSWORD").get()
+            }
+        }
+    }
+
+    buildTypes {
+        getByName("debug") {
+            signingConfigs.findByName("ciTest")?.let { signingConfig = it }
+        }
     }
 
     packaging {

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,6 +36,8 @@ scripts/celeste-env ./gradlew --no-daemon assembleDebug
 
 Use [`testing.md`](testing.md) to select the checks required for a change. `assembleDebug` writes `app/build/outputs/apk/debug/app-debug.apk`.
 
+GitHub Actions uses the checked-in Gradle wrapper directly on a standard Ubuntu runner. Workflow actions must be limited to necessary official actions and pinned to immutable commit SHAs. The CI and current-test-APK behavior is defined in [`testing.md`](testing.md).
+
 ## Change workflow
 
 1. Read `AGENTS.md` and the documents that own the task.

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,6 +52,12 @@ Do not log or fixture:
 
 Use synthetic values in tests and `[REDACTED]` in documentation.
 
+## Test-build signing
+
+GitHub Actions signs the downloadable debug APK with a dedicated test-only key stored in repository Actions secrets. The key exists only to make successive test APKs update-compatible. It must never sign a release or store build.
+
+Do not commit, print, upload as an artifact, or reuse the test keystore or its password. The workflow decodes it into the runner's temporary directory only for packaging and removes it in an `always()` cleanup step. A release signing identity requires a separate design and explicit project-owner approval.
+
 ## Authentication changes
 
 For a new authentication mode:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -85,3 +85,11 @@ Use a real device for Android-only behavior such as lifecycle transitions, IME/i
 There is currently no `app/src/androidTest` suite. The configured instrumentation runner and connected-device tasks do not constitute device coverage; report Android runtime behavior as untested unless it was explicitly exercised.
 
 Base-path-prefixed dashboard routing is supported in source but does not yet have a direct MockWebServer regression. Add one when route joining changes.
+
+## GitHub Actions
+
+`.github/workflows/android.yml` runs the repository checks on pull requests. Pull requests must pass unit tests, lint, screenshot validation, and debug APK assembly without publishing an artifact.
+
+A successful `main` run, including a manually dispatched run, publishes `Hermes-Celeste-latest.apk` as the current test build. The workflow uploads the new APK before deleting older artifacts with the same name, then verifies that exactly one remains. A failed build cannot remove the last known-good package. GitHub requires artifacts to expire; the current APK uses the maximum 90-day retention and requires GitHub sign-in to download.
+
+The test APK is a debug build signed with a dedicated test-only identity, not a release or store artifact. Install it only for project testing. Each successful build uses the same application ID and test signing identity so Android can update-install it over an earlier GitHub Actions build while preserving application data. A locally built debug APK has a different signing identity and cannot update a GitHub-built installation.


### PR DESCRIPTION
## Summary
- verify Android changes with unit tests, lint, screenshots, and packaging
- publish one update-compatible debug APK from successful `main` builds
- replace superseded APK artifacts and keep signing material in GitHub secrets

## Verification
- `scripts/celeste-env ./gradlew --no-daemon testDebugUnitTest lintDebug`
- `scripts/celeste-env ./gradlew --no-daemon validateDebugScreenshotTest`
- local debug and CI-style test-signed `assembleDebug` builds
- workflow action references pinned to immutable commit SHAs
- documentation links, staged secret scan, and `git diff --check`