### PR TITLE
fix: stabilize resumed transcript identity

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -433,6 +434,20 @@ internal fun SessionListScreen(
     }
 }
 
+internal const val STREAMING_TRANSCRIPT_KEY = "streaming:assistant"
+
+internal fun transcriptItemKeys(messages: List<ConversationMessage>): List<String> {
+    val occurrences = mutableMapOf<String, Int>()
+    return messages.mapIndexed { index, message ->
+        val id = message.id?.takeIf(String::isNotBlank)
+            ?: return@mapIndexed "transcript:fallback:$index"
+        val base = "transcript:id:${id.length}:$id"
+        val occurrence = occurrences.getOrDefault(base, 0) + 1
+        occurrences[base] = occurrence
+        if (occurrence == 1) base else "$base:occurrence:$occurrence"
+    }
+}
+
 @Composable
 internal fun ConversationScreen(
     summary: StoredSession,
@@ -450,6 +465,7 @@ internal fun ConversationScreen(
 ) {
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
+    val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
     val visibleMessageCount = messages.size + if (streamingText.isNotBlank()) 1 else 0
     LaunchedEffect(visibleMessageCount, streamingText.length) {
         if (visibleMessageCount > 0) listState.animateScrollToItem(visibleMessageCount - 1)
@@ -511,11 +527,14 @@ internal fun ConversationScreen(
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 18.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                items(messages, key = { it.id ?: "${it.role}-${it.hashCode()}" }) { message ->
+                itemsIndexed(
+                    items = messages,
+                    key = { index, _ -> transcriptKeys[index] },
+                ) { _, message ->
                     MessageBubble(message)
                 }
                 if (streamingText.isNotBlank()) {
-                    item(key = "streaming-assistant") {
+                    item(key = STREAMING_TRANSCRIPT_KEY) {
                         MessageBubble(
                             ConversationMessage(role = "assistant", text = streamingText, pending = true),
                         )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -73,7 +73,7 @@ suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): Resu
             ?: result.string("stored_session_id")
             ?: result.string("session_key")
             ?: storedSessionId,
-        messages = result["messages"]?.jsonArray.orEmpty().mapNotNull(::decodeGatewayMessage),
+        messages = decodeGatewayMessages(result["messages"]?.jsonArray.orEmpty()),
         running = running,
         status = status,
         inflightAssistantText = inflightAssistantText(inflight),
@@ -102,6 +102,21 @@ suspend fun GatewayConnection.interruptSession(runtimeSessionId: String): JsonOb
     ).asObject("Hermes returned no interrupt status.")
 }
 
+internal fun decodeGatewayMessages(elements: List<JsonElement>): List<ConversationMessage> {
+    val usedIds = mutableSetOf<String>()
+    return elements.mapIndexedNotNull { index, element ->
+        val message = decodeGatewayMessage(element) ?: return@mapIndexedNotNull null
+        val preferredId = message.id?.takeIf(String::isNotBlank)
+        val id = if (preferredId != null && usedIds.add(preferredId)) {
+            preferredId
+        } else {
+            generateSequence("resume-$index") { current -> "$current-duplicate" }
+                .first(usedIds::add)
+        }
+        message.copy(id = id)
+    }
+}
+
 private fun decodeGatewayMessage(element: JsonElement): ConversationMessage? {
     val row = element as? JsonObject ?: return null
     val role = row.string("role")?.takeIf(String::isNotBlank) ?: return null
@@ -114,10 +129,14 @@ private fun decodeGatewayMessage(element: JsonElement): ConversationMessage? {
         role = role,
         text = text,
         toolName = toolName,
-        id = row["id"]?.jsonPrimitive?.contentOrNull
-            ?: row["message_id"]?.jsonPrimitive?.contentOrNull,
+        id = row["row_id"].scalarIdentity()?.let { "row-$it" }
+            ?: row["id"].scalarIdentity()
+            ?: row["message_id"].scalarIdentity(),
     )
 }
+
+private fun JsonElement?.scalarIdentity(): String? =
+    (this as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
 
 private fun inflightAssistantText(element: JsonElement?): String {
     val row = element as? JsonObject ?: return ""

--- a/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
@@ -1,0 +1,46 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.network.ConversationMessage
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TranscriptItemKeysTest {
+    @Test
+    fun namespacesMessagesAwayFromStreamingAndFallbackRows() {
+        val keys = transcriptItemKeys(
+            listOf(
+                message("streaming-assistant"),
+                message("transcript-2"),
+                message(null),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                "transcript:id:19:streaming-assistant",
+                "transcript:id:12:transcript-2",
+                "transcript:fallback:2",
+            ),
+            keys,
+        )
+        assertEquals(false, STREAMING_TRANSCRIPT_KEY in keys)
+    }
+
+    @Test
+    fun duplicateMessageIdentitiesReceiveDeterministicOccurrenceKeys() {
+        val messages = listOf(message("shared"), message("shared"), message("shared"))
+
+        assertEquals(
+            listOf(
+                "transcript:id:6:shared",
+                "transcript:id:6:shared:occurrence:2",
+                "transcript:id:6:shared:occurrence:3",
+            ),
+            transcriptItemKeys(messages),
+        )
+        assertEquals(transcriptItemKeys(messages), transcriptItemKeys(messages))
+    }
+
+    private fun message(id: String?): ConversationMessage =
+        ConversationMessage(role = "assistant", text = "Fixture", id = id)
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import mockwebserver3.MockResponse
@@ -92,6 +93,51 @@ class HermesGatewayTest {
         assertEquals("runtime-7", events.single { it.type == "message.delta" }.sessionId)
         assertEquals("hello", events.single { it.type == "message.delta" }.payload.string("text"))
         gateway.close()
+    }
+
+    @Test
+    fun resumedHistoryUsesDurableAndFallbackMessageIdentities() {
+        val messages = decodeGatewayMessages(
+            Json.parseToJsonElement(
+                """[{"row_id":41,"role":"user","text":"Earlier message"},{"role":"tool","name":"terminal","context":"Repeated output"},{"role":"tool","name":"terminal","context":"Repeated output"}]""",
+            ).jsonArray,
+        )
+
+        assertEquals(listOf("row-41", "resume-1", "resume-2"), messages.map { it.id })
+        assertEquals(messages.size, messages.map { it.id }.toSet().size)
+    }
+
+    @Test
+    fun resumedHistoryIgnoresMalformedAndBlankMessageIdentities() {
+        val messages = decodeGatewayMessages(
+            Json.parseToJsonElement(
+                """[
+                    {"row_id":{},"id":"legacy-id","role":"user","text":"One"},
+                    {"row_id":[],"id":" ","message_id":7,"role":"assistant","text":"Two"},
+                    {"row_id":null,"id":true,"role":"assistant","text":"Three"},
+                    {"row_id":" ","id":null,"message_id":false,"role":"tool","text":"Four"}
+                ]""".trimIndent(),
+            ).jsonArray,
+        )
+
+        assertEquals(listOf("legacy-id", "7", "true", "false"), messages.map { it.id })
+    }
+
+    @Test
+    fun resumedHistoryDeduplicatesExplicitAndSyntheticIdentityCollisions() {
+        val messages = decodeGatewayMessages(
+            Json.parseToJsonElement(
+                """[
+                    {"id":"shared","role":"user","text":"One"},
+                    {"message_id":"shared","role":"assistant","text":"Two"},
+                    {"id":"resume-2","role":"assistant","text":"Three"},
+                    {"role":"tool","text":"Four"}
+                ]""".trimIndent(),
+            ).jsonArray,
+        )
+
+        assertEquals(listOf("shared", "resume-1", "resume-2", "resume-3"), messages.map { it.id })
+        assertEquals(messages.size, messages.map { it.id }.toSet().size)
     }
 
     @Test

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,6 +71,7 @@ Do not substitute one for the other because they happen to match in a test fixtu
 - A newly created blank runtime may not yet be resumable. If it disconnects before the first prompt, recreate only that untouched empty session and preserve the draft.
 - On foreground, health-check the persistent socket. Replace and reconcile a stale connection rather than trusting an apparently open transport.
 - Ignore events carrying a different non-empty runtime session ID.
+- Give every rendered transcript row a unique UI identity. Prefer a scalar, nonblank Hermes `row_id`; synthesize a deterministic per-resume identity when projections such as tool rows omit one. Namespace Compose keys separately from protocol IDs and occurrence-qualify duplicates so malformed or reused server IDs cannot collide with local, tool, fallback, or streaming rows.
 - Recovered in-flight assistant text may include a prefix already present in persisted history. Render only the unpersisted suffix.
 - Attach the event collector before connecting. `HermesGateway.events` has no replay and a bounded extra buffer, so late collectors can miss conversational events.
 


### PR DESCRIPTION
## Summary
- preserve durable Hermes row identities when resuming conversations
- assign unique fallback identities to legacy transcript projections
- prevent duplicate Compose keys from crashing resumed conversations

## Verification
- focused resumed-history regression
- unit tests and lint
- Compose screenshot validation
- debug APK assembly
- git diff --check