### PR TITLE
feat: support assistant display names

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -93,6 +93,7 @@ internal data class CelesteUiState(
     val assistantDisplayName: String = DEFAULT_ASSISTANT_NAME,
     val assistantNameKey: AssistantNameKey? = null,
     val assistantNameCleanupRetryOrigin: String? = null,
+    val connectionForgetRetryPending: Boolean = false,
     val assistantNameEditor: AssistantNameEditState = AssistantNameEditState(),
     val activeSummary: StoredSession? = null,
     val messages: List<ConversationMessage> = emptyList(),
@@ -144,11 +145,14 @@ internal class CelesteViewModel(
     private val connectionStoreMutex = Mutex()
     private val assistantNameStoreMutex = Mutex()
     private var assistantNameContextGeneration = 0L
+    private var assistantNameReadGeneration = 0L
+    private var assistantNameSaveGeneration = 0L
     private var assistantNameReadJob: Job? = null
     private var assistantNameSaveJob: Job? = null
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var pendingAssistantNameContext: AssistantNameContext? = null
     private val pendingAssistantNameCleanupOrigins = linkedSetOf<String>()
+    private var pendingConnectionForget = false
     private var reconnectAttempts = 0
     private var reconciling = false
     private var currentSessionCanResume = true
@@ -235,7 +239,11 @@ internal class CelesteViewModel(
             return
         }
 
-        val generation = assistantNameContextGeneration
+        val contextGeneration = assistantNameContextGeneration
+        val saveGeneration = ++assistantNameSaveGeneration
+        assistantNameReadGeneration += 1
+        assistantNameReadJob?.cancel()
+        assistantNameReadJob = null
         mutableState.value = snapshot.copy(
             assistantNameEditor = editor.copy(
                 isSaving = true,
@@ -249,15 +257,23 @@ internal class CelesteViewModel(
                 assistantNameStoreMutex.withLock {
                     assistantNameStore.write(key.origin, key.profile, validation.normalized)
                 }
-                if (!isCurrentAssistantNameContext(generation, key)) return@launch
+                if (!isCurrentAssistantNameSave(contextGeneration, key, saveGeneration)) {
+                    return@launch
+                }
+                assistantNameReadGeneration += 1
+                assistantNameReadJob?.cancel()
+                assistantNameReadJob = null
                 mutableState.value = mutableState.value.copy(
                     assistantDisplayName = validation.normalized ?: DEFAULT_ASSISTANT_NAME,
                     assistantNameEditor = AssistantNameEditState(),
                 )
+                assistantNameSaveJob = null
             } catch (error: CancellationException) {
                 throw error
             } catch (_: Throwable) {
-                if (!isCurrentAssistantNameContext(generation, key)) return@launch
+                if (!isCurrentAssistantNameSave(contextGeneration, key, saveGeneration)) {
+                    return@launch
+                }
                 mutableState.value = mutableState.value.copy(
                     assistantNameEditor = mutableState.value.assistantNameEditor.copy(
                         isSaving = false,
@@ -265,6 +281,7 @@ internal class CelesteViewModel(
                         isRetryableError = true,
                     ),
                 )
+                assistantNameSaveJob = null
             }
         }
     }
@@ -283,13 +300,20 @@ internal class CelesteViewModel(
         key: AssistantNameKey?,
         baseState: CelesteUiState = mutableState.value,
     ) {
-        assistantNameContextGeneration += 1
-        val generation = assistantNameContextGeneration
-        assistantNameReadJob?.cancel()
-        assistantNameSaveJob?.cancel()
-        assistantNameReadJob = null
-        assistantNameSaveJob = null
         val sameContext = key != null && baseState.assistantNameKey == key
+        val saveInFlight = sameContext && assistantNameSaveJob?.isActive == true
+        if (!sameContext) {
+            assistantNameContextGeneration += 1
+            assistantNameSaveGeneration += 1
+            assistantNameSaveJob?.cancel()
+            assistantNameSaveJob = null
+        }
+        assistantNameReadGeneration += 1
+        val contextGeneration = assistantNameContextGeneration
+        val readGeneration = assistantNameReadGeneration
+        val saveGeneration = assistantNameSaveGeneration
+        assistantNameReadJob?.cancel()
+        assistantNameReadJob = null
         mutableState.value = baseState.copy(
             assistantDisplayName = if (sameContext) {
                 baseState.assistantDisplayName.ifBlank { DEFAULT_ASSISTANT_NAME }
@@ -297,7 +321,11 @@ internal class CelesteViewModel(
                 DEFAULT_ASSISTANT_NAME
             },
             assistantNameKey = key,
-            assistantNameEditor = AssistantNameEditState(),
+            assistantNameEditor = if (saveInFlight) {
+                baseState.assistantNameEditor
+            } else {
+                AssistantNameEditState()
+            },
         )
         if (key == null) return
 
@@ -324,7 +352,15 @@ internal class CelesteViewModel(
                     }
                 }
             }
-            if (!isCurrentAssistantNameContext(generation, key)) return@launch
+            if (!isCurrentAssistantNameRead(
+                    contextGeneration = contextGeneration,
+                    readGeneration = readGeneration,
+                    saveGeneration = saveGeneration,
+                    key = key,
+                )
+            ) {
+                return@launch
+            }
             mutableState.value = mutableState.value.copy(
                 assistantDisplayName = storedName ?: DEFAULT_ASSISTANT_NAME,
             )
@@ -348,6 +384,24 @@ internal class CelesteViewModel(
     ): Boolean =
         assistantNameContextGeneration == generation && mutableState.value.assistantNameKey == key
 
+    private fun isCurrentAssistantNameRead(
+        contextGeneration: Long,
+        readGeneration: Long,
+        saveGeneration: Long,
+        key: AssistantNameKey,
+    ): Boolean =
+        isCurrentAssistantNameContext(contextGeneration, key) &&
+            assistantNameReadGeneration == readGeneration &&
+            assistantNameSaveGeneration == saveGeneration
+
+    private fun isCurrentAssistantNameSave(
+        contextGeneration: Long,
+        key: AssistantNameKey,
+        saveGeneration: Long,
+    ): Boolean =
+        isCurrentAssistantNameContext(contextGeneration, key) &&
+            assistantNameSaveGeneration == saveGeneration
+
     private fun assistantNameOriginFor(state: CelesteUiState): String? =
         state.assistantNameKey?.origin
             ?: AssistantNameKey.from(
@@ -358,6 +412,33 @@ internal class CelesteViewModel(
     private fun cleanupRetryOrigin(preferredOrigin: String? = null): String? =
         preferredOrigin?.takeIf { it in pendingAssistantNameCleanupOrigins }
             ?: pendingAssistantNameCleanupOrigins.firstOrNull()
+
+    private suspend fun captureCleanupFailure(
+        operation: suspend () -> Unit,
+    ): Throwable? = try {
+        operation()
+        null
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        error
+    }
+
+    private fun cleanupErrorMessage(
+        assistantNameError: Throwable?,
+        connectionError: Throwable?,
+    ): String? {
+        val assistantNamePending = assistantNameError != null ||
+            pendingAssistantNameCleanupOrigins.isNotEmpty()
+        return when {
+            assistantNamePending && connectionError != null -> {
+                "Celeste could not remove the local assistant name or saved connection. Try again."
+            }
+            assistantNamePending -> "Celeste could not remove the local assistant name. Try again."
+            connectionError != null -> "Celeste could not remove the saved connection. Try again."
+            else -> null
+        }
+    }
 
     fun findDashboard() {
         val rawUrl = mutableState.value.dashboardUrl
@@ -464,6 +545,7 @@ internal class CelesteViewModel(
                 if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
                 credential = remembered.loaded.credential
                 currentDescriptor = remembered.descriptor
+                pendingConnectionForget = false
                 publishConnectedDashboard(
                     loaded = remembered.loaded,
                     password = "",
@@ -567,6 +649,7 @@ internal class CelesteViewModel(
         if (forgottenOrigin != null) {
             pendingAssistantNameCleanupOrigins += forgottenOrigin
         }
+        pendingConnectionForget = true
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
         resetAssistantNameContext()
@@ -576,22 +659,37 @@ internal class CelesteViewModel(
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Forgetting this connection…",
-            assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
+            assistantNameCleanupRetryOrigin = cleanupRetryOrigin(
+                preferredOrigin = forgottenOrigin,
+            ),
         )
         connectionJob = viewModelScope.launch {
-            val error = connectionStoreMutex.withLock {
-                runCatching { connectionStore.forget() }.exceptionOrNull()
-            }
             val assistantNameError = forgottenOrigin?.let { origin ->
                 assistantNameStoreMutex.withLock {
-                    runCatching { assistantNameStore.clearOrigin(origin) }.exceptionOrNull()
+                    captureCleanupFailure { assistantNameStore.clearOrigin(origin) }
                 }
             }
             if (assistantNameError == null && forgottenOrigin != null) {
                 pendingAssistantNameCleanupOrigins -= forgottenOrigin
             }
+            val connectionError = if (assistantNameError == null) {
+                connectionStoreMutex.withLock {
+                    captureCleanupFailure { connectionStore.forget() }
+                }
+            } else {
+                null
+            }
+            if (assistantNameError == null && connectionError == null) {
+                pendingConnectionForget = false
+            }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
-                runCatching { dashboard.logout(snapshot.probe.baseUrl) }
+                try {
+                    dashboard.logout(snapshot.probe.baseUrl)
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Throwable) {
+                    // Local cleanup remains authoritative when the dashboard is offline.
+                }
             }
             dashboard.clearAuthentication()
             if (!isCurrentConnectionAttempt(attempt)) return@launch
@@ -600,13 +698,8 @@ internal class CelesteViewModel(
                 assistantNameCleanupRetryOrigin = cleanupRetryOrigin(
                     preferredOrigin = forgottenOrigin.takeIf { assistantNameError != null },
                 ),
-                errorMessage = when {
-                    assistantNameError != null -> {
-                        "Celeste could not remove the local assistant name. Try again."
-                    }
-                    error != null -> "Celeste could not remove the saved connection. Try again."
-                    else -> null
-                },
+                connectionForgetRetryPending = connectionError != null,
+                errorMessage = cleanupErrorMessage(assistantNameError, connectionError),
             )
         }
     }
@@ -619,25 +712,65 @@ internal class CelesteViewModel(
             loadingMessage = "Removing the local assistant name…",
             errorMessage = null,
             assistantNameCleanupRetryOrigin = retryOrigin,
+            connectionForgetRetryPending = false,
         )
         connectionJob = viewModelScope.launch {
-            val error = assistantNameStoreMutex.withLock {
-                runCatching { assistantNameStore.clearOrigin(retryOrigin) }.exceptionOrNull()
+            val assistantNameError = assistantNameStoreMutex.withLock {
+                captureCleanupFailure { assistantNameStore.clearOrigin(retryOrigin) }
             }
-            if (error == null) {
+            if (assistantNameError == null) {
                 pendingAssistantNameCleanupOrigins -= retryOrigin
+            }
+            val connectionError = if (assistantNameError == null && pendingConnectionForget) {
+                connectionStoreMutex.withLock {
+                    captureCleanupFailure { connectionStore.forget() }
+                }
+            } else {
+                null
+            }
+            if (assistantNameError == null && connectionError == null && pendingConnectionForget) {
+                pendingConnectionForget = false
             }
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = mutableState.value.copy(
                 loadingMessage = null,
                 assistantNameCleanupRetryOrigin = cleanupRetryOrigin(
-                    preferredOrigin = retryOrigin.takeIf { error != null },
+                    preferredOrigin = retryOrigin.takeIf { assistantNameError != null },
                 ),
-                errorMessage = if (error == null) {
-                    null
+                assistantDisplayName = if (
+                    assistantNameError == null &&
+                    mutableState.value.assistantNameKey?.origin == retryOrigin
+                ) {
+                    DEFAULT_ASSISTANT_NAME
                 } else {
-                    "Celeste could not remove the local assistant name. Try again."
+                    mutableState.value.assistantDisplayName
                 },
+                connectionForgetRetryPending = connectionError != null,
+                errorMessage = cleanupErrorMessage(assistantNameError, connectionError),
+            )
+        }
+    }
+
+    fun retryConnectionCleanup() {
+        if (!pendingConnectionForget || pendingAssistantNameCleanupOrigins.isNotEmpty()) return
+        val attempt = beginConnectionAttempt()
+        mutableState.value = mutableState.value.copy(
+            loadingMessage = "Removing the saved connection…",
+            errorMessage = null,
+            connectionForgetRetryPending = true,
+        )
+        connectionJob = viewModelScope.launch {
+            val connectionError = connectionStoreMutex.withLock {
+                captureCleanupFailure { connectionStore.forget() }
+            }
+            if (connectionError == null) {
+                pendingConnectionForget = false
+            }
+            if (!isCurrentConnectionAttempt(attempt)) return@launch
+            mutableState.value = mutableState.value.copy(
+                loadingMessage = null,
+                connectionForgetRetryPending = connectionError != null,
+                errorMessage = cleanupErrorMessage(null, connectionError),
             )
         }
     }
@@ -750,6 +883,7 @@ internal class CelesteViewModel(
             }
             credential = loaded.credential
             currentDescriptor = descriptor
+            pendingConnectionForget = false
             mutableState.value = mutableState.value.copy(
                 dashboardUrl = probe.baseUrl,
                 probe = probe,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -29,6 +29,11 @@ import dev.hazydreams.hermesceleste.network.interruptSession
 import dev.hazydreams.hermesceleste.network.resumeStoredSession
 import dev.hazydreams.hermesceleste.network.string
 import dev.hazydreams.hermesceleste.network.submitPrompt
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.AssistantNamePolicy
+import dev.hazydreams.hermesceleste.presentation.AssistantNameStore
+import dev.hazydreams.hermesceleste.presentation.DEFAULT_ASSISTANT_NAME
+import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
@@ -61,6 +66,15 @@ internal enum class ConnectionPhase {
     Connected,
 }
 
+internal data class AssistantNameEditState(
+    val isOpen: Boolean = false,
+    val draft: String = "",
+    val errorMessage: String? = null,
+    val isSaving: Boolean = false,
+) {
+    val canSave: Boolean get() = !isSaving && errorMessage == null
+}
+
 internal data class CelesteUiState(
     val connectionPhase: ConnectionPhase = ConnectionPhase.CheckingSavedConnection,
     val dashboardUrl: String = "",
@@ -72,6 +86,9 @@ internal data class CelesteUiState(
     val sessions: List<StoredSession>? = null,
     val profiles: List<DashboardProfile> = listOf(DashboardProfile(name = "default", isDefault = true)),
     val selectedProfile: String = "default",
+    val assistantDisplayName: String = DEFAULT_ASSISTANT_NAME,
+    val assistantNameKey: AssistantNameKey? = null,
+    val assistantNameEditor: AssistantNameEditState = AssistantNameEditState(),
     val activeSummary: StoredSession? = null,
     val messages: List<ConversationMessage> = emptyList(),
     val streamingText: String = "",
@@ -96,6 +113,7 @@ private data class RememberedDashboard(
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
+    private val assistantNameStore: AssistantNameStore = InMemoryAssistantNameStore(),
     private val reconnectDelayMillis: (attempt: Int, wasRunning: Boolean) -> Long = { attempt, wasRunning ->
         if (wasRunning && attempt == 0) 100L else min(5_000L, 1_000L shl attempt.coerceAtMost(2))
     },
@@ -113,6 +131,10 @@ internal class CelesteViewModel(
     private var connectionJob: Job? = null
     private var connectionAttempt = 0L
     private val connectionStoreMutex = Mutex()
+    private val assistantNameStoreMutex = Mutex()
+    private var assistantNameContextGeneration = 0L
+    private var assistantNameReadJob: Job? = null
+    private var assistantNameSaveJob: Job? = null
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
     private var reconciling = false
@@ -149,13 +171,141 @@ internal class CelesteViewModel(
 
     fun selectProfile(name: String) {
         if (mutableState.value.profiles.none { it.name == name }) return
-        mutableState.value = mutableState.value.copy(selectedProfile = name)
+        resolveAssistantNameContext(mutableState.value.copy(selectedProfile = name))
     }
+
+    fun openAssistantNameEditor() {
+        val snapshot = mutableState.value
+        if (snapshot.assistantNameKey == null) return
+        mutableState.value = snapshot.copy(
+            assistantNameEditor = AssistantNameEditState(
+                isOpen = true,
+                draft = snapshot.assistantDisplayName,
+            ),
+        )
+    }
+
+    fun updateAssistantNameDraft(value: String) {
+        val editor = mutableState.value.assistantNameEditor
+        if (!editor.isOpen || editor.isSaving) return
+        val validation = AssistantNamePolicy.validate(value)
+        mutableState.value = mutableState.value.copy(
+            assistantNameEditor = editor.copy(
+                draft = value,
+                errorMessage = validation.errorMessage,
+            ),
+        )
+    }
+
+    fun cancelAssistantNameEdit() {
+        if (!mutableState.value.assistantNameEditor.isSaving) {
+            mutableState.value = mutableState.value.copy(
+                assistantNameEditor = AssistantNameEditState(),
+            )
+        }
+    }
+
+    fun saveAssistantName() {
+        val snapshot = mutableState.value
+        val editor = snapshot.assistantNameEditor
+        val key = snapshot.assistantNameKey
+        if (!editor.isOpen || editor.isSaving || key == null) return
+        val validation = AssistantNamePolicy.validate(editor.draft)
+        if (validation.errorMessage != null) {
+            mutableState.value = snapshot.copy(
+                assistantNameEditor = editor.copy(errorMessage = validation.errorMessage),
+            )
+            return
+        }
+
+        val generation = assistantNameContextGeneration
+        mutableState.value = snapshot.copy(
+            assistantNameEditor = editor.copy(isSaving = true, errorMessage = null),
+        )
+        assistantNameSaveJob?.cancel()
+        assistantNameSaveJob = viewModelScope.launch {
+            try {
+                assistantNameStoreMutex.withLock {
+                    assistantNameStore.write(key.origin, key.profile, validation.normalized)
+                }
+                if (!isCurrentAssistantNameContext(generation, key)) return@launch
+                mutableState.value = mutableState.value.copy(
+                    assistantDisplayName = validation.normalized ?: DEFAULT_ASSISTANT_NAME,
+                    assistantNameEditor = AssistantNameEditState(),
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                if (!isCurrentAssistantNameContext(generation, key)) return@launch
+                mutableState.value = mutableState.value.copy(
+                    assistantNameEditor = mutableState.value.assistantNameEditor.copy(
+                        isSaving = false,
+                        errorMessage = "Couldn’t save assistant name on this device. Try again.",
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun resolveAssistantNameContext(baseState: CelesteUiState = mutableState.value) {
+        val key = AssistantNameKey.from(baseState.probe?.baseUrl, baseState.selectedProfile)
+        publishAssistantNameContext(key, baseState)
+    }
+
+    private fun reloadAssistantNameContext() {
+        val key = mutableState.value.assistantNameKey ?: return
+        publishAssistantNameContext(key)
+    }
+
+    private fun publishAssistantNameContext(
+        key: AssistantNameKey?,
+        baseState: CelesteUiState = mutableState.value,
+    ) {
+        assistantNameContextGeneration += 1
+        val generation = assistantNameContextGeneration
+        assistantNameReadJob?.cancel()
+        assistantNameSaveJob?.cancel()
+        assistantNameReadJob = null
+        assistantNameSaveJob = null
+        mutableState.value = baseState.copy(
+            assistantDisplayName = DEFAULT_ASSISTANT_NAME,
+            assistantNameKey = key,
+            assistantNameEditor = AssistantNameEditState(),
+        )
+        if (key == null) return
+
+        assistantNameReadJob = viewModelScope.launch {
+            val storedName = runCatching {
+                assistantNameStoreMutex.withLock {
+                    assistantNameStore.read(key.origin, key.profile)
+                }
+            }.getOrNull()?.let { value ->
+                AssistantNamePolicy.validate(value)
+                    .takeIf { it.errorMessage == null && it.normalized != null }
+                    ?.normalized
+            }
+            if (!isCurrentAssistantNameContext(generation, key)) return@launch
+            mutableState.value = mutableState.value.copy(
+                assistantDisplayName = storedName ?: DEFAULT_ASSISTANT_NAME,
+            )
+        }
+    }
+
+    private fun resetAssistantNameContext() {
+        publishAssistantNameContext(null)
+    }
+
+    private fun isCurrentAssistantNameContext(
+        generation: Long,
+        key: AssistantNameKey,
+    ): Boolean =
+        assistantNameContextGeneration == generation && mutableState.value.assistantNameKey == key
 
     fun findDashboard() {
         val rawUrl = mutableState.value.dashboardUrl
         if (rawUrl.isBlank()) return
         val attempt = beginConnectionAttempt()
+        resetAssistantNameContext()
         closeGateway()
         credential = null
         currentDescriptor = null
@@ -282,6 +432,7 @@ internal class CelesteViewModel(
 
     fun leaveSessionList() {
         beginConnectionAttempt()
+        resetAssistantNameContext()
         closeGateway()
         credential = null
         mutableState.value = mutableState.value.copy(
@@ -301,6 +452,7 @@ internal class CelesteViewModel(
 
     fun useAnotherConnection() {
         beginConnectionAttempt()
+        resetAssistantNameContext()
         closeGateway()
         credential = null
         currentDescriptor = null
@@ -312,10 +464,11 @@ internal class CelesteViewModel(
         val snapshot = mutableState.value
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
+        resetAssistantNameContext()
         closeGateway()
         credential = null
         currentDescriptor = null
-        mutableState.value = snapshot.copy(
+        mutableState.value = mutableState.value.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             sessions = null,
             activeSummary = null,
@@ -349,8 +502,14 @@ internal class CelesteViewModel(
 
     fun forgetConnection() {
         val snapshot = mutableState.value
+        val forgottenOrigin = snapshot.assistantNameKey?.origin
+            ?: AssistantNameKey.from(
+                snapshot.probe?.baseUrl ?: currentDescriptor?.baseUrl ?: snapshot.dashboardUrl,
+                "default",
+            )?.origin
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
+        resetAssistantNameContext()
         closeGateway()
         credential = null
         currentDescriptor = null
@@ -362,6 +521,11 @@ internal class CelesteViewModel(
             val error = connectionStoreMutex.withLock {
                 runCatching { connectionStore.forget() }.exceptionOrNull()
             }
+            val assistantNameError = forgottenOrigin?.let { origin ->
+                assistantNameStoreMutex.withLock {
+                    runCatching { assistantNameStore.clearOrigin(origin) }.exceptionOrNull()
+                }
+            }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
                 runCatching { dashboard.logout(snapshot.probe.baseUrl) }
             }
@@ -369,8 +533,12 @@ internal class CelesteViewModel(
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = CelesteUiState(
                 connectionPhase = ConnectionPhase.ManualSetup,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved connection. Try again."
+                errorMessage = when {
+                    assistantNameError != null -> {
+                        "Celeste could not remove the local assistant name. Try again."
+                    }
+                    error != null -> "Celeste could not remove the saved connection. Try again."
+                    else -> null
                 },
             )
         }
@@ -378,6 +546,7 @@ internal class CelesteViewModel(
 
     private fun restoreSavedConnection() {
         val attempt = beginConnectionAttempt()
+        resetAssistantNameContext()
         closeGateway()
         credential = null
         mutableState.value = CelesteUiState(
@@ -520,6 +689,7 @@ internal class CelesteViewModel(
     ) {
         credential = null
         currentDescriptor = null
+        resetAssistantNameContext()
         dashboard.clearAuthentication()
         connectionStoreMutex.withLock {
             runCatching { connectionStore.clearSecret() }
@@ -543,7 +713,7 @@ internal class CelesteViewModel(
             ?: loaded.profiles.firstOrNull(DashboardProfile::isDefault)?.name
             ?: loaded.profiles.firstOrNull()?.name
             ?: "default"
-        mutableState.value = mutableState.value.copy(
+        val connectedState = mutableState.value.copy(
             connectionPhase = ConnectionPhase.Connected,
             savedAuthMode = currentDescriptor?.authMode,
             sessions = loaded.sessions,
@@ -556,6 +726,7 @@ internal class CelesteViewModel(
             loadingMessage = null,
             errorMessage = errorMessage,
         )
+        resolveAssistantNameContext(connectedState)
     }
 
     private fun manualState(
@@ -786,6 +957,7 @@ internal class CelesteViewModel(
     }
 
     fun onForeground() {
+        reloadAssistantNameContext()
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: return
         if (foregroundCheckJob?.isActive == true || reconciling) return
@@ -1139,6 +1311,10 @@ internal class CelesteViewModel(
     override fun onCleared() {
         connectionJob?.cancel()
         connectionJob = null
+        assistantNameReadJob?.cancel()
+        assistantNameReadJob = null
+        assistantNameSaveJob?.cancel()
+        assistantNameSaveJob = null
         closeGateway()
         dashboard.clearAuthentication()
         super.onCleared()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -92,6 +92,7 @@ internal data class CelesteUiState(
     val selectedProfile: String = "default",
     val assistantDisplayName: String = DEFAULT_ASSISTANT_NAME,
     val assistantNameKey: AssistantNameKey? = null,
+    val assistantNameCleanupRetryOrigin: String? = null,
     val assistantNameEditor: AssistantNameEditState = AssistantNameEditState(),
     val activeSummary: StoredSession? = null,
     val messages: List<ConversationMessage> = emptyList(),
@@ -147,7 +148,7 @@ internal class CelesteViewModel(
     private var assistantNameSaveJob: Job? = null
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var pendingAssistantNameContext: AssistantNameContext? = null
-    private var pendingAssistantNameCleanupOrigin: String? = null
+    private val pendingAssistantNameCleanupOrigins = linkedSetOf<String>()
     private var reconnectAttempts = 0
     private var reconciling = false
     private var currentSessionCanResume = true
@@ -347,6 +348,17 @@ internal class CelesteViewModel(
     ): Boolean =
         assistantNameContextGeneration == generation && mutableState.value.assistantNameKey == key
 
+    private fun assistantNameOriginFor(state: CelesteUiState): String? =
+        state.assistantNameKey?.origin
+            ?: AssistantNameKey.from(
+                state.probe?.baseUrl ?: currentDescriptor?.baseUrl ?: state.dashboardUrl,
+                state.selectedProfile,
+            )?.origin
+
+    private fun cleanupRetryOrigin(preferredOrigin: String? = null): String? =
+        preferredOrigin?.takeIf { it in pendingAssistantNameCleanupOrigins }
+            ?: pendingAssistantNameCleanupOrigins.firstOrNull()
+
     fun findDashboard() {
         val rawUrl = mutableState.value.dashboardUrl
         if (rawUrl.isBlank()) return
@@ -503,7 +515,10 @@ internal class CelesteViewModel(
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
-        mutableState.value = CelesteUiState(connectionPhase = ConnectionPhase.ManualSetup)
+        mutableState.value = CelesteUiState(
+            connectionPhase = ConnectionPhase.ManualSetup,
+            assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
+        )
     }
 
     fun signOut() {
@@ -548,14 +563,9 @@ internal class CelesteViewModel(
 
     fun forgetConnection() {
         val snapshot = mutableState.value
-        val forgottenOrigin = pendingAssistantNameCleanupOrigin
-            ?: snapshot.assistantNameKey?.origin
-            ?: AssistantNameKey.from(
-                snapshot.probe?.baseUrl ?: currentDescriptor?.baseUrl ?: snapshot.dashboardUrl,
-                "default",
-            )?.origin
+        val forgottenOrigin = assistantNameOriginFor(snapshot)
         if (forgottenOrigin != null) {
-            pendingAssistantNameCleanupOrigin = forgottenOrigin
+            pendingAssistantNameCleanupOrigins += forgottenOrigin
         }
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
@@ -566,6 +576,7 @@ internal class CelesteViewModel(
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Forgetting this connection…",
+            assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
         )
         connectionJob = viewModelScope.launch {
             val error = connectionStoreMutex.withLock {
@@ -577,7 +588,7 @@ internal class CelesteViewModel(
                 }
             }
             if (assistantNameError == null && forgottenOrigin != null) {
-                pendingAssistantNameCleanupOrigin = null
+                pendingAssistantNameCleanupOrigins -= forgottenOrigin
             }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
                 runCatching { dashboard.logout(snapshot.probe.baseUrl) }
@@ -586,12 +597,46 @@ internal class CelesteViewModel(
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = CelesteUiState(
                 connectionPhase = ConnectionPhase.ManualSetup,
+                assistantNameCleanupRetryOrigin = cleanupRetryOrigin(
+                    preferredOrigin = forgottenOrigin.takeIf { assistantNameError != null },
+                ),
                 errorMessage = when {
                     assistantNameError != null -> {
                         "Celeste could not remove the local assistant name. Try again."
                     }
                     error != null -> "Celeste could not remove the saved connection. Try again."
                     else -> null
+                },
+            )
+        }
+    }
+
+    fun retryAssistantNameCleanup() {
+        val retryOrigin = cleanupRetryOrigin(mutableState.value.assistantNameCleanupRetryOrigin)
+            ?: return
+        val attempt = beginConnectionAttempt()
+        mutableState.value = mutableState.value.copy(
+            loadingMessage = "Removing the local assistant name…",
+            errorMessage = null,
+            assistantNameCleanupRetryOrigin = retryOrigin,
+        )
+        connectionJob = viewModelScope.launch {
+            val error = assistantNameStoreMutex.withLock {
+                runCatching { assistantNameStore.clearOrigin(retryOrigin) }.exceptionOrNull()
+            }
+            if (error == null) {
+                pendingAssistantNameCleanupOrigins -= retryOrigin
+            }
+            if (!isCurrentConnectionAttempt(attempt)) return@launch
+            mutableState.value = mutableState.value.copy(
+                loadingMessage = null,
+                assistantNameCleanupRetryOrigin = cleanupRetryOrigin(
+                    preferredOrigin = retryOrigin.takeIf { error != null },
+                ),
+                errorMessage = if (error == null) {
+                    null
+                } else {
+                    "Celeste could not remove the local assistant name. Try again."
                 },
             )
         }
@@ -611,6 +656,7 @@ internal class CelesteViewModel(
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.CheckingSavedConnection,
             loadingMessage = "Checking this device…",
+            assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
         )
         connectionJob = viewModelScope.launch {
             val savedResult = connectionStoreMutex.withLock {
@@ -652,6 +698,7 @@ internal class CelesteViewModel(
             savedAuthMode = descriptor.authMode,
             username = descriptor.username.orEmpty(),
             loadingMessage = "Reconnecting to your Hermes…",
+            assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
         )
         dashboard.clearAuthentication()
         runCatching {
@@ -729,6 +776,7 @@ internal class CelesteViewModel(
                     dashboardUrl = descriptor.baseUrl,
                     savedAuthMode = descriptor.authMode,
                     username = descriptor.username.orEmpty(),
+                    assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
                     errorMessage = error.message ?: "Could not reconnect to Hermes.",
                 )
             }
@@ -810,6 +858,7 @@ internal class CelesteViewModel(
         probe = probe,
         savedAuthMode = descriptor?.authMode,
         username = descriptor?.username.orEmpty(),
+        assistantNameCleanupRetryOrigin = cleanupRetryOrigin(),
         errorMessage = errorMessage,
     )
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -150,6 +150,9 @@ internal class CelesteViewModel(
     private var assistantNameReadJob: Job? = null
     private var assistantNameSaveJob: Job? = null
     private var currentDescriptor: SavedConnectionDescriptor? = null
+    // The descriptor currently committed to ConnectionStore can differ from the
+    // active descriptor while a new address is being probed or persistence retries.
+    private var committedDescriptor: SavedConnectionDescriptor? = null
     private var pendingAssistantNameContext: AssistantNameContext? = null
     private val pendingAssistantNameCleanupOrigins = linkedSetOf<String>()
     private var pendingConnectionForget = false
@@ -403,11 +406,11 @@ internal class CelesteViewModel(
             assistantNameSaveGeneration == saveGeneration
 
     private fun assistantNameOriginFor(state: CelesteUiState): String? =
-        state.assistantNameKey?.origin
-            ?: AssistantNameKey.from(
-                state.probe?.baseUrl ?: currentDescriptor?.baseUrl ?: state.dashboardUrl,
-                state.selectedProfile,
-            )?.origin
+        (committedDescriptor ?: currentDescriptor)
+            ?.let { descriptor ->
+                AssistantNameKey.from(descriptor.baseUrl, state.selectedProfile)?.origin
+            }
+            ?: state.assistantNameKey?.origin
 
     private fun cleanupRetryOrigin(preferredOrigin: String? = null): String? =
         preferredOrigin?.takeIf { it in pendingAssistantNameCleanupOrigins }
@@ -545,6 +548,9 @@ internal class CelesteViewModel(
                 if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
                 credential = remembered.loaded.credential
                 currentDescriptor = remembered.descriptor
+                if (remembered.persistenceError == null) {
+                    committedDescriptor = remembered.descriptor
+                }
                 pendingConnectionForget = false
                 publishConnectedDashboard(
                     loaded = remembered.loaded,
@@ -634,6 +640,7 @@ internal class CelesteViewModel(
             dashboard.clearAuthentication()
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             currentDescriptor = saved?.descriptor
+            committedDescriptor = saved?.descriptor
             mutableState.value = manualState(
                 descriptor = saved?.descriptor,
                 errorMessage = if (error == null) null else {
@@ -681,6 +688,7 @@ internal class CelesteViewModel(
             }
             if (assistantNameError == null && connectionError == null) {
                 pendingConnectionForget = false
+                committedDescriptor = null
             }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
                 try {
@@ -730,6 +738,7 @@ internal class CelesteViewModel(
             }
             if (assistantNameError == null && connectionError == null && pendingConnectionForget) {
                 pendingConnectionForget = false
+                committedDescriptor = null
             }
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = mutableState.value.copy(
@@ -765,6 +774,7 @@ internal class CelesteViewModel(
             }
             if (connectionError == null) {
                 pendingConnectionForget = false
+                committedDescriptor = null
             }
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = mutableState.value.copy(
@@ -803,6 +813,7 @@ internal class CelesteViewModel(
                 )
                 return@launch
             }
+            committedDescriptor = saved?.descriptor
             when (val decision = connectionBootstrapDecision(saved)) {
                 ConnectionBootstrapDecision.ManualSetup -> {
                     pendingAssistantNameContext = null
@@ -883,6 +894,9 @@ internal class CelesteViewModel(
             }
             credential = loaded.credential
             currentDescriptor = descriptor
+            if (persistenceError == null) {
+                committedDescriptor = descriptor
+            }
             pendingConnectionForget = false
             mutableState.value = mutableState.value.copy(
                 dashboardUrl = probe.baseUrl,
@@ -1204,6 +1218,7 @@ internal class CelesteViewModel(
                 if (credential != GatewayCredential.CookieSession || currentDescriptor != descriptor) return@withLock
                 runCatching {
                     connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
+                    committedDescriptor = descriptor
                 }
             }
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -29,11 +29,14 @@ import dev.hazydreams.hermesceleste.network.interruptSession
 import dev.hazydreams.hermesceleste.network.resumeStoredSession
 import dev.hazydreams.hermesceleste.network.string
 import dev.hazydreams.hermesceleste.network.submitPrompt
+import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostic
+import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostics
 import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
 import dev.hazydreams.hermesceleste.presentation.AssistantNamePolicy
 import dev.hazydreams.hermesceleste.presentation.AssistantNameStore
 import dev.hazydreams.hermesceleste.presentation.DEFAULT_ASSISTANT_NAME
 import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
+import dev.hazydreams.hermesceleste.presentation.NoOpAssistantNameDiagnostics
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
@@ -71,8 +74,9 @@ internal data class AssistantNameEditState(
     val draft: String = "",
     val errorMessage: String? = null,
     val isSaving: Boolean = false,
+    val isRetryableError: Boolean = false,
 ) {
-    val canSave: Boolean get() = !isSaving && errorMessage == null
+    val canSave: Boolean get() = isOpen && !isSaving && (errorMessage == null || isRetryableError)
 }
 
 internal data class CelesteUiState(
@@ -110,10 +114,16 @@ private data class RememberedDashboard(
     val persistenceError: Throwable?,
 )
 
+private data class AssistantNameContext(
+    val key: AssistantNameKey,
+    val name: String,
+)
+
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
     private val assistantNameStore: AssistantNameStore = InMemoryAssistantNameStore(),
+    private val assistantNameDiagnostics: AssistantNameDiagnostics = NoOpAssistantNameDiagnostics,
     private val reconnectDelayMillis: (attempt: Int, wasRunning: Boolean) -> Long = { attempt, wasRunning ->
         if (wasRunning && attempt == 0) 100L else min(5_000L, 1_000L shl attempt.coerceAtMost(2))
     },
@@ -136,6 +146,8 @@ internal class CelesteViewModel(
     private var assistantNameReadJob: Job? = null
     private var assistantNameSaveJob: Job? = null
     private var currentDescriptor: SavedConnectionDescriptor? = null
+    private var pendingAssistantNameContext: AssistantNameContext? = null
+    private var pendingAssistantNameCleanupOrigin: String? = null
     private var reconnectAttempts = 0
     private var reconciling = false
     private var currentSessionCanResume = true
@@ -193,6 +205,7 @@ internal class CelesteViewModel(
             assistantNameEditor = editor.copy(
                 draft = value,
                 errorMessage = validation.errorMessage,
+                isRetryableError = false,
             ),
         )
     }
@@ -213,14 +226,21 @@ internal class CelesteViewModel(
         val validation = AssistantNamePolicy.validate(editor.draft)
         if (validation.errorMessage != null) {
             mutableState.value = snapshot.copy(
-                assistantNameEditor = editor.copy(errorMessage = validation.errorMessage),
+                assistantNameEditor = editor.copy(
+                    errorMessage = validation.errorMessage,
+                    isRetryableError = false,
+                ),
             )
             return
         }
 
         val generation = assistantNameContextGeneration
         mutableState.value = snapshot.copy(
-            assistantNameEditor = editor.copy(isSaving = true, errorMessage = null),
+            assistantNameEditor = editor.copy(
+                isSaving = true,
+                errorMessage = null,
+                isRetryableError = false,
+            ),
         )
         assistantNameSaveJob?.cancel()
         assistantNameSaveJob = viewModelScope.launch {
@@ -241,6 +261,7 @@ internal class CelesteViewModel(
                     assistantNameEditor = mutableState.value.assistantNameEditor.copy(
                         isSaving = false,
                         errorMessage = "Couldn’t save assistant name on this device. Try again.",
+                        isRetryableError = true,
                     ),
                 )
             }
@@ -267,22 +288,40 @@ internal class CelesteViewModel(
         assistantNameSaveJob?.cancel()
         assistantNameReadJob = null
         assistantNameSaveJob = null
+        val sameContext = key != null && baseState.assistantNameKey == key
         mutableState.value = baseState.copy(
-            assistantDisplayName = DEFAULT_ASSISTANT_NAME,
+            assistantDisplayName = if (sameContext) {
+                baseState.assistantDisplayName.ifBlank { DEFAULT_ASSISTANT_NAME }
+            } else {
+                DEFAULT_ASSISTANT_NAME
+            },
             assistantNameKey = key,
             assistantNameEditor = AssistantNameEditState(),
         )
         if (key == null) return
 
         assistantNameReadJob = viewModelScope.launch {
-            val storedName = runCatching {
+            val rawStoredName = try {
                 assistantNameStoreMutex.withLock {
                     assistantNameStore.read(key.origin, key.profile)
                 }
-            }.getOrNull()?.let { value ->
-                AssistantNamePolicy.validate(value)
-                    .takeIf { it.errorMessage == null && it.normalized != null }
-                    ?.normalized
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                recordAssistantNameDiagnostic(AssistantNameDiagnostic.ReadFailure)
+                null
+            }
+            val storedName = when {
+                rawStoredName == null -> null
+                else -> {
+                    val validation = AssistantNamePolicy.validate(rawStoredName)
+                    if (validation.errorMessage == null && validation.normalized != null) {
+                        validation.normalized
+                    } else {
+                        recordAssistantNameDiagnostic(AssistantNameDiagnostic.InvalidRecord)
+                        null
+                    }
+                }
             }
             if (!isCurrentAssistantNameContext(generation, key)) return@launch
             mutableState.value = mutableState.value.copy(
@@ -291,8 +330,15 @@ internal class CelesteViewModel(
         }
     }
 
-    private fun resetAssistantNameContext() {
+    private fun resetAssistantNameContext(clearPending: Boolean = true) {
+        if (clearPending) {
+            pendingAssistantNameContext = null
+        }
         publishAssistantNameContext(null)
+    }
+
+    private fun recordAssistantNameDiagnostic(diagnostic: AssistantNameDiagnostic) {
+        runCatching { assistantNameDiagnostics.record(diagnostic) }
     }
 
     private fun isCurrentAssistantNameContext(
@@ -502,11 +548,15 @@ internal class CelesteViewModel(
 
     fun forgetConnection() {
         val snapshot = mutableState.value
-        val forgottenOrigin = snapshot.assistantNameKey?.origin
+        val forgottenOrigin = pendingAssistantNameCleanupOrigin
+            ?: snapshot.assistantNameKey?.origin
             ?: AssistantNameKey.from(
                 snapshot.probe?.baseUrl ?: currentDescriptor?.baseUrl ?: snapshot.dashboardUrl,
                 "default",
             )?.origin
+        if (forgottenOrigin != null) {
+            pendingAssistantNameCleanupOrigin = forgottenOrigin
+        }
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
         resetAssistantNameContext()
@@ -525,6 +575,9 @@ internal class CelesteViewModel(
                 assistantNameStoreMutex.withLock {
                     runCatching { assistantNameStore.clearOrigin(origin) }.exceptionOrNull()
                 }
+            }
+            if (assistantNameError == null && forgottenOrigin != null) {
+                pendingAssistantNameCleanupOrigin = null
             }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
                 runCatching { dashboard.logout(snapshot.probe.baseUrl) }
@@ -545,8 +598,14 @@ internal class CelesteViewModel(
     }
 
     private fun restoreSavedConnection() {
+        val currentAssistantName = mutableState.value.assistantNameKey?.let { key ->
+            AssistantNameContext(key, mutableState.value.assistantDisplayName)
+        }
+        if (currentAssistantName != null) {
+            pendingAssistantNameContext = currentAssistantName
+        }
         val attempt = beginConnectionAttempt()
-        resetAssistantNameContext()
+        resetAssistantNameContext(clearPending = false)
         closeGateway()
         credential = null
         mutableState.value = CelesteUiState(
@@ -567,9 +626,11 @@ internal class CelesteViewModel(
             }
             when (val decision = connectionBootstrapDecision(saved)) {
                 ConnectionBootstrapDecision.ManualSetup -> {
+                    pendingAssistantNameContext = null
                     mutableState.value = manualState()
                 }
                 is ConnectionBootstrapDecision.Prefill -> {
+                    pendingAssistantNameContext = null
                     mutableState.value = manualState(decision.descriptor)
                 }
                 is ConnectionBootstrapDecision.Restore -> {
@@ -726,7 +787,16 @@ internal class CelesteViewModel(
             loadingMessage = null,
             errorMessage = errorMessage,
         )
-        resolveAssistantNameContext(connectedState)
+        val targetKey = AssistantNameKey.from(connectedState.probe?.baseUrl, selectedProfile)
+        val preservedName = pendingAssistantNameContext?.takeIf { it.key == targetKey }
+        pendingAssistantNameContext = null
+        val stateForAssistantName = preservedName?.let { context ->
+            connectedState.copy(
+                assistantDisplayName = context.name,
+                assistantNameKey = context.key,
+            )
+        } ?: connectedState
+        resolveAssistantNameContext(stateForAssistantName)
     }
 
     private fun manualState(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.hazydreams.hermesceleste.connection.AndroidConnectionStore
+import dev.hazydreams.hermesceleste.presentation.AndroidAssistantNameStore
 import dev.hazydreams.hermesceleste.ui.CelesteRoutes
 import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
 
@@ -45,7 +46,10 @@ private class CelesteViewModelFactory(
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass.isAssignableFrom(CelesteViewModel::class.java))
-        return CelesteViewModel(connectionStore = AndroidConnectionStore(context)) as T
+        return CelesteViewModel(
+            connectionStore = AndroidConnectionStore(context),
+            assistantNameStore = AndroidAssistantNameStore(context),
+        ) as T
     }
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.hazydreams.hermesceleste.connection.AndroidConnectionStore
 import dev.hazydreams.hermesceleste.presentation.AndroidAssistantNameStore
+import dev.hazydreams.hermesceleste.presentation.LogcatAssistantNameDiagnostics
 import dev.hazydreams.hermesceleste.ui.CelesteRoutes
 import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
 
@@ -46,9 +47,14 @@ private class CelesteViewModelFactory(
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass.isAssignableFrom(CelesteViewModel::class.java))
+        val diagnostics = LogcatAssistantNameDiagnostics
         return CelesteViewModel(
             connectionStore = AndroidConnectionStore(context),
-            assistantNameStore = AndroidAssistantNameStore(context),
+            assistantNameStore = AndroidAssistantNameStore(
+                context = context,
+                diagnostics = diagnostics,
+            ),
+            assistantNameDiagnostics = diagnostics,
         ) as T
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/presentation/AssistantNameStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/presentation/AssistantNameStore.kt
@@ -140,6 +140,12 @@ internal interface AssistantNameStore {
     suspend fun clearOrigin(origin: String)
 }
 
+internal interface AssistantNameRecordStorage {
+    fun readRecords(): String?
+
+    fun commitRecords(encoded: String?): Boolean
+}
+
 @Serializable
 internal data class AssistantNameRecord(
     val version: Int,
@@ -239,15 +245,20 @@ internal class InMemoryAssistantNameStore(
 }
 
 internal class AndroidAssistantNameStore(
-    context: Context,
+    private val recordStorage: AssistantNameRecordStorage,
     private val json: Json = Json { ignoreUnknownKeys = false },
-    private val diagnostics: AssistantNameDiagnostics = LogcatAssistantNameDiagnostics,
+    private val diagnostics: AssistantNameDiagnostics = NoOpAssistantNameDiagnostics,
 ) : AssistantNameStore {
-    private val applicationContext = context.applicationContext
-    private val preferences = applicationContext.getSharedPreferences(
-        PREFERENCES_NAME,
-        Context.MODE_PRIVATE,
+    constructor(
+        context: Context,
+        json: Json = Json { ignoreUnknownKeys = false },
+        diagnostics: AssistantNameDiagnostics = LogcatAssistantNameDiagnostics,
+    ) : this(
+        recordStorage = SharedPreferencesAssistantNameRecordStorage(context),
+        json = json,
+        diagnostics = diagnostics,
     )
+
     private val mutex = Mutex()
 
     override suspend fun read(origin: String, profile: String): String? = withContext(Dispatchers.IO) {
@@ -289,20 +300,35 @@ internal class AndroidAssistantNameStore(
     }
 
     private fun readRecords(): List<AssistantNameRecord> {
-        val encoded = preferences.getString(KEY_RECORDS, null) ?: return emptyList()
+        val encoded = recordStorage.readRecords() ?: return emptyList()
         return decodeAssistantNameRecords(encoded, json, diagnostics)
     }
 
     private fun commitRecords(records: List<AssistantNameRecord>) {
         commitAssistantNameRecords(records, json) { encoded ->
-            val editor = preferences.edit()
-            if (encoded == null) {
-                editor.remove(KEY_RECORDS)
-            } else {
-                editor.putString(KEY_RECORDS, encoded)
-            }
-            editor.commit()
+            recordStorage.commitRecords(encoded)
         }
+    }
+}
+
+private class SharedPreferencesAssistantNameRecordStorage(
+    context: Context,
+) : AssistantNameRecordStorage {
+    private val preferences = context.applicationContext.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+
+    override fun readRecords(): String? = preferences.getString(KEY_RECORDS, null)
+
+    override fun commitRecords(encoded: String?): Boolean {
+        val editor = preferences.edit()
+        if (encoded == null) {
+            editor.remove(KEY_RECORDS)
+        } else {
+            editor.putString(KEY_RECORDS, encoded)
+        }
+        return editor.commit()
     }
 
     private companion object {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/presentation/AssistantNameStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/presentation/AssistantNameStore.kt
@@ -1,0 +1,253 @@
+package dev.hazydreams.hermesceleste.presentation
+
+import android.content.Context
+import dev.hazydreams.hermesceleste.network.DashboardUrlPolicy
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.decodeFromJsonElement
+
+const val DEFAULT_ASSISTANT_NAME = "Hermes"
+
+internal const val ASSISTANT_NAME_MAX_CODE_POINTS = 40
+internal const val ASSISTANT_NAME_STORE_VERSION = 1
+
+internal data class AssistantNameValidation(
+    val normalized: String?,
+    val errorMessage: String?,
+)
+
+internal object AssistantNamePolicy {
+    fun validate(raw: String): AssistantNameValidation {
+        if (containsForbiddenCodePoint(raw)) {
+            return AssistantNameValidation(
+                normalized = null,
+                errorMessage = "Use a single line without control characters.",
+            )
+        }
+
+        val normalized = trimUnicodeWhitespace(raw)
+        if (normalized.isEmpty()) {
+            return AssistantNameValidation(normalized = null, errorMessage = null)
+        }
+
+        if (normalized.codePointCount(0, normalized.length) > ASSISTANT_NAME_MAX_CODE_POINTS) {
+            return AssistantNameValidation(
+                normalized = null,
+                errorMessage = "Use $ASSISTANT_NAME_MAX_CODE_POINTS Unicode code points or fewer.",
+            )
+        }
+
+        return AssistantNameValidation(normalized = normalized, errorMessage = null)
+    }
+
+    internal fun requireValid(raw: String?): String? {
+        if (raw == null) return null
+        val result = validate(raw)
+        require(result.errorMessage == null) { result.errorMessage.orEmpty() }
+        return result.normalized
+    }
+
+    private fun containsForbiddenCodePoint(value: String): Boolean {
+        var index = 0
+        while (index < value.length) {
+            val codePoint = value.codePointAt(index)
+            if (
+                Character.isISOControl(codePoint) ||
+                codePoint == 0x2028 ||
+                codePoint == 0x2029
+            ) {
+                return true
+            }
+            index += Character.charCount(codePoint)
+        }
+        return false
+    }
+
+    private fun trimUnicodeWhitespace(value: String): String {
+        var start = 0
+        var end = value.length
+        while (start < end) {
+            val codePoint = value.codePointAt(start)
+            if (!isUnicodeWhitespace(codePoint)) break
+            start += Character.charCount(codePoint)
+        }
+        while (end > start) {
+            val codePoint = value.codePointBefore(end)
+            if (!isUnicodeWhitespace(codePoint)) break
+            end -= Character.charCount(codePoint)
+        }
+        return value.substring(start, end)
+    }
+
+    private fun isUnicodeWhitespace(codePoint: Int): Boolean =
+        Character.isWhitespace(codePoint) || Character.isSpaceChar(codePoint)
+}
+
+internal data class AssistantNameKey(
+    val origin: String,
+    val profile: String,
+) {
+    companion object {
+        fun from(baseUrl: String?, selectedProfile: String?): AssistantNameKey? {
+            if (baseUrl.isNullOrBlank() || selectedProfile == null) return null
+            val origin = runCatching { DashboardUrlPolicy.normalize(baseUrl) }.getOrNull()
+                ?: return null
+            return AssistantNameKey(
+                origin = origin,
+                profile = selectedProfile.trim().ifEmpty { "default" },
+            )
+        }
+    }
+}
+
+internal interface AssistantNameStore {
+    suspend fun read(origin: String, profile: String): String?
+
+    suspend fun write(origin: String, profile: String, name: String?)
+
+    suspend fun clearOrigin(origin: String)
+}
+
+internal class InMemoryAssistantNameStore(
+    private val entries: MutableMap<AssistantNameKey, String> = linkedMapOf(),
+) : AssistantNameStore {
+    private val mutex = Mutex()
+
+    override suspend fun read(origin: String, profile: String): String? = mutex.withLock {
+        entries[storeKey(origin, profile)]
+    }
+
+    override suspend fun write(origin: String, profile: String, name: String?) {
+        val normalized = AssistantNamePolicy.requireValid(name)
+        mutex.withLock {
+            val key = storeKey(origin, profile)
+            if (normalized == null) {
+                entries.remove(key)
+            } else {
+                entries[key] = normalized
+            }
+        }
+    }
+
+    override suspend fun clearOrigin(origin: String) {
+        val normalizedOrigin = storeOrigin(origin)
+        mutex.withLock {
+            entries.keys.removeAll { it.origin == normalizedOrigin }
+        }
+    }
+}
+
+internal class AndroidAssistantNameStore(
+    context: Context,
+    private val json: Json = Json { ignoreUnknownKeys = false },
+) : AssistantNameStore {
+    private val applicationContext = context.applicationContext
+    private val preferences = applicationContext.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+    private val mutex = Mutex()
+
+    override suspend fun read(origin: String, profile: String): String? = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            val key = storeKey(origin, profile)
+            readRecords().firstOrNull { it.origin == key.origin && it.profile == key.profile }?.name
+        }
+    }
+
+    override suspend fun write(origin: String, profile: String, name: String?) {
+        withContext(Dispatchers.IO) {
+            val normalized = AssistantNamePolicy.requireValid(name)
+            mutex.withLock {
+                val key = storeKey(origin, profile)
+                val records = readRecords()
+                    .filterNot { it.origin == key.origin && it.profile == key.profile }
+                    .toMutableList()
+                if (normalized != null) {
+                    records += AssistantNameRecord(
+                        version = ASSISTANT_NAME_STORE_VERSION,
+                        origin = key.origin,
+                        profile = key.profile,
+                        name = normalized,
+                    )
+                }
+                commitRecords(records)
+            }
+        }
+    }
+
+    override suspend fun clearOrigin(origin: String) {
+        val normalizedOrigin = storeOrigin(origin)
+        withContext(Dispatchers.IO) {
+            mutex.withLock {
+                val records = readRecords().filterNot { it.origin == normalizedOrigin }
+                commitRecords(records)
+            }
+        }
+    }
+
+    private fun readRecords(): List<AssistantNameRecord> {
+        val encoded = preferences.getString(KEY_RECORDS, null) ?: return emptyList()
+        val root = runCatching { json.parseToJsonElement(encoded) }.getOrNull()
+            as? JsonArray ?: return emptyList()
+
+        return root.mapNotNull { element ->
+            val record = runCatching {
+                json.decodeFromJsonElement<AssistantNameRecord>(element)
+            }.getOrNull() ?: return@mapNotNull null
+            if (record.version != ASSISTANT_NAME_STORE_VERSION) return@mapNotNull null
+            val key = AssistantNameKey.from(record.origin, record.profile)
+                ?: return@mapNotNull null
+            val validatedName = AssistantNamePolicy.validate(record.name)
+            if (validatedName.errorMessage != null || validatedName.normalized == null) {
+                return@mapNotNull null
+            }
+            AssistantNameRecord(
+                version = ASSISTANT_NAME_STORE_VERSION,
+                origin = key.origin,
+                profile = key.profile,
+                name = validatedName.normalized,
+            )
+        }
+    }
+
+    private fun commitRecords(records: List<AssistantNameRecord>) {
+        val editor = preferences.edit()
+        if (records.isEmpty()) {
+            editor.remove(KEY_RECORDS)
+        } else {
+            editor.putString(KEY_RECORDS, json.encodeToString(records))
+        }
+        if (!editor.commit()) {
+            throw IOException("Could not save assistant name on this device.")
+        }
+    }
+
+    @Serializable
+    private data class AssistantNameRecord(
+        val version: Int,
+        val origin: String,
+        val profile: String,
+        val name: String,
+    )
+
+    private companion object {
+        const val PREFERENCES_NAME = "assistant_presentation_v1"
+        const val KEY_RECORDS = "records"
+    }
+}
+
+private fun storeKey(origin: String, profile: String): AssistantNameKey =
+    AssistantNameKey.from(origin, profile)
+        ?: throw IllegalArgumentException("A valid assistant name context is required.")
+
+private fun storeOrigin(origin: String): String =
+    AssistantNameKey.from(origin, "default")?.origin
+        ?: throw IllegalArgumentException("A valid assistant name origin is required.")

--- a/app/src/main/java/dev/hazydreams/hermesceleste/presentation/AssistantNameStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/presentation/AssistantNameStore.kt
@@ -1,6 +1,7 @@
 package dev.hazydreams.hermesceleste.presentation
 
 import android.content.Context
+import android.util.Log
 import dev.hazydreams.hermesceleste.network.DashboardUrlPolicy
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +18,30 @@ const val DEFAULT_ASSISTANT_NAME = "Hermes"
 
 internal const val ASSISTANT_NAME_MAX_CODE_POINTS = 40
 internal const val ASSISTANT_NAME_STORE_VERSION = 1
+
+internal enum class AssistantNameDiagnostic(val code: String) {
+    ReadFailure("read_failure"),
+    MalformedPayload("malformed_payload"),
+    MalformedRecord("malformed_record"),
+    UnsupportedVersion("unsupported_version"),
+    InvalidRecord("invalid_record"),
+}
+
+internal fun interface AssistantNameDiagnostics {
+    fun record(diagnostic: AssistantNameDiagnostic)
+}
+
+internal object NoOpAssistantNameDiagnostics : AssistantNameDiagnostics {
+    override fun record(diagnostic: AssistantNameDiagnostic) = Unit
+}
+
+internal object LogcatAssistantNameDiagnostics : AssistantNameDiagnostics {
+    private const val TAG = "CelesteAssistantName"
+
+    override fun record(diagnostic: AssistantNameDiagnostic) {
+        Log.w(TAG, "Local assistant-name record discarded: ${diagnostic.code}")
+    }
+}
 
 internal data class AssistantNameValidation(
     val normalized: String?,
@@ -115,6 +140,75 @@ internal interface AssistantNameStore {
     suspend fun clearOrigin(origin: String)
 }
 
+@Serializable
+internal data class AssistantNameRecord(
+    val version: Int,
+    val origin: String,
+    val profile: String,
+    val name: String,
+)
+
+internal fun interface AssistantNameRecordCommitter {
+    fun commit(encoded: String?): Boolean
+}
+
+internal fun commitAssistantNameRecords(
+    records: List<AssistantNameRecord>,
+    json: Json,
+    committer: AssistantNameRecordCommitter,
+) {
+    val encoded = records
+        .takeIf { it.isNotEmpty() }
+        ?.let { json.encodeToString(it) }
+    if (!committer.commit(encoded)) {
+        throw IOException("Could not save assistant name on this device.")
+    }
+}
+
+internal fun decodeAssistantNameRecords(
+    encoded: String,
+    json: Json,
+    diagnostics: AssistantNameDiagnostics,
+): List<AssistantNameRecord> {
+    val root = runCatching { json.parseToJsonElement(encoded) }.getOrElse {
+        diagnostics.record(AssistantNameDiagnostic.MalformedPayload)
+        return emptyList()
+    }
+    val records = root as? JsonArray ?: run {
+        diagnostics.record(AssistantNameDiagnostic.MalformedPayload)
+        return emptyList()
+    }
+
+    return records.mapNotNull { element ->
+        val record = runCatching {
+            json.decodeFromJsonElement<AssistantNameRecord>(element)
+        }.getOrElse {
+            diagnostics.record(AssistantNameDiagnostic.MalformedRecord)
+            return@mapNotNull null
+        }
+        if (record.version != ASSISTANT_NAME_STORE_VERSION) {
+            diagnostics.record(AssistantNameDiagnostic.UnsupportedVersion)
+            return@mapNotNull null
+        }
+        val key = AssistantNameKey.from(record.origin, record.profile)
+            ?: run {
+                diagnostics.record(AssistantNameDiagnostic.InvalidRecord)
+                return@mapNotNull null
+            }
+        val validatedName = AssistantNamePolicy.validate(record.name)
+        if (validatedName.errorMessage != null || validatedName.normalized == null) {
+            diagnostics.record(AssistantNameDiagnostic.InvalidRecord)
+            return@mapNotNull null
+        }
+        AssistantNameRecord(
+            version = ASSISTANT_NAME_STORE_VERSION,
+            origin = key.origin,
+            profile = key.profile,
+            name = validatedName.normalized,
+        )
+    }
+}
+
 internal class InMemoryAssistantNameStore(
     private val entries: MutableMap<AssistantNameKey, String> = linkedMapOf(),
 ) : AssistantNameStore {
@@ -147,6 +241,7 @@ internal class InMemoryAssistantNameStore(
 internal class AndroidAssistantNameStore(
     context: Context,
     private val json: Json = Json { ignoreUnknownKeys = false },
+    private val diagnostics: AssistantNameDiagnostics = LogcatAssistantNameDiagnostics,
 ) : AssistantNameStore {
     private val applicationContext = context.applicationContext
     private val preferences = applicationContext.getSharedPreferences(
@@ -195,48 +290,20 @@ internal class AndroidAssistantNameStore(
 
     private fun readRecords(): List<AssistantNameRecord> {
         val encoded = preferences.getString(KEY_RECORDS, null) ?: return emptyList()
-        val root = runCatching { json.parseToJsonElement(encoded) }.getOrNull()
-            as? JsonArray ?: return emptyList()
-
-        return root.mapNotNull { element ->
-            val record = runCatching {
-                json.decodeFromJsonElement<AssistantNameRecord>(element)
-            }.getOrNull() ?: return@mapNotNull null
-            if (record.version != ASSISTANT_NAME_STORE_VERSION) return@mapNotNull null
-            val key = AssistantNameKey.from(record.origin, record.profile)
-                ?: return@mapNotNull null
-            val validatedName = AssistantNamePolicy.validate(record.name)
-            if (validatedName.errorMessage != null || validatedName.normalized == null) {
-                return@mapNotNull null
-            }
-            AssistantNameRecord(
-                version = ASSISTANT_NAME_STORE_VERSION,
-                origin = key.origin,
-                profile = key.profile,
-                name = validatedName.normalized,
-            )
-        }
+        return decodeAssistantNameRecords(encoded, json, diagnostics)
     }
 
     private fun commitRecords(records: List<AssistantNameRecord>) {
-        val editor = preferences.edit()
-        if (records.isEmpty()) {
-            editor.remove(KEY_RECORDS)
-        } else {
-            editor.putString(KEY_RECORDS, json.encodeToString(records))
-        }
-        if (!editor.commit()) {
-            throw IOException("Could not save assistant name on this device.")
+        commitAssistantNameRecords(records, json) { encoded ->
+            val editor = preferences.edit()
+            if (encoded == null) {
+                editor.remove(KEY_RECORDS)
+            } else {
+                editor.putString(KEY_RECORDS, encoded)
+            }
+            editor.commit()
         }
     }
-
-    @Serializable
-    private data class AssistantNameRecord(
-        val version: Int,
-        val origin: String,
-        val profile: String,
-        val name: String,
-    )
 
     private companion object {
         const val PREFERENCES_NAME = "assistant_presentation_v1"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -158,6 +158,7 @@ private fun GatewaySettingsRoute(
             connectionPhase = ui.connectionPhase,
             loadingMessage = ui.loadingMessage,
             errorMessage = ui.errorMessage,
+            assistantNameCleanupRetryOrigin = ui.assistantNameCleanupRetryOrigin,
         ),
         actions = GatewaySettingsActions(
             onUsernameChange = viewModel::updateUsername,
@@ -172,6 +173,7 @@ private fun GatewaySettingsRoute(
             onSignOut = viewModel::signOut,
             onForgetConnection = viewModel::forgetConnection,
             onBack = onBack,
+            onRetryAssistantNameCleanup = viewModel::retryAssistantNameCleanup,
         ),
     )
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -159,6 +159,7 @@ private fun GatewaySettingsRoute(
             loadingMessage = ui.loadingMessage,
             errorMessage = ui.errorMessage,
             assistantNameCleanupRetryOrigin = ui.assistantNameCleanupRetryOrigin,
+            connectionForgetRetryPending = ui.connectionForgetRetryPending,
         ),
         actions = GatewaySettingsActions(
             onUsernameChange = viewModel::updateUsername,
@@ -174,6 +175,7 @@ private fun GatewaySettingsRoute(
             onForgetConnection = viewModel::forgetConnection,
             onBack = onBack,
             onRetryAssistantNameCleanup = viewModel::retryAssistantNameCleanup,
+            onRetryConnectionCleanup = viewModel::retryConnectionCleanup,
         ),
     )
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -53,12 +53,25 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
 
     when (destination) {
         CelesteDestination.Settings -> {
-            BackHandler { destination = CelesteDestination.Content }
+            BackHandler {
+                if (ui.assistantNameEditor.isOpen) {
+                    viewModel.cancelAssistantNameEdit()
+                } else {
+                    destination = CelesteDestination.Content
+                }
+            }
             SettingsScreen(
                 dashboardUrl = ui.dashboardUrl,
                 connectionPhase = ui.connectionPhase,
+                assistantDisplayName = ui.assistantDisplayName,
+                assistantNameScope = ui.assistantNameKey,
+                assistantNameEditor = ui.assistantNameEditor,
                 onBack = { destination = CelesteDestination.Content },
                 onGateway = { destination = CelesteDestination.Gateway },
+                onOpenAssistantName = viewModel::openAssistantNameEditor,
+                onAssistantNameDraftChange = viewModel::updateAssistantNameDraft,
+                onSaveAssistantName = viewModel::saveAssistantName,
+                onCancelAssistantName = viewModel::cancelAssistantNameEdit,
             )
         }
 
@@ -84,6 +97,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     messages = ui.messages,
                     streamingText = ui.streamingText,
                     draft = ui.draft,
+                    assistantDisplayName = ui.assistantDisplayName,
                     turnState = ui.turnState,
                     loadingMessage = ui.loadingMessage,
                     errorMessage = ui.errorMessage,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.TurnState
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.presentation.DEFAULT_ASSISTANT_NAME
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteCoral
@@ -69,6 +70,7 @@ internal fun ConversationScreen(
     messages: List<ConversationMessage>,
     streamingText: String,
     draft: String,
+    assistantDisplayName: String = DEFAULT_ASSISTANT_NAME,
     turnState: TurnState,
     loadingMessage: String?,
     errorMessage: String?,
@@ -80,6 +82,7 @@ internal fun ConversationScreen(
 ) {
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
+    val effectiveAssistantDisplayName = assistantDisplayName.ifBlank { DEFAULT_ASSISTANT_NAME }
     val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
     val visibleMessageCount = messages.size + if (streamingText.isNotBlank()) 1 else 0
     val safeDrawingInsets = WindowInsets.safeDrawing
@@ -163,12 +166,13 @@ internal fun ConversationScreen(
                     items = messages,
                     key = { index, _ -> transcriptKeys[index] },
                 ) { _, message ->
-                    MessageBubble(message)
+                    MessageBubble(message, effectiveAssistantDisplayName)
                 }
                 if (streamingText.isNotBlank()) {
                     item(key = STREAMING_TRANSCRIPT_KEY) {
                         MessageBubble(
                             ConversationMessage(role = "assistant", text = streamingText, pending = true),
+                            effectiveAssistantDisplayName,
                         )
                     }
                 }
@@ -191,8 +195,8 @@ internal fun ConversationScreen(
                     placeholder = {
                         Text(
                             when (turnState) {
-                                TurnState.Idle -> "Message Hermes"
-                                TurnState.Running -> "Hermes is responding…"
+                                TurnState.Idle -> "Message $effectiveAssistantDisplayName"
+                                TurnState.Running -> "$effectiveAssistantDisplayName is responding…"
                                 TurnState.Synchronizing -> "Synchronizing…"
                                 TurnState.Reconnecting -> "Keep drafting while Celeste reconnects…"
                             },

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.presentation.DEFAULT_ASSISTANT_NAME
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteCoral
 import dev.hazydreams.hermesceleste.ui.CelesteGoldText
@@ -50,10 +51,14 @@ internal fun transcriptItemKeys(messages: List<ConversationMessage>): List<Strin
 }
 
 @Composable
-internal fun MessageBubble(message: ConversationMessage) {
+internal fun MessageBubble(
+    message: ConversationMessage,
+    assistantDisplayName: String = DEFAULT_ASSISTANT_NAME,
+) {
+    val effectiveAssistantDisplayName = assistantDisplayName.ifBlank { DEFAULT_ASSISTANT_NAME }
     when (message.role) {
         "user" -> UserMessage(message)
-        "assistant" -> AssistantMessage(message)
+        "assistant" -> AssistantMessage(message, effectiveAssistantDisplayName)
         else -> ToolMessage(message)
     }
 }
@@ -84,7 +89,7 @@ private fun UserMessage(message: ConversationMessage) {
 }
 
 @Composable
-private fun AssistantMessage(message: ConversationMessage) {
+private fun AssistantMessage(message: ConversationMessage, assistantDisplayName: String) {
     val accent = CelesteCoral
     Column(
         modifier = Modifier
@@ -99,7 +104,7 @@ private fun AssistantMessage(message: ConversationMessage) {
             }
             .padding(start = 17.dp, end = 8.dp, top = 3.dp, bottom = 3.dp),
     ) {
-        MessageLabel("Hermes", accent, message.pending)
+        MessageLabel(assistantDisplayName, accent, message.pending)
         if (message.text.isNotBlank()) {
             Spacer(Modifier.height(8.dp))
             Text(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
@@ -143,13 +143,17 @@ private fun ToolMessage(message: ConversationMessage) {
 
 @Composable
 private fun MessageLabel(label: String, color: Color, pending: Boolean) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Text(
             text = label.uppercase(),
             color = color,
             fontSize = 10.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 1.sp,
+            modifier = Modifier.weight(1f, fill = false),
         )
         if (pending) {
             Spacer(Modifier.size(7.dp))

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -48,14 +50,18 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.ConnectionPhase
+import dev.hazydreams.hermesceleste.AssistantNameEditState
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.DEFAULT_ASSISTANT_NAME
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteCoral
@@ -173,8 +179,15 @@ internal fun ConnectionUnavailableScreen(
 internal fun SettingsScreen(
     dashboardUrl: String,
     connectionPhase: ConnectionPhase,
+    assistantDisplayName: String = DEFAULT_ASSISTANT_NAME,
+    assistantNameScope: AssistantNameKey? = null,
+    assistantNameEditor: AssistantNameEditState = AssistantNameEditState(),
     onBack: () -> Unit,
     onGateway: () -> Unit,
+    onOpenAssistantName: () -> Unit = {},
+    onAssistantNameDraftChange: (String) -> Unit = {},
+    onSaveAssistantName: () -> Unit = {},
+    onCancelAssistantName: () -> Unit = {},
 ) {
     CelesteBackdrop {
         Column(
@@ -182,43 +195,180 @@ internal fun SettingsScreen(
                 .fillMaxSize()
                 .padding(horizontal = 28.dp, vertical = 38.dp),
         ) {
-            EditorialHeader(title = "Settings", onBack = onBack)
+            EditorialHeader(
+                title = "Settings",
+                onBack = if (assistantNameEditor.isOpen) onCancelAssistantName else onBack,
+            )
             Spacer(Modifier.height(44.dp))
-            CelesteSectionLabel("Connection")
-            Spacer(Modifier.height(12.dp))
-            EditorialDivider()
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = onGateway)
-                    .padding(vertical = 20.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(Modifier.weight(1f)) {
-                    Text("Gateway", style = MaterialTheme.typography.titleLarge)
-                    Spacer(Modifier.height(5.dp))
+            if (assistantNameEditor.isOpen) {
+                AssistantNameEditor(
+                    state = assistantNameEditor,
+                    scope = assistantNameScope,
+                    onDraftChange = onAssistantNameDraftChange,
+                    onSave = onSaveAssistantName,
+                    onCancel = onCancelAssistantName,
+                )
+            } else {
+                CelesteSectionLabel("Connection")
+                Spacer(Modifier.height(12.dp))
+                EditorialDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onGateway)
+                        .padding(vertical = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text("Gateway", style = MaterialTheme.typography.titleLarge)
+                        Spacer(Modifier.height(5.dp))
+                        Text(
+                            dashboardUrl.ifBlank { "Not configured" },
+                            color = CelesteMuted,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    StatusDot(connectionPhase)
+                    Spacer(Modifier.size(8.dp))
                     Text(
-                        dashboardUrl.ifBlank { "Not configured" },
+                        connectionStatusLabel(connectionPhase),
                         color = CelesteMuted,
                         style = MaterialTheme.typography.bodyMedium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
                     )
+                    Spacer(Modifier.size(10.dp))
+                    Text("→", color = CelesteInk, fontSize = 18.sp)
                 }
-                StatusDot(connectionPhase)
-                Spacer(Modifier.size(8.dp))
-                Text(
-                    connectionStatusLabel(connectionPhase),
-                    color = CelesteMuted,
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Spacer(Modifier.size(10.dp))
-                Text("→", color = CelesteInk, fontSize = 18.sp)
+                EditorialDivider()
+                Spacer(Modifier.height(30.dp))
+                CelesteSectionLabel("On this device")
+                Spacer(Modifier.height(12.dp))
+                EditorialDivider()
+                val canEditAssistantName = assistantNameScope != null
+                val effectiveAssistantName = assistantDisplayName.ifBlank { DEFAULT_ASSISTANT_NAME }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(
+                            enabled = canEditAssistantName,
+                            onClick = onOpenAssistantName,
+                        )
+                        .semantics {
+                            contentDescription = if (canEditAssistantName) {
+                                "Assistant name, $effectiveAssistantName"
+                            } else {
+                                "Assistant name unavailable until a connection and profile are selected"
+                            }
+                        }
+                        .padding(vertical = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            "Assistant name",
+                            style = MaterialTheme.typography.titleLarge,
+                            color = if (canEditAssistantName) CelesteInk else CelesteMuted,
+                        )
+                        Spacer(Modifier.height(5.dp))
+                        if (canEditAssistantName) {
+                            Text(
+                                effectiveAssistantName,
+                                color = CelesteInk,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                assistantNameScope?.scopeLabel().orEmpty(),
+                                color = CelesteMuted,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        } else {
+                            Text(
+                                "Connect to a gateway and select a profile to set a local name.",
+                                color = CelesteMuted,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                    if (canEditAssistantName) {
+                        Spacer(Modifier.size(10.dp))
+                        Text("→", color = CelesteInk, fontSize = 18.sp)
+                    }
+                }
+                EditorialDivider()
             }
-            EditorialDivider()
         }
     }
 }
+
+@Composable
+private fun AssistantNameEditor(
+    state: AssistantNameEditState,
+    scope: AssistantNameKey?,
+    onDraftChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Text("Assistant name", style = MaterialTheme.typography.displaySmall)
+    Spacer(Modifier.height(12.dp))
+    Text(
+        text = scope?.scopeLabel().orEmpty(),
+        color = CelesteMuted,
+        style = MaterialTheme.typography.bodyMedium,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+    )
+    Spacer(Modifier.height(24.dp))
+    OutlinedTextField(
+        value = state.draft,
+        onValueChange = onDraftChange,
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = "Assistant name" },
+        label = { Text("Assistant name") },
+        singleLine = true,
+        isError = state.errorMessage != null,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { if (state.canSave) onSave() }),
+        shape = RoundedCornerShape(15.dp),
+        textStyle = MaterialTheme.typography.bodyLarge,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = CelesteBlue,
+            unfocusedBorderColor = CelesteHairline,
+            focusedContainerColor = CelestePanel,
+            unfocusedContainerColor = CelestePanel,
+            cursorColor = CelesteBlue,
+        ),
+        supportingText = {
+            state.errorMessage?.let { error -> Text(error, color = CelesteError) }
+        },
+    )
+    Spacer(Modifier.height(18.dp))
+    Text(
+        "Only changes how Celeste labels the assistant on this device. It does not rename the Hermes profile or change how Hermes responds.",
+        color = CelesteMuted,
+        style = MaterialTheme.typography.bodyMedium,
+    )
+    Spacer(Modifier.height(28.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TextButton(onClick = onCancel, enabled = !state.isSaving) {
+            Text("Cancel", color = CelesteBlue)
+        }
+        TextButton(onClick = onSave, enabled = state.canSave) {
+            Text("Save", color = if (state.canSave) CelesteBlue else CelesteMuted)
+        }
+    }
+}
+
+private fun AssistantNameKey.scopeLabel(): String = "$origin · profile: $profile"
 
 @Composable
 internal fun GatewaySettingsScreen(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -46,7 +47,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.error
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -56,8 +62,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import dev.hazydreams.hermesceleste.ConnectionPhase
 import dev.hazydreams.hermesceleste.AssistantNameEditState
+import dev.hazydreams.hermesceleste.ConnectionPhase
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
@@ -193,6 +199,8 @@ internal fun SettingsScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .imePadding()
                 .padding(horizontal = 28.dp, vertical = 38.dp),
         ) {
             EditorialHeader(
@@ -255,8 +263,9 @@ internal fun SettingsScreen(
                             onClick = onOpenAssistantName,
                         )
                         .semantics {
+                            role = Role.Button
                             contentDescription = if (canEditAssistantName) {
-                                "Assistant name, $effectiveAssistantName"
+                                "Assistant name, $effectiveAssistantName, ${assistantNameScope?.scopeLabel().orEmpty()}"
                             } else {
                                 "Assistant name unavailable until a connection and profile are selected"
                             }
@@ -276,8 +285,6 @@ internal fun SettingsScreen(
                                 effectiveAssistantName,
                                 color = CelesteInk,
                                 style = MaterialTheme.typography.bodyMedium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
                             )
                             Text(
                                 assistantNameScope?.scopeLabel().orEmpty(),
@@ -328,7 +335,9 @@ private fun AssistantNameEditor(
         onValueChange = onDraftChange,
         modifier = Modifier
             .fillMaxWidth()
-            .semantics { contentDescription = "Assistant name" },
+            .semantics {
+                state.errorMessage?.let { error(it) }
+            },
         label = { Text("Assistant name") },
         singleLine = true,
         isError = state.errorMessage != null,
@@ -344,7 +353,15 @@ private fun AssistantNameEditor(
             cursorColor = CelesteBlue,
         ),
         supportingText = {
-            state.errorMessage?.let { error -> Text(error, color = CelesteError) }
+            state.errorMessage?.let { errorMessage ->
+                Text(
+                    text = errorMessage,
+                    color = CelesteError,
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Assertive
+                    },
+                )
+            }
         },
     )
     Spacer(Modifier.height(18.dp))

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -96,6 +96,7 @@ internal data class GatewaySettingsUiState(
     val connectionPhase: ConnectionPhase,
     val loadingMessage: String?,
     val errorMessage: String?,
+    val assistantNameCleanupRetryOrigin: String? = null,
 )
 
 internal data class GatewaySettingsActions(
@@ -108,6 +109,7 @@ internal data class GatewaySettingsActions(
     val onSignOut: () -> Unit,
     val onForgetConnection: () -> Unit,
     val onBack: (() -> Unit)?,
+    val onRetryAssistantNameCleanup: () -> Unit = {},
 )
 
 @Composable
@@ -588,6 +590,15 @@ internal fun GatewaySettingsScreen(
             if (connectionPhase == ConnectionPhase.RestoreFailed && loadingMessage == null) {
                 TextButton(onClick = actions.onRetry, modifier = Modifier.fillMaxWidth()) {
                     Text("Try saved connection again", color = CelesteBlue)
+                }
+            }
+
+            if (state.assistantNameCleanupRetryOrigin != null && loadingMessage == null) {
+                TextButton(
+                    onClick = actions.onRetryAssistantNameCleanup,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Retry local cleanup", color = CelesteBlue)
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -97,6 +97,7 @@ internal data class GatewaySettingsUiState(
     val loadingMessage: String?,
     val errorMessage: String?,
     val assistantNameCleanupRetryOrigin: String? = null,
+    val connectionForgetRetryPending: Boolean = false,
 )
 
 internal data class GatewaySettingsActions(
@@ -110,6 +111,7 @@ internal data class GatewaySettingsActions(
     val onForgetConnection: () -> Unit,
     val onBack: (() -> Unit)?,
     val onRetryAssistantNameCleanup: () -> Unit = {},
+    val onRetryConnectionCleanup: () -> Unit = {},
 )
 
 @Composable
@@ -599,6 +601,18 @@ internal fun GatewaySettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text("Retry local cleanup", color = CelesteBlue)
+                }
+            }
+
+            if (state.connectionForgetRetryPending &&
+                state.assistantNameCleanupRetryOrigin == null &&
+                loadingMessage == null
+            ) {
+                TextButton(
+                    onClick = actions.onRetryConnectionCleanup,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Retry saved-connection cleanup", color = CelesteBlue)
                 }
             }
 

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -9,6 +9,7 @@ import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
 import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
 import dev.hazydreams.hermesceleste.ui.conversation.ConversationScreen
 import dev.hazydreams.hermesceleste.ui.gateway.ConnectionLoadingScreen
@@ -187,6 +188,74 @@ fun SessionTokenGatewayPreviewScreenshot() {
 }
 
 @PreviewTest
+@Preview(name = "14 · Assistant name editor", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun AssistantNameEditorPreviewScreenshot() {
+    HermesCelesteTheme {
+        SettingsScreen(
+            dashboardUrl = "https://hermes.example.net/hermes",
+            connectionPhase = ConnectionPhase.Connected,
+            assistantDisplayName = "Juno",
+            assistantNameScope = AssistantNameKey("https://hermes.example.net/hermes", "default"),
+            assistantNameEditor = AssistantNameEditState(
+                isOpen = true,
+                draft = "Juno",
+            ),
+            onBack = {},
+            onGateway = {},
+            onOpenAssistantName = {},
+            onAssistantNameDraftChange = {},
+            onSaveAssistantName = {},
+            onCancelAssistantName = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "15 · Assistant name invalid", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun InvalidAssistantNamePreviewScreenshot() {
+    HermesCelesteTheme {
+        SettingsScreen(
+            dashboardUrl = "https://hermes.example.net/hermes",
+            connectionPhase = ConnectionPhase.Connected,
+            assistantDisplayName = "Hermes",
+            assistantNameScope = AssistantNameKey("https://hermes.example.net/hermes", "work"),
+            assistantNameEditor = AssistantNameEditState(
+                isOpen = true,
+                draft = "Juno\n",
+                errorMessage = "Use a single line without control characters.",
+            ),
+            onBack = {},
+            onGateway = {},
+            onOpenAssistantName = {},
+            onAssistantNameDraftChange = {},
+            onSaveAssistantName = {},
+            onCancelAssistantName = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "16 · Custom assistant transcript", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun CustomAssistantConversationPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            assistantDisplayName = "Juno",
+            messages = listOf(
+                ConversationMessage(
+                    role = "assistant",
+                    text = "The local presentation name updates without changing the Hermes session.",
+                    id = "preview-assistant-name",
+                ),
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
+@PreviewTest
 @Preview(name = "09 · Settings", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun SettingsPreviewScreenshot() {
@@ -350,6 +419,7 @@ private fun PreviewConversation(
     messages: List<ConversationMessage> = previewMessages,
     streamingText: String = "",
     draft: String = "",
+    assistantDisplayName: String = "Hermes",
     turnState: TurnState,
     errorMessage: String? = null,
 ) {
@@ -358,6 +428,7 @@ private fun PreviewConversation(
         messages = messages,
         streamingText = streamingText,
         draft = draft,
+        assistantDisplayName = assistantDisplayName,
         turnState = turnState,
         loadingMessage = null,
         errorMessage = errorMessage,

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -256,6 +256,104 @@ fun CustomAssistantConversationPreviewScreenshot() {
 }
 
 @PreviewTest
+@Preview(name = "17 · Saved assistant name", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun SavedAssistantNameSettingsPreviewScreenshot() {
+    HermesCelesteTheme {
+        SettingsScreen(
+            dashboardUrl = "https://hermes.example.net/hermes",
+            connectionPhase = ConnectionPhase.Connected,
+            assistantDisplayName = "Juno",
+            assistantNameScope = AssistantNameKey("https://hermes.example.net/hermes", "default"),
+            onBack = {},
+            onGateway = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "18 · Assistant name write error", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun AssistantNameWriteErrorPreviewScreenshot() {
+    HermesCelesteTheme {
+        SettingsScreen(
+            dashboardUrl = "https://hermes.example.net/hermes",
+            connectionPhase = ConnectionPhase.Connected,
+            assistantDisplayName = "Juno",
+            assistantNameScope = AssistantNameKey("https://hermes.example.net/hermes", "default"),
+            assistantNameEditor = AssistantNameEditState(
+                isOpen = true,
+                draft = "Nova",
+                errorMessage = "Couldn’t save assistant name on this device. Try again.",
+                isRetryableError = true,
+            ),
+            onBack = {},
+            onGateway = {},
+            onOpenAssistantName = {},
+            onAssistantNameDraftChange = {},
+            onSaveAssistantName = {},
+            onCancelAssistantName = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "19 · Custom assistant responding", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun CustomAssistantRunningPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            assistantDisplayName = "Juno",
+            messages = emptyList(),
+            turnState = TurnState.Running,
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "20 · Assistant name large text", widthDp = 320, heightDp = 844, fontScale = 2f, showBackground = true)
+@Composable
+fun AssistantNameLargeTextNarrowPreviewScreenshot() {
+    HermesCelesteTheme {
+        SettingsScreen(
+            dashboardUrl = "https://hermes.example.net/hermes",
+            connectionPhase = ConnectionPhase.Connected,
+            assistantDisplayName = "Juno",
+            assistantNameScope = AssistantNameKey("https://hermes.example.net/hermes", "work"),
+            assistantNameEditor = AssistantNameEditState(
+                isOpen = true,
+                draft = "🌙".repeat(40),
+            ),
+            onBack = {},
+            onGateway = {},
+            onOpenAssistantName = {},
+            onAssistantNameDraftChange = {},
+            onSaveAssistantName = {},
+            onCancelAssistantName = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "21 · Hermes fallback", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun AssistantNameFallbackPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            assistantDisplayName = "",
+            messages = listOf(
+                ConversationMessage(
+                    role = "assistant",
+                    text = "A missing local alias stays safe and readable as Hermes.",
+                    id = "preview-assistant-fallback",
+                ),
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
+@PreviewTest
 @Preview(name = "09 · Settings", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun SettingsPreviewScreenshot() {

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -345,7 +345,6 @@ fun AssistantNameFallbackPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "09 · Settings", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun SettingsPreviewScreenshot() {

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -187,7 +187,6 @@ fun SessionTokenGatewayPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "14 · Assistant name editor", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun AssistantNameEditorPreviewScreenshot() {
@@ -211,7 +210,6 @@ fun AssistantNameEditorPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "15 · Assistant name invalid", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun InvalidAssistantNamePreviewScreenshot() {
@@ -236,7 +234,6 @@ fun InvalidAssistantNamePreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "16 · Custom assistant transcript", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun CustomAssistantConversationPreviewScreenshot() {
@@ -255,7 +252,6 @@ fun CustomAssistantConversationPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "17 · Saved assistant name", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun SavedAssistantNameSettingsPreviewScreenshot() {
@@ -271,7 +267,6 @@ fun SavedAssistantNameSettingsPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "18 · Assistant name write error", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun AssistantNameWriteErrorPreviewScreenshot() {
@@ -297,7 +292,6 @@ fun AssistantNameWriteErrorPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "19 · Custom assistant responding", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun CustomAssistantRunningPreviewScreenshot() {
@@ -310,7 +304,6 @@ fun CustomAssistantRunningPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "20 · Assistant name large text", widthDp = 320, heightDp = 844, fontScale = 2f, showBackground = true)
 @Composable
 fun AssistantNameLargeTextNarrowPreviewScreenshot() {
@@ -334,7 +327,6 @@ fun AssistantNameLargeTextNarrowPreviewScreenshot() {
     }
 }
 
-@PreviewTest
 @Preview(name = "21 · Hermes fallback", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun AssistantNameFallbackPreviewScreenshot() {

--- a/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNamePolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNamePolicyTest.kt
@@ -1,0 +1,67 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.AssistantNamePolicy
+import dev.hazydreams.hermesceleste.presentation.DEFAULT_ASSISTANT_NAME
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AssistantNamePolicyTest {
+    @Test
+    fun blankInputResetsToTheSafeDefault() {
+        val result = AssistantNamePolicy.validate(" \u2003 ")
+
+        assertNull(result.normalized)
+        assertNull(result.errorMessage)
+        assertEquals("Hermes", DEFAULT_ASSISTANT_NAME)
+    }
+
+    @Test
+    fun trimsUnicodeWhitespaceButPreservesCasingAndEmoji() {
+        val result = AssistantNamePolicy.validate("\u2003 jUnO 🌙 \u2003")
+
+        assertEquals("jUnO 🌙", result.normalized)
+        assertNull(result.errorMessage)
+    }
+
+    @Test
+    fun rejectsControlsAndUnicodeLineSeparatorsWithoutTruncating() {
+        listOf("Juno\n", "Juno\u0000", "Juno\u2028", "Juno\u2029").forEach { input ->
+            val result = AssistantNamePolicy.validate(input)
+            assertNull(result.normalized)
+            assertTrue(result.errorMessage?.isNotBlank() == true)
+        }
+    }
+
+    @Test
+    fun limitsUnicodeCodePointsRatherThanUtf16Units() {
+        val valid = AssistantNamePolicy.validate("🌙".repeat(40))
+        val invalid = AssistantNamePolicy.validate("🌙".repeat(41))
+
+        assertEquals(40, valid.normalized?.codePointCount(0, valid.normalized!!.length))
+        assertNull(invalid.normalized)
+        assertTrue(invalid.errorMessage?.contains("40") == true)
+    }
+
+    @Test
+    fun canonicalKeyNormalizesOriginPathAndProfile() {
+        assertEquals(
+            AssistantNameKey(origin = "https://gateway.example/hermes", profile = "default"),
+            AssistantNameKey.from(" HTTPS://Gateway.Example/hermes/ ", " "),
+        )
+        assertEquals(
+            AssistantNameKey(origin = "https://gateway.example/other", profile = "work"),
+            AssistantNameKey.from("https://gateway.example/other", " work "),
+        )
+    }
+
+    @Test
+    fun invalidGatewayContextDoesNotProduceAStoreKey() {
+        assertNull(AssistantNameKey.from("not a dashboard", "default"))
+        assertNull(AssistantNameKey.from(null, "default"))
+        assertFalse(AssistantNameKey.from("https://gateway.example", null) != null)
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNameStoreTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNameStoreTest.kt
@@ -1,0 +1,62 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
+import org.junit.Test
+
+class AssistantNameStoreTest {
+    @Test
+    fun missingAndResetEntriesUseTheHermesFallback() = runTest {
+        val store = InMemoryAssistantNameStore()
+        val origin = "https://gateway.example/hermes"
+
+        assertNull(store.read(origin, "default"))
+        store.write(origin, "default", "Juno")
+        assertEquals("Juno", store.read(origin, "default"))
+        store.write(origin, "default", null)
+        assertNull(store.read(origin, "default"))
+    }
+
+    @Test
+    fun entriesIsolateOriginsPathPrefixesAndProfilesAcrossStoreInstances() = runTest {
+        val backing = linkedMapOf<AssistantNameKey, String>()
+        val first = InMemoryAssistantNameStore(backing)
+        first.write("https://gateway.example/hermes", "default", "Juno")
+        first.write("https://gateway.example/hermes", "work", "Nova")
+        first.write("https://gateway.example/other", "default", "Atlas")
+
+        val recreated = InMemoryAssistantNameStore(backing)
+        assertEquals("Juno", recreated.read("https://gateway.example/hermes/", "default"))
+        assertEquals("Nova", recreated.read("https://gateway.example/hermes", "work"))
+        assertEquals("Atlas", recreated.read("https://gateway.example/other", "default"))
+
+        recreated.clearOrigin("https://gateway.example/hermes/")
+
+        assertNull(recreated.read("https://gateway.example/hermes", "default"))
+        assertNull(recreated.read("https://gateway.example/hermes", "work"))
+        assertEquals("Atlas", recreated.read("https://gateway.example/other", "default"))
+    }
+
+    @Test
+    fun invalidWritesAreRejectedAndNeverSilentlyTruncated() = runTest {
+        val store = InMemoryAssistantNameStore()
+
+        try {
+            store.write("https://gateway.example", "default", "Juno\n")
+            fail("Expected control characters to be rejected")
+        } catch (_: IllegalArgumentException) {
+            // Expected.
+        }
+        try {
+            store.write("https://gateway.example", "default", "🌙".repeat(41))
+            fail("Expected overlong names to be rejected")
+        } catch (_: IllegalArgumentException) {
+            // Expected.
+        }
+        assertNull(store.read("https://gateway.example", "default"))
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNameStoreTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNameStoreTest.kt
@@ -6,8 +6,10 @@ import dev.hazydreams.hermesceleste.presentation.ASSISTANT_NAME_STORE_VERSION
 import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostic
 import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostics
 import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.AssistantNameRecordStorage
 import dev.hazydreams.hermesceleste.presentation.AssistantNameRecord
 import dev.hazydreams.hermesceleste.presentation.AssistantNameRecordCommitter
+import dev.hazydreams.hermesceleste.presentation.AndroidAssistantNameStore
 import dev.hazydreams.hermesceleste.presentation.commitAssistantNameRecords
 import dev.hazydreams.hermesceleste.presentation.decodeAssistantNameRecords
 import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
@@ -69,6 +71,44 @@ class AssistantNameStoreTest {
             // Expected.
         }
         assertNull(store.read("https://gateway.example", "default"))
+    }
+
+    @Test
+    fun androidStorePersistsAcrossRecreatedInstancesAndClearsOnlyOneOrigin() = runTest {
+        val storage = FakeAssistantNameRecordStorage()
+        val first = AndroidAssistantNameStore(storage)
+        first.write("https://gateway.example/hermes", "default", "Juno")
+        first.write("https://gateway.example/other", "default", "Atlas")
+
+        val recreated = AndroidAssistantNameStore(storage)
+        assertEquals("Juno", recreated.read("https://gateway.example/hermes/", "default"))
+        assertEquals("Atlas", recreated.read("https://gateway.example/other", "default"))
+
+        recreated.clearOrigin("https://gateway.example/hermes")
+
+        assertNull(recreated.read("https://gateway.example/hermes", "default"))
+        assertEquals("Atlas", AndroidAssistantNameStore(storage).read("https://gateway.example/other", "default"))
+    }
+
+    @Test
+    fun androidStoreSurfacesStorageFailuresWithoutReplacingTheLastCommittedPayload() = runTest {
+        val storage = FakeAssistantNameRecordStorage()
+        val store = AndroidAssistantNameStore(storage)
+        store.write("https://gateway.example", "default", "Juno")
+
+        storage.failCommit = true
+        val writeFailure = runCatching {
+            store.write("https://gateway.example", "default", "Nova")
+        }.exceptionOrNull()
+
+        assertTrue(writeFailure is IOException)
+        assertEquals("Juno", AndroidAssistantNameStore(storage).read("https://gateway.example", "default"))
+
+        storage.failRead = true
+        val readFailure = runCatching {
+            store.read("https://gateway.example", "default")
+        }.exceptionOrNull()
+        assertTrue(readFailure is IOException)
     }
 
     @Test
@@ -145,5 +185,22 @@ class AssistantNameStoreTest {
         assertTrue(diagnostics.contains(AssistantNameDiagnostic.MalformedPayload))
         assertTrue(diagnostics.none { it.code.contains("Juno") })
         assertTrue(diagnostics.none { it.code.contains("private") })
+    }
+
+    private class FakeAssistantNameRecordStorage : AssistantNameRecordStorage {
+        var persistedRecords: String? = null
+        var failRead = false
+        var failCommit = false
+
+        override fun readRecords(): String? {
+            if (failRead) throw IOException("synthetic record read failure")
+            return persistedRecords
+        }
+
+        override fun commitRecords(encoded: String?): Boolean {
+            if (failCommit) return false
+            persistedRecords = encoded
+            return true
+        }
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNameStoreTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/AssistantNameStoreTest.kt
@@ -1,10 +1,21 @@
 package dev.hazydreams.hermesceleste
 
+import java.io.IOException
+
+import dev.hazydreams.hermesceleste.presentation.ASSISTANT_NAME_STORE_VERSION
+import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostic
+import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostics
 import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.AssistantNameRecord
+import dev.hazydreams.hermesceleste.presentation.AssistantNameRecordCommitter
+import dev.hazydreams.hermesceleste.presentation.commitAssistantNameRecords
+import dev.hazydreams.hermesceleste.presentation.decodeAssistantNameRecords
 import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 
@@ -58,5 +69,81 @@ class AssistantNameStoreTest {
             // Expected.
         }
         assertNull(store.read("https://gateway.example", "default"))
+    }
+
+    @Test
+    fun failedAtomicCommitKeepsTheLastCommittedPayloadAndRetryReplacesItAsAWhole() {
+        val oldPayload = "[old-record]"
+        var persistedPayload: String? = oldPayload
+        var failCommit = true
+        val committer = AssistantNameRecordCommitter { encoded ->
+            if (failCommit) {
+                false
+            } else {
+                persistedPayload = encoded
+                true
+            }
+        }
+        val records = listOf(
+            AssistantNameRecord(
+                version = ASSISTANT_NAME_STORE_VERSION,
+                origin = "https://gateway.example",
+                profile = "default",
+                name = "Nova",
+            ),
+        )
+
+        val failure = runCatching {
+            commitAssistantNameRecords(
+                records = records,
+                json = Json { ignoreUnknownKeys = false },
+                committer = committer,
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is IOException)
+        assertEquals(oldPayload, persistedPayload)
+
+        failCommit = false
+        commitAssistantNameRecords(
+            records = records,
+            json = Json { ignoreUnknownKeys = false },
+            committer = committer,
+        )
+        val committed = decodeAssistantNameRecords(
+            encoded = requireNotNull(persistedPayload),
+            json = Json { ignoreUnknownKeys = false },
+            diagnostics = AssistantNameDiagnostics { },
+        )
+        assertEquals(listOf("Nova"), committed.map { it.name })
+    }
+
+    @Test
+    fun malformedAndUnsupportedRecordsUseHermesAndEmitRedactedDiagnostics() {
+        val diagnostics = mutableListOf<AssistantNameDiagnostic>()
+        val decoded = decodeAssistantNameRecords(
+            encoded = """
+                [
+                  {"version":$ASSISTANT_NAME_STORE_VERSION,"origin":"https://gateway.example","profile":"default","name":"Juno"},
+                  {"version":99,"origin":"https://gateway.example","profile":"work","name":"Nova"},
+                  {"version":$ASSISTANT_NAME_STORE_VERSION,"origin":"https://gateway.example","profile":"default"}
+                ]
+            """.trimIndent(),
+            json = Json { ignoreUnknownKeys = false },
+            diagnostics = AssistantNameDiagnostics { diagnostic -> diagnostics += diagnostic },
+        )
+        decodeAssistantNameRecords(
+            encoded = "not-json /private/Juno",
+            json = Json { ignoreUnknownKeys = false },
+            diagnostics = AssistantNameDiagnostics { diagnostic -> diagnostics += diagnostic },
+        )
+
+        assertEquals(1, decoded.size)
+        assertEquals("Juno", decoded.single().name)
+        assertTrue(diagnostics.contains(AssistantNameDiagnostic.UnsupportedVersion))
+        assertTrue(diagnostics.contains(AssistantNameDiagnostic.MalformedRecord))
+        assertTrue(diagnostics.contains(AssistantNameDiagnostic.MalformedPayload))
+        assertTrue(diagnostics.none { it.code.contains("Juno") })
+        assertTrue(diagnostics.none { it.code.contains("private") })
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
@@ -18,6 +18,8 @@ import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.TransportUnavailable
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -72,6 +74,51 @@ class CelesteViewModelAutoLoginTest {
         assertEquals(listOf("stored-1"), state.sessions?.map { it.id })
         assertNull(state.activeSummary)
         assertEquals(1, dashboard.probeCalls)
+    }
+
+    @Test
+    fun recreatedViewModelRestoresPersistedConnectionAndAssistantNameAtStartup() = runTest {
+        val connectionStore = InMemoryConnectionStore()
+        val assistantNameStore = InMemoryAssistantNameStore()
+        val firstDashboard = AutoLoginDashboard(openProbe)
+        val firstViewModel = CelesteViewModel(
+            dashboard = firstDashboard,
+            connectionStore = connectionStore,
+            assistantNameStore = assistantNameStore,
+        )
+        advanceUntilIdle()
+
+        firstViewModel.updateDashboardUrl("https://hermes.example.net")
+        firstViewModel.findDashboard()
+        advanceUntilIdle()
+        firstViewModel.loadSessions()
+        advanceUntilIdle()
+        firstViewModel.openAssistantNameEditor()
+        firstViewModel.updateAssistantNameDraft("Juno")
+        firstViewModel.saveAssistantName()
+        advanceUntilIdle()
+
+        assertEquals("https://hermes.example.net", connectionStore.load()?.descriptor?.baseUrl)
+        assertEquals("Juno", assistantNameStore.read("https://hermes.example.net", "default"))
+
+        val recreatedDashboard = AutoLoginDashboard(openProbe)
+        val recreatedViewModel = CelesteViewModel(
+            dashboard = recreatedDashboard,
+            connectionStore = connectionStore,
+            assistantNameStore = assistantNameStore,
+        )
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.Connected, recreatedViewModel.state.value.connectionPhase)
+        assertEquals("https://hermes.example.net", recreatedViewModel.state.value.dashboardUrl)
+        assertEquals("Juno", recreatedViewModel.state.value.assistantDisplayName)
+        assertEquals(
+            AssistantNameKey("https://hermes.example.net", "default"),
+            recreatedViewModel.state.value.assistantNameKey,
+        )
+        assertEquals(listOf("stored-1"), recreatedViewModel.state.value.sessions?.map { it.id })
+        assertNull(recreatedViewModel.state.value.activeSummary)
+        assertEquals(1, recreatedDashboard.probeCalls)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -15,12 +15,15 @@ import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostic
+import dev.hazydreams.hermesceleste.presentation.AssistantNameDiagnostics
 import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
 import dev.hazydreams.hermesceleste.presentation.AssistantNameStore
 import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -30,6 +33,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -368,6 +372,13 @@ class CelesteViewModelTest {
             "Couldn’t save assistant name on this device. Try again.",
             viewModel.state.value.assistantNameEditor.errorMessage,
         )
+        assertTrue(viewModel.state.value.assistantNameEditor.canSave)
+        assistantNames.failWrites = false
+        viewModel.saveAssistantName()
+        advanceUntilIdle()
+        assertEquals("Nova", viewModel.state.value.assistantDisplayName)
+        assertFalse(viewModel.state.value.assistantNameEditor.isOpen)
+        assertEquals("Nova", assistantNames.read("http://hermes.test:9119", "default"))
         viewModel.leaveConversation()
     }
 
@@ -375,7 +386,7 @@ class CelesteViewModelTest {
     fun signOutRetainsAliasesButForgetClearsOnlyTheCurrentOrigin() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
-        val assistantNames = InMemoryAssistantNameStore()
+        val assistantNames = ClearFailingAssistantNameStore()
         assistantNames.write("http://hermes.test:9119", "default", "Juno")
         assistantNames.write("https://other.example", "default", "Atlas")
         val viewModel = CelesteViewModel(
@@ -392,11 +403,153 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals("Juno", assistantNames.read("http://hermes.test:9119", "default"))
+        assistantNames.failClears = true
+        viewModel.forgetConnection()
+        advanceUntilIdle()
+
+        assertEquals(
+            "Celeste could not remove the local assistant name. Try again.",
+            viewModel.state.value.errorMessage,
+        )
+        assertEquals("Juno", assistantNames.read("http://hermes.test:9119", "default"))
+
+        assistantNames.failClears = false
         viewModel.forgetConnection()
         advanceUntilIdle()
 
         assertNull(assistantNames.read("http://hermes.test:9119", "default"))
         assertEquals("Atlas", assistantNames.read("https://other.example", "default"))
+    }
+
+    @Test
+    fun sameKeySavedReconnectKeepsAliasWhileTheLocalReadIsPending() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = BlockingAssistantNameStore("Juno")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+
+        assistantNames.blockNextRead()
+        viewModel.retrySavedConnection()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+
+        assistantNames.releaseRead()
+        advanceUntilIdle()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+    }
+
+    @Test
+    fun originSwitchLoadsOnlyTheNewOriginAlias() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write("http://hermes.test:9119", "default", "Juno")
+        assistantNames.write("https://other.example", "default", "Atlas")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+
+        viewModel.updateDashboardUrl("https://other.example")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals("Atlas", viewModel.state.value.assistantDisplayName)
+        assertEquals("https://other.example", viewModel.state.value.assistantNameKey?.origin)
+    }
+
+    @Test
+    fun removedProfileFallsBackToItsOwnAliasInsteadOfRetargetingTheRemovedProfile() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write("http://hermes.test:9119", "default", "Juno")
+        assistantNames.write("http://hermes.test:9119", "work", "Nova")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.selectProfile("work")
+        advanceUntilIdle()
+        assertEquals("Nova", viewModel.state.value.assistantDisplayName)
+
+        dashboard.profiles = listOf(DashboardProfile(name = "default", isDefault = true))
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals("default", viewModel.state.value.selectedProfile)
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+    }
+
+    @Test
+    fun blankAssistantNameClearsTheOverrideAndReturnsToHermes() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write("http://hermes.test:9119", "default", "Juno")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.openAssistantNameEditor()
+        viewModel.updateAssistantNameDraft("   ")
+        viewModel.saveAssistantName()
+        advanceUntilIdle()
+
+        assertEquals("Hermes", viewModel.state.value.assistantDisplayName)
+        assertNull(assistantNames.read("http://hermes.test:9119", "default"))
+    }
+
+    @Test
+    fun localReadFailureFallsBackAndEmitsOnlyAStableRedactedDiagnostic() = runTest {
+        val diagnostics = RecordingAssistantNameDiagnostics()
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = ReadFailingAssistantNameStore("/private/Juno/records"),
+            assistantNameDiagnostics = diagnostics,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals("Hermes", viewModel.state.value.assistantDisplayName)
+        assertEquals(listOf(AssistantNameDiagnostic.ReadFailure), diagnostics.events)
+        assertFalse(diagnostics.events.joinToString().contains("Juno"))
+        assertFalse(diagnostics.events.joinToString().contains("/private"))
     }
 
     private suspend fun openConversation(gateway: FakeGateway): CelesteViewModel {
@@ -419,7 +572,9 @@ class CelesteViewModelTest {
         private val release = CompletableDeferred<Unit>()
 
         override suspend fun read(origin: String, profile: String): String? {
-            if (profile == blockedProfile) release.await()
+            if (profile == blockedProfile) {
+                withContext(NonCancellable) { release.await() }
+            }
             return values[profile]
         }
 
@@ -432,13 +587,82 @@ class CelesteViewModelTest {
         }
     }
 
-    private class FailingAssistantNameStore(
+    private class BlockingAssistantNameStore(
         private val value: String,
     ) : AssistantNameStore {
-        override suspend fun read(origin: String, profile: String): String? = value
+        private var blockReads = false
+        private var release = CompletableDeferred<Unit>()
+
+        override suspend fun read(origin: String, profile: String): String? {
+            if (blockReads) {
+                blockReads = false
+                withContext(NonCancellable) { release.await() }
+            }
+            return value
+        }
+
+        override suspend fun write(origin: String, profile: String, name: String?) = Unit
+
+        override suspend fun clearOrigin(origin: String) = Unit
+
+        fun blockNextRead() {
+            release = CompletableDeferred()
+            blockReads = true
+        }
+
+        fun releaseRead() {
+            release.complete(Unit)
+        }
+    }
+
+    private class ReadFailingAssistantNameStore(
+        private val message: String,
+    ) : AssistantNameStore {
+        override suspend fun read(origin: String, profile: String): String? {
+            throw IOException(message)
+        }
+
+        override suspend fun write(origin: String, profile: String, name: String?) = Unit
+
+        override suspend fun clearOrigin(origin: String) = Unit
+    }
+
+    private class RecordingAssistantNameDiagnostics : AssistantNameDiagnostics {
+        val events = mutableListOf<AssistantNameDiagnostic>()
+
+        override fun record(diagnostic: AssistantNameDiagnostic) {
+            events += diagnostic
+        }
+    }
+
+    private class ClearFailingAssistantNameStore : AssistantNameStore {
+        private val delegate = InMemoryAssistantNameStore()
+        var failClears = false
+
+        override suspend fun read(origin: String, profile: String): String? =
+            delegate.read(origin, profile)
 
         override suspend fun write(origin: String, profile: String, name: String?) {
-            throw IOException("synthetic local write failure")
+            delegate.write(origin, profile, name)
+        }
+
+        override suspend fun clearOrigin(origin: String) {
+            if (failClears) throw IOException("synthetic local cleanup failure")
+            delegate.clearOrigin(origin)
+        }
+    }
+
+    private class FailingAssistantNameStore(
+        initialValue: String,
+    ) : AssistantNameStore {
+        private var storedValue: String? = initialValue
+        var failWrites = true
+
+        override suspend fun read(origin: String, profile: String): String? = storedValue
+
+        override suspend fun write(origin: String, profile: String, name: String?) {
+            if (failWrites) throw IOException("synthetic local write failure")
+            storedValue = name
         }
 
         override suspend fun clearOrigin(origin: String) = Unit
@@ -449,6 +673,10 @@ class CelesteViewModelTest {
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
+        var profiles: List<DashboardProfile> = listOf(
+            DashboardProfile(name = "default", isDefault = true),
+            DashboardProfile(name = "work"),
+        )
 
         val session = StoredSession(
             id = "stored-42",
@@ -489,10 +717,7 @@ class CelesteViewModelTest {
             credential: GatewayCredential,
         ): List<DashboardProfile> {
             profileFailure?.let { throw it }
-            return listOf(
-                DashboardProfile(name = "default", isDefault = true),
-                DashboardProfile(name = "work"),
-            )
+            return profiles
         }
 
         override fun exportAuthentication(baseUrl: String): AuthenticationMaterial? =

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -414,11 +414,61 @@ class CelesteViewModelTest {
         assertEquals("Juno", assistantNames.read("http://hermes.test:9119", "default"))
 
         assistantNames.failClears = false
-        viewModel.forgetConnection()
+        viewModel.retryAssistantNameCleanup()
         advanceUntilIdle()
 
         assertNull(assistantNames.read("http://hermes.test:9119", "default"))
         assertEquals("Atlas", assistantNames.read("https://other.example", "default"))
+    }
+
+    @Test
+    fun failedForgetCleanupStaysScopedAcrossOriginSwitchAndExposesRetry() = runTest {
+        val firstOrigin = "http://hermes.test:9119"
+        val secondOrigin = "https://other.example"
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = ClearFailingAssistantNameStore()
+        assistantNames.write(firstOrigin, "default", "Juno")
+        assistantNames.write(secondOrigin, "default", "Atlas")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl(firstOrigin)
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assistantNames.failingOrigin = firstOrigin
+        viewModel.forgetConnection()
+        advanceUntilIdle()
+
+        assertEquals(firstOrigin, viewModel.state.value.assistantNameCleanupRetryOrigin)
+        assertEquals("Juno", assistantNames.read(firstOrigin, "default"))
+        assertEquals("Atlas", assistantNames.read(secondOrigin, "default"))
+
+        assistantNames.failingOrigin = null
+        viewModel.updateDashboardUrl(secondOrigin)
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        assertEquals(secondOrigin, viewModel.state.value.assistantNameKey?.origin)
+        assertEquals("Atlas", viewModel.state.value.assistantDisplayName)
+
+        viewModel.forgetConnection()
+        advanceUntilIdle()
+
+        assertNull(assistantNames.read(secondOrigin, "default"))
+        assertEquals("Juno", assistantNames.read(firstOrigin, "default"))
+        assertEquals(firstOrigin, viewModel.state.value.assistantNameCleanupRetryOrigin)
+
+        viewModel.retryAssistantNameCleanup()
+        advanceUntilIdle()
+
+        assertNull(assistantNames.read(firstOrigin, "default"))
+        assertNull(viewModel.state.value.assistantNameCleanupRetryOrigin)
     }
 
     @Test
@@ -638,6 +688,7 @@ class CelesteViewModelTest {
     private class ClearFailingAssistantNameStore : AssistantNameStore {
         private val delegate = InMemoryAssistantNameStore()
         var failClears = false
+        var failingOrigin: String? = null
 
         override suspend fun read(origin: String, profile: String): String? =
             delegate.read(origin, profile)
@@ -647,7 +698,7 @@ class CelesteViewModelTest {
         }
 
         override suspend fun clearOrigin(origin: String) {
-            if (failClears) throw IOException("synthetic local cleanup failure")
+            if (failClears || origin == failingOrigin) throw IOException("synthetic local cleanup failure")
             delegate.clearOrigin(origin)
         }
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -15,6 +15,10 @@ import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.presentation.AssistantNameKey
+import dev.hazydreams.hermesceleste.presentation.AssistantNameStore
+import dev.hazydreams.hermesceleste.presentation.InMemoryAssistantNameStore
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -231,6 +235,7 @@ class CelesteViewModelTest {
         val createParams = gateway.requests.first { it.first == "session.create" }.second
         assertEquals("work", createParams["profile"]?.jsonPrimitive?.content)
         assertEquals("android", createParams["source"]?.jsonPrimitive?.content)
+        assertFalse(createParams.containsKey("assistant_name"))
 
         gateway.disconnect("blank session socket died")
         advanceUntilIdle()
@@ -254,6 +259,8 @@ class CelesteViewModelTest {
         assertEquals(2, gateway.methods.count { it == "session.create" })
         assertEquals(1, gateway.methods.count { it == "session.resume" })
         assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        val resumeParams = gateway.requests.last { it.first == "session.resume" }.second
+        assertFalse(resumeParams.containsKey("assistant_name"))
         viewModel.leaveConversation()
     }
 
@@ -267,6 +274,131 @@ class CelesteViewModelTest {
         assertEquals("and still arriving", suffix)
     }
 
+    @Test
+    fun assistantNameLoadsForTheActiveProfileAndSavesWithoutGatewayMutation() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write("http://hermes.test:9119", "default", "Juno")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+        assertEquals(
+            AssistantNameKey("http://hermes.test:9119", "default"),
+            viewModel.state.value.assistantNameKey,
+        )
+        val gatewayMethodsBeforeSave = gateway.methods.toList()
+
+        viewModel.openAssistantNameEditor()
+        viewModel.updateAssistantNameDraft("Nova")
+        viewModel.saveAssistantName()
+        advanceUntilIdle()
+
+        assertEquals("Nova", viewModel.state.value.assistantDisplayName)
+        assertFalse(viewModel.state.value.assistantNameEditor.isOpen)
+        assertEquals(gatewayMethodsBeforeSave, gateway.methods)
+        assertEquals("Nova", assistantNames.read("http://hermes.test:9119", "default"))
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun profileSwitchPublishesHermesAndRejectsAStaleRead() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = DelayedAssistantNameStore(
+            values = mapOf("default" to "Juno", "work" to "Nova"),
+            blockedProfile = "work",
+        )
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+
+        viewModel.selectProfile("work")
+        assertEquals("Hermes", viewModel.state.value.assistantDisplayName)
+        viewModel.selectProfile("default")
+        advanceUntilIdle()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+
+        assistantNames.releaseBlockedRead()
+        advanceUntilIdle()
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun failedAssistantNameSaveRetainsTheEffectiveValueAndAllowsRetry() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = FailingAssistantNameStore("Juno")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.openAssistantNameEditor()
+        viewModel.updateAssistantNameDraft("Nova")
+        viewModel.saveAssistantName()
+        advanceUntilIdle()
+
+        assertEquals("Juno", viewModel.state.value.assistantDisplayName)
+        assertTrue(viewModel.state.value.assistantNameEditor.isOpen)
+        assertEquals(
+            "Couldn’t save assistant name on this device. Try again.",
+            viewModel.state.value.assistantNameEditor.errorMessage,
+        )
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun signOutRetainsAliasesButForgetClearsOnlyTheCurrentOrigin() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write("http://hermes.test:9119", "default", "Juno")
+        assistantNames.write("https://other.example", "default", "Atlas")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.signOut()
+        advanceUntilIdle()
+
+        assertEquals("Juno", assistantNames.read("http://hermes.test:9119", "default"))
+        viewModel.forgetConnection()
+        advanceUntilIdle()
+
+        assertNull(assistantNames.read("http://hermes.test:9119", "default"))
+        assertEquals("Atlas", assistantNames.read("https://other.example", "default"))
+    }
+
     private suspend fun openConversation(gateway: FakeGateway): CelesteViewModel {
         val dashboard = FakeDashboard(gateway)
         val viewModel = CelesteViewModel(
@@ -278,6 +410,38 @@ class CelesteViewModelTest {
         viewModel.loadSessions()
         viewModel.openSession(dashboard.session)
         return viewModel
+    }
+
+    private class DelayedAssistantNameStore(
+        private val values: Map<String, String>,
+        private val blockedProfile: String,
+    ) : AssistantNameStore {
+        private val release = CompletableDeferred<Unit>()
+
+        override suspend fun read(origin: String, profile: String): String? {
+            if (profile == blockedProfile) release.await()
+            return values[profile]
+        }
+
+        override suspend fun write(origin: String, profile: String, name: String?) = Unit
+
+        override suspend fun clearOrigin(origin: String) = Unit
+
+        fun releaseBlockedRead() {
+            release.complete(Unit)
+        }
+    }
+
+    private class FailingAssistantNameStore(
+        private val value: String,
+    ) : AssistantNameStore {
+        override suspend fun read(origin: String, profile: String): String? = value
+
+        override suspend fun write(origin: String, profile: String, name: String?) {
+            throw IOException("synthetic local write failure")
+        }
+
+        override suspend fun clearOrigin(origin: String) = Unit
     }
 
     private class FakeDashboard(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -2,7 +2,11 @@ package dev.hazydreams.hermesceleste
 
 import java.io.IOException
 
+import dev.hazydreams.hermesceleste.connection.ConnectionStore
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
+import dev.hazydreams.hermesceleste.connection.ReusableSecret
+import dev.hazydreams.hermesceleste.connection.SavedConnectionDescriptor
+import dev.hazydreams.hermesceleste.connection.StoredConnection
 import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.AuthProvider
@@ -31,6 +35,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
@@ -383,6 +388,41 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun foregroundReloadDoesNotCancelAnInFlightAssistantNameSave() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val assistantNames = BlockingWriteAssistantNameStore("Juno")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.openAssistantNameEditor()
+        viewModel.updateAssistantNameDraft("Nova")
+
+        assistantNames.blockNextWrite()
+        viewModel.saveAssistantName()
+        runCurrent()
+        assertTrue(viewModel.state.value.assistantNameEditor.isSaving)
+
+        viewModel.onForeground()
+        runCurrent()
+        assertTrue(viewModel.state.value.assistantNameEditor.isSaving)
+
+        assistantNames.releaseWrite()
+        advanceUntilIdle()
+
+        assertEquals("Nova", viewModel.state.value.assistantDisplayName)
+        assertFalse(viewModel.state.value.assistantNameEditor.isOpen)
+        assertEquals("Nova", assistantNames.read("http://hermes.test:9119", "default"))
+    }
+
+    @Test
     fun signOutRetainsAliasesButForgetClearsOnlyTheCurrentOrigin() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
@@ -469,6 +509,45 @@ class CelesteViewModelTest {
 
         assertNull(assistantNames.read(firstOrigin, "default"))
         assertNull(viewModel.state.value.assistantNameCleanupRetryOrigin)
+    }
+
+    @Test
+    fun connectionForgetFailureRemainsRetryableAfterLocalAliasCleanup() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val connectionStore = FailingForgetConnectionStore()
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write("http://hermes.test:9119", "default", "Juno")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            connectionStore = connectionStore,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        viewModel.forgetConnection()
+        advanceUntilIdle()
+
+        assertNull(assistantNames.read("http://hermes.test:9119", "default"))
+        assertTrue(viewModel.state.value.connectionForgetRetryPending)
+        assertEquals(
+            "Celeste could not remove the saved connection. Try again.",
+            viewModel.state.value.errorMessage,
+        )
+        assertTrue(connectionStore.load() != null)
+
+        connectionStore.failForget = false
+        viewModel.retryConnectionCleanup()
+        advanceUntilIdle()
+
+        assertNull(connectionStore.load())
+        assertFalse(viewModel.state.value.connectionForgetRetryPending)
+        assertNull(viewModel.state.value.errorMessage)
     }
 
     @Test
@@ -665,6 +744,37 @@ class CelesteViewModelTest {
         }
     }
 
+    private class BlockingWriteAssistantNameStore(
+        initialValue: String,
+    ) : AssistantNameStore {
+        private var storedValue: String? = initialValue
+        private var blockWrites = false
+        private var release = CompletableDeferred<Unit>()
+
+        override suspend fun read(origin: String, profile: String): String? = storedValue
+
+        override suspend fun write(origin: String, profile: String, name: String?) {
+            if (blockWrites) {
+                blockWrites = false
+                withContext(NonCancellable) { release.await() }
+            }
+            storedValue = name
+        }
+
+        override suspend fun clearOrigin(origin: String) {
+            storedValue = null
+        }
+
+        fun blockNextWrite() {
+            release = CompletableDeferred()
+            blockWrites = true
+        }
+
+        fun releaseWrite() {
+            release.complete(Unit)
+        }
+    }
+
     private class ReadFailingAssistantNameStore(
         private val message: String,
     ) : AssistantNameStore {
@@ -700,6 +810,29 @@ class CelesteViewModelTest {
         override suspend fun clearOrigin(origin: String) {
             if (failClears || origin == failingOrigin) throw IOException("synthetic local cleanup failure")
             delegate.clearOrigin(origin)
+        }
+    }
+
+    private class FailingForgetConnectionStore : ConnectionStore {
+        private val delegate = InMemoryConnectionStore()
+        var failForget = true
+
+        override suspend fun load(): StoredConnection? = delegate.load()
+
+        override suspend fun replace(
+            descriptor: SavedConnectionDescriptor,
+            secret: ReusableSecret?,
+        ) {
+            delegate.replace(descriptor, secret)
+        }
+
+        override suspend fun clearSecret() {
+            delegate.clearSecret()
+        }
+
+        override suspend fun forget() {
+            if (failForget) throw IOException("synthetic saved-connection cleanup failure")
+            delegate.forget()
         }
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -605,6 +605,47 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun forgetDuringPendingAddressProbeUsesTheCommittedOriginForConnectionAndAliasCleanup() = runTest {
+        val firstOrigin = "http://hermes.test:9119"
+        val secondOrigin = "https://other.example"
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val connectionStore = InMemoryConnectionStore()
+        val assistantNames = InMemoryAssistantNameStore()
+        assistantNames.write(firstOrigin, "default", "Juno")
+        assistantNames.write(secondOrigin, "default", "Atlas")
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            connectionStore = connectionStore,
+            assistantNameStore = assistantNames,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+
+        advanceUntilIdle()
+        viewModel.updateDashboardUrl(firstOrigin)
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        assertEquals(firstOrigin, connectionStore.load()?.descriptor?.baseUrl)
+
+        dashboard.blockProbe(secondOrigin)
+        viewModel.updateDashboardUrl(secondOrigin)
+        viewModel.findDashboard()
+        runCurrent()
+
+        assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
+        assertEquals(firstOrigin, connectionStore.load()?.descriptor?.baseUrl)
+
+        viewModel.forgetConnection()
+        advanceUntilIdle()
+
+        assertNull(connectionStore.load())
+        assertNull(assistantNames.read(firstOrigin, "default"))
+        assertEquals("Atlas", assistantNames.read(secondOrigin, "default"))
+    }
+
+    @Test
     fun removedProfileFallsBackToItsOwnAliasInsteadOfRetargetingTheRemovedProfile() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
@@ -857,6 +898,8 @@ class CelesteViewModelTest {
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
+        private var blockedProbeUrl: String? = null
+        private var probeRelease = CompletableDeferred<Unit>()
         var profiles: List<DashboardProfile> = listOf(
             DashboardProfile(name = "default", isDefault = true),
             DashboardProfile(name = "work"),
@@ -871,8 +914,11 @@ class CelesteViewModelTest {
             source = "desktop",
         )
 
-        override suspend fun probe(rawBaseUrl: String): DashboardProbeResult =
-            DashboardProbeResult(
+        override suspend fun probe(rawBaseUrl: String): DashboardProbeResult {
+            if (rawBaseUrl == blockedProbeUrl) {
+                probeRelease.await()
+            }
+            return DashboardProbeResult(
                 baseUrl = rawBaseUrl,
                 authRequired = authRequired,
                 providers = if (authRequired) {
@@ -882,6 +928,12 @@ class CelesteViewModelTest {
                 },
                 version = "test",
             )
+        }
+
+        fun blockProbe(url: String) {
+            blockedProbeUrl = url
+            probeRelease = CompletableDeferred()
+        }
 
         override suspend fun passwordLogin(
             baseUrl: String,


### PR DESCRIPTION
## Summary
- Adds a device-local assistant display-name alias scoped to the normalized gateway origin and selected Hermes profile.
- Adds the Settings editor, validation, persistence/lifecycle handling, and immediate use of the saved name in the assistant transcript label and assistant-specific composer copy.
- Keeps the alias local to Celeste; it does not rename a Hermes profile or change gateway/session protocol behavior.

## Branch context
This branch also carries temporary DF-01/CF-01 specs and a twenty-item backlog. This draft's feature summary is DF-01 only.

## Review and verification
- Luna spec PASS
- Luna quality APPROVED
- Local Gradle/lint/screenshot/device/APK gates NOT RUN
- Accepted assistant-name/Settings PNG updates remain owner-review pending

No merge requested.