### PR TITLE
feat: add conversation model controls

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
     debugImplementation("androidx.compose.ui:ui-tooling")
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver3")

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/RuntimeControlsComposeAccessibilityTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/RuntimeControlsComposeAccessibilityTest.kt
@@ -1,0 +1,114 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.waitForIdle
+import dev.hazydreams.hermesceleste.RuntimeControlsLifecycle
+import dev.hazydreams.hermesceleste.RuntimeControlsUiState
+import dev.hazydreams.hermesceleste.TurnState
+import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.RuntimeControlsCapabilities
+import dev.hazydreams.hermesceleste.network.RuntimeControlsSnapshot
+import dev.hazydreams.hermesceleste.network.RuntimeModelOption
+import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
+import org.junit.Rule
+import org.junit.Test
+
+class RuntimeControlsComposeAccessibilityTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun dismissingRuntimeControlsSheetRestoresFocusToThePill() {
+        val controls = mutableStateOf(testRuntimeControls)
+        mount(controls)
+
+        val pill = composeTestRule.onNodeWithTag("runtime-controls-pill")
+        pill.assert(hasContentDescription("nous / gpt-5.6-sol, Reasoning high, change settings"))
+        pill.performSemanticsAction(SemanticsActions.RequestFocus)
+        pill.assertIsFocused()
+
+        pill.performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag("runtime-controls-sheet").assertExists()
+        val cancel = composeTestRule.onNodeWithTag("runtime-controls-cancel")
+        cancel.performSemanticsAction(SemanticsActions.RequestFocus)
+        cancel.assertIsFocused()
+
+        cancel.performClick()
+        composeTestRule.waitForIdle()
+        pill.assertIsFocused()
+    }
+
+    private fun mount(controls: MutableState<RuntimeControlsUiState>) {
+        composeTestRule.setContent {
+            HermesCelesteTheme {
+                ConversationScreen(
+                    summary = testSession,
+                    messages = emptyList<ConversationMessage>(),
+                    streamingText = "",
+                    draft = "",
+                    turnState = TurnState.Idle,
+                    runtimeControls = controls.value,
+                    loadingMessage = null,
+                    errorMessage = null,
+                    onDraftChange = {},
+                    onSend = {},
+                    onInterrupt = {},
+                    onReconnect = {},
+                    onRuntimeControlsOpen = {
+                        controls.value = controls.value.copy(pickerOpen = true)
+                    },
+                    onRuntimeModelSelected = { _, _ -> },
+                    onRuntimeReasoningSelected = {},
+                    onRuntimeControlsApply = {},
+                    onRuntimeControlsCancel = {
+                        controls.value = controls.value.copy(pickerOpen = false)
+                    },
+                    onBack = {},
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+
+    private companion object {
+        val testSession = StoredSession(
+            id = "ui-test-session",
+            title = "UI test conversation",
+            preview = "",
+            startedAt = 0.0,
+            messageCount = 0,
+            source = "android",
+            profile = "default",
+        )
+        val testRuntimeControls = RuntimeControlsUiState(
+            lifecycle = RuntimeControlsLifecycle.Available,
+            snapshot = RuntimeControlsSnapshot(
+                origin = "https://hermes.example",
+                profile = "default",
+                storedSessionId = "ui-test-session",
+                runtimeSessionId = "runtime-session",
+                provider = "nous",
+                model = "gpt-5.6-sol",
+                reasoningEffort = "high",
+                capabilities = RuntimeControlsCapabilities(
+                    available = true,
+                    modelOptions = listOf(
+                        RuntimeModelOption(provider = "nous", model = "gpt-5.6-sol"),
+                    ),
+                    reasoningEfforts = listOf("high"),
+                ),
+            ),
+        )
+    }
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -68,7 +68,7 @@ internal enum class RuntimeControlsOperation {
     Idle,
     Applying,
     Queued,
-    Checking,
+    Unknown,
 }
 
 internal enum class RuntimeControlsLifecycle {
@@ -87,6 +87,14 @@ internal data class RuntimeControlsUiState(
     val message: String? = null,
     val canApply: Boolean = false,
 ) {
+    val operationAnnouncement: String?
+        get() = when (operation) {
+            RuntimeControlsOperation.Idle -> null
+            RuntimeControlsOperation.Applying -> "Applying"
+            RuntimeControlsOperation.Queued -> "Queued for next response"
+            RuntimeControlsOperation.Unknown -> "Unknown result; reconnect to verify"
+        }
+
     val modelLabel: String
         get() {
             val provider = snapshot?.provider?.takeIf(String::isNotBlank)
@@ -107,6 +115,11 @@ internal data class RuntimeControlsUiState(
     val accessibilityLabel: String
         get() = "$modelLabel, $reasoningLabel, change settings"
 }
+
+internal fun shouldRestoreRuntimeControlsFocus(
+    wasPickerOpen: Boolean,
+    pickerOpen: Boolean,
+): Boolean = wasPickerOpen && !pickerOpen
 
 private data class PendingRuntimeApply(
     val origin: String,
@@ -440,7 +453,7 @@ internal class CelesteViewModel(
         if (draft.model == snapshot.model && draft.provider == snapshot.provider && !reasoningChanged) {
             return false
         }
-        return turnState != TurnState.Running || snapshot.capabilities.canApplyWhileRunning
+        return turnState != TurnState.Running || snapshot.capabilities.canApplyWhileRunning == true
     }
 
     private fun draftMatchesSnapshot(
@@ -518,6 +531,18 @@ internal class CelesteViewModel(
         snapshot.model == pending.target.model && snapshot.provider == pending.target.provider
         )) && (!pending.reasoningChanged || snapshot.reasoningEffort == pending.target.reasoningEffort)
 
+    private fun shouldRetainPendingEffectiveState(
+        info: RuntimeControlsInfo,
+        pending: PendingRuntimeApply,
+    ): Boolean {
+        if (!pending.modelChanged) return false
+        if (info.pendingModelSwitch == true) return true
+        if (info.pendingModelSwitch == false) return false
+        return info.running == true &&
+            info.model == pending.target.model &&
+            (info.provider == null || info.provider == pending.target.provider)
+    }
+
     private fun handleRuntimeControlsAcknowledgement(
         activeGateway: GatewayConnection,
         pending: PendingRuntimeApply,
@@ -533,11 +558,13 @@ internal class CelesteViewModel(
         }
         val current = mutableState.value
         val controls = current.runtimeControls
-        val updated = acknowledgement.authoritativeInfo?.let { info ->
-            controls.snapshot?.let { expected ->
-                applyRuntimeControlsInfo(info, RuntimeControlsSource.ApplyAcknowledgement, expected)
+        val updated = acknowledgement.authoritativeInfo
+            ?.takeUnless { acknowledgement.deferred }
+            ?.let { info ->
+                controls.snapshot?.let { expected ->
+                    applyRuntimeControlsInfo(info, RuntimeControlsSource.ApplyAcknowledgement, expected)
+                }
             }
-        }
         val withAcknowledgement = if (updated != null) controls.copy(snapshot = updated) else controls
         val confirmed = withAcknowledgement.snapshot?.let { authoritativeRuntimeControlsMatch(it, pending) } == true
         mutableState.value = current.copy(
@@ -566,8 +593,8 @@ internal class CelesteViewModel(
             if (reconciled.isFailure && gateway === activeGateway) {
                 mutableState.value = mutableState.value.copy(
                     runtimeControls = mutableState.value.runtimeControls.copy(
-                        operation = RuntimeControlsOperation.Checking,
-                        message = "Checking the current Hermes setting…",
+                        operation = RuntimeControlsOperation.Unknown,
+                        message = "Could not confirm that change. Reconnect to verify.",
                         canApply = false,
                     ),
                 )
@@ -632,8 +659,8 @@ internal class CelesteViewModel(
         pendingRuntimeApply = pending
         mutableState.value = mutableState.value.copy(
             runtimeControls = mutableState.value.runtimeControls.copy(
-                operation = RuntimeControlsOperation.Checking,
-                message = "Checking the current Hermes setting…",
+                operation = RuntimeControlsOperation.Unknown,
+                message = "Could not confirm that change. Reconnect to verify.",
                 canApply = false,
             ),
         )
@@ -684,10 +711,10 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             runtimeControls = controls.copy(
                 lifecycle = RuntimeControlsLifecycle.Reconnecting,
-                operation = if (controls.operation == RuntimeControlsOperation.Applying) {
-                    RuntimeControlsOperation.Checking
-                } else {
-                    controls.operation
+                operation = when (controls.operation) {
+                    RuntimeControlsOperation.Applying,
+                    RuntimeControlsOperation.Queued -> RuntimeControlsOperation.Unknown
+                    else -> controls.operation
                 },
                 message = message ?: controls.message ?: "Reconnecting to Hermes…",
                 canApply = false,
@@ -1443,19 +1470,30 @@ internal class CelesteViewModel(
             previousSnapshot.profile == profile &&
             previousSnapshot.storedSessionId == storedSessionId
         val info = resumed.runtimeControls
+        val pendingForSnapshot = pendingRuntimeApply?.takeIf {
+            it.origin == origin &&
+                it.profile == profile &&
+                it.storedSessionId == storedSessionId
+        }
+        val retainPendingEffectiveState = pendingForSnapshot?.let {
+            shouldRetainPendingEffectiveState(info, it)
+        } == true
+        val retainedSnapshot = previousSnapshot?.takeIf { sameStoredScope }
         val snapshot = RuntimeControlsSnapshot(
             origin = origin,
             profile = profile,
             storedSessionId = storedSessionId,
             runtimeSessionId = resumed.runtimeSessionId,
-            provider = info.provider ?: previousSnapshot?.takeIf { sameStoredScope }?.provider,
-            model = info.model ?: previousSnapshot?.takeIf { sameStoredScope }?.model,
-            reasoningEffort = info.reasoningEffort
-                ?: previousSnapshot?.takeIf { sameStoredScope }?.reasoningEffort,
-            reasoningEnabled = info.reasoningEnabled
-                ?: previousSnapshot?.takeIf { sameStoredScope }?.reasoningEnabled,
+            provider = if (retainPendingEffectiveState) retainedSnapshot?.provider
+            else info.provider ?: retainedSnapshot?.provider,
+            model = if (retainPendingEffectiveState) retainedSnapshot?.model
+            else info.model ?: retainedSnapshot?.model,
+            reasoningEffort = if (retainPendingEffectiveState) retainedSnapshot?.reasoningEffort
+            else info.reasoningEffort ?: retainedSnapshot?.reasoningEffort,
+            reasoningEnabled = if (retainPendingEffectiveState) retainedSnapshot?.reasoningEnabled
+            else info.reasoningEnabled ?: retainedSnapshot?.reasoningEnabled,
             running = info.running ?: resumed.running
-                ?: previousSnapshot?.takeIf { sameStoredScope }?.running,
+                ?: retainedSnapshot?.running,
             capabilities = previousSnapshot
                 ?.takeIf { sameStoredScope && it.runtimeSessionId == resumed.runtimeSessionId }
                 ?.capabilities
@@ -1495,12 +1533,12 @@ internal class CelesteViewModel(
             optionsLoading = false,
             operation = when {
                 confirmed -> RuntimeControlsOperation.Idle
-                previousControls.operation == RuntimeControlsOperation.Checking -> RuntimeControlsOperation.Idle
+                previousControls.operation == RuntimeControlsOperation.Unknown -> RuntimeControlsOperation.Idle
                 else -> previousControls.operation
             },
             message = when {
                 confirmed -> null
-                previousControls.operation == RuntimeControlsOperation.Checking -> "Reconnect and try again."
+                previousControls.operation == RuntimeControlsOperation.Unknown -> "Reconnect and try again."
                 else -> previousControls.message
             },
             canApply = false,
@@ -1522,12 +1560,29 @@ internal class CelesteViewModel(
         val controls = current.runtimeControls
         val expected = controls.snapshot ?: return
         val info = decodeRuntimeControlsInfo(event.payload, authoritative = true)
+        val pending = pendingRuntimeApply
+        val retainPendingEffectiveState = pending?.takeIf {
+            it.origin == expected.origin &&
+                it.profile == expected.profile &&
+                it.storedSessionId == expected.storedSessionId
+        }?.let {
+            shouldRetainPendingEffectiveState(info, it)
+        } == true
+        val effectiveInfo = if (retainPendingEffectiveState) {
+            info.copy(
+                provider = null,
+                model = null,
+                reasoningEffort = null,
+                reasoningEnabled = null,
+            )
+        } else {
+            info
+        }
         val updated = applyRuntimeControlsInfo(
-            info = info,
+            info = effectiveInfo,
             source = RuntimeControlsSource.SessionInfo,
             expected = expected,
         ) ?: return
-        val pending = pendingRuntimeApply
         val confirmed = pending?.let { authoritativeRuntimeControlsMatch(updated, it) } == true
         if (confirmed) pendingRuntimeApply = null
         val nextTurnState = info.running?.let { if (it) TurnState.Running else TurnState.Idle }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -131,6 +131,22 @@ private data class PendingRuntimeApply(
     val reasoningChanged: Boolean,
 )
 
+private data class RuntimeControlsCapabilityCache(
+    val gateway: GatewayConnection,
+    val origin: String,
+    val profile: String,
+    val storedSessionId: String,
+    val runtimeSessionId: String,
+    val revision: Long,
+    val capabilities: RuntimeControlsCapabilities,
+)
+
+private data class ReconciliationRun(
+    val gateway: GatewayConnection,
+    val generation: Long,
+    val bufferedEvents: MutableList<GatewayEvent> = mutableListOf(),
+)
+
 internal enum class ConnectionPhase {
     CheckingSavedConnection,
     ManualSetup,
@@ -193,12 +209,15 @@ internal class CelesteViewModel(
     private var connectionJob: Job? = null
     private var connectionAttempt = 0L
     private val connectionStoreMutex = Mutex()
+    private val reconciliationMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
-    private var reconciling = false
     private var currentSessionCanResume = true
-    private val bufferedEvents = mutableListOf<GatewayEvent>()
     private var pendingRuntimeApply: PendingRuntimeApply? = null
+    private var runtimeControlsRevision = 0L
+    private var runtimeControlsCapabilityCache: RuntimeControlsCapabilityCache? = null
+    private var reconciliationGeneration = 0L
+    private var activeReconciliation: ReconciliationRun? = null
 
     init {
         restoreSavedConnection()
@@ -264,24 +283,71 @@ internal class CelesteViewModel(
             ),
         )
         val identity = RuntimeControlIdentity.from(snapshot)
+        val capturedRevision = runtimeControlsRevision
+        val cachedCapabilities = runtimeControlsCapabilityCache?.takeIf {
+            it.gateway === activeGateway &&
+                it.origin == identity.origin &&
+                it.profile == identity.profile &&
+                it.storedSessionId == identity.storedSessionId &&
+                it.runtimeSessionId == identity.runtimeSessionId &&
+                it.revision == capturedRevision
+        }
+        val needsConfigFallback = snapshot.provider == null ||
+            snapshot.model == null ||
+            snapshot.reasoningEffort == null
         viewModelScope.launch {
-            val optionsResult = runCatching {
-                activeGateway.readRuntimeControlsOptions(snapshot.runtimeSessionId)
+            val optionsResult = if (cachedCapabilities != null) {
+                Result.success(cachedCapabilities.capabilities)
+            } else {
+                try {
+                    Result.success(activeGateway.readRuntimeControlsOptions(snapshot.runtimeSessionId))
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    Result.failure(error)
+                }
             }
-            val needsConfigFallback = snapshot.provider == null ||
-                snapshot.model == null ||
-                snapshot.reasoningEffort == null
             val configInfo = if (needsConfigFallback) {
-                runCatching {
+                try {
                     activeGateway.readRuntimeControlsConfig(snapshot.runtimeSessionId)
-                }.getOrNull()
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Throwable) {
+                    null
+                }
             } else {
                 null
             }
-            if (!isCurrentRuntimeControlIdentity(activeGateway, identity)) return@launch
+            val readStillCurrent = isCurrentRuntimeControlIdentity(activeGateway, identity) &&
+                runtimeControlsRevision == capturedRevision
+            if (!readStillCurrent) {
+                if (gateway === activeGateway && mutableState.value.runtimeControls.pickerOpen) {
+                    openRuntimeControls()
+                }
+                return@launch
+            }
             var next = mutableState.value.runtimeControls
             val nextSnapshot = next.snapshot ?: return@launch
+            val capabilities = optionsResult.getOrElse {
+                RuntimeControlsCapabilities.Unavailable
+            }
+            if (cachedCapabilities == null) {
+                runtimeControlsCapabilityCache = RuntimeControlsCapabilityCache(
+                    gateway = activeGateway,
+                    origin = identity.origin,
+                    profile = identity.profile,
+                    storedSessionId = identity.storedSessionId,
+                    runtimeSessionId = identity.runtimeSessionId,
+                    revision = runtimeControlsRevision,
+                    capabilities = capabilities,
+                )
+            }
             optionsResult.onSuccess { capabilities ->
+                next = next.copy(
+                    snapshot = nextSnapshot.copy(capabilities = capabilities),
+                )
+            }
+            if (optionsResult.isFailure) {
                 next = next.copy(
                     snapshot = nextSnapshot.copy(capabilities = capabilities),
                 )
@@ -290,16 +356,28 @@ internal class CelesteViewModel(
             if (configInfo?.authoritative == true) {
                 applyRuntimeControlsInfo(
                     info = configInfo,
-                    source = RuntimeControlsSource.SessionInfo,
+                    source = RuntimeControlsSource.ConfigFallback,
                     expected = refreshedSnapshot,
                 )?.let { merged ->
+                    if (merged != refreshedSnapshot) runtimeControlsRevision += 1
                     next = next.copy(snapshot = merged)
                 }
             }
+            runtimeControlsCapabilityCache = runtimeControlsCapabilityCache?.takeIf {
+                it.gateway === activeGateway &&
+                    it.origin == identity.origin &&
+                    it.profile == identity.profile &&
+                    it.storedSessionId == identity.storedSessionId &&
+                    it.runtimeSessionId == identity.runtimeSessionId
+            }?.copy(revision = runtimeControlsRevision)
             val message = when {
                 optionsResult.isFailure -> "This gateway cannot change model or reasoning settings."
                 next.snapshot?.capabilities?.available != true -> {
                     "Model and reasoning choices are unavailable on this gateway."
+                }
+                mutableState.value.turnState == TurnState.Running &&
+                    next.snapshot?.capabilities?.canApplyWhileRunning != true -> {
+                    "Apply when this response finishes."
                 }
                 else -> null
             }
@@ -438,18 +516,22 @@ internal class CelesteViewModel(
         val modelOption = snapshot.capabilities.modelOptions.firstOrNull {
             it.provider == draft.provider && it.model == draft.model
         }
-        if (draft.model != snapshot.model || draft.provider != snapshot.provider) {
-            if (modelOption == null) return false
-        }
+        if (modelOption == null) return false
+        val modelChanged = draft.model != snapshot.model || draft.provider != snapshot.provider
+        if (modelChanged && snapshot.capabilities.canChangeModel == false) return false
         val reasoningChanged = draft.reasoningEffort != snapshot.reasoningEffort
+        if (reasoningChanged && snapshot.capabilities.canChangeReasoning == false) return false
         if (reasoningChanged && (
                 draft.reasoningEffort == null ||
                     draft.reasoningEffort !in snapshot.capabilities.reasoningEfforts ||
-                    modelOption?.supportsReasoning == false
+                    (draft.reasoningEffort != "none" && !modelOption.supportsReasoning)
             )
         ) {
             return false
         }
+        val targetRequiresReasoning = draft.reasoningEffort?.equals("none", ignoreCase = true) != true &&
+            (draft.reasoningEffort != null || snapshot.reasoningEnabled == true)
+        if (targetRequiresReasoning && !modelOption.supportsReasoning) return false
         if (draft.model == snapshot.model && draft.provider == snapshot.provider && !reasoningChanged) {
             return false
         }
@@ -543,12 +625,24 @@ internal class CelesteViewModel(
             (info.provider == null || info.provider == pending.target.provider)
     }
 
+    private fun deferredApplyWasRejected(
+        info: RuntimeControlsInfo,
+        pending: PendingRuntimeApply,
+        snapshot: RuntimeControlsSnapshot,
+    ): Boolean = pending.modelChanged &&
+        info.pendingModelSwitch == false &&
+        !authoritativeRuntimeControlsMatch(snapshot, pending)
+
     private fun handleRuntimeControlsAcknowledgement(
         activeGateway: GatewayConnection,
         pending: PendingRuntimeApply,
         acknowledgement: RuntimeControlsApplyResult,
     ) {
         if (!acknowledgement.acknowledged) {
+            if (acknowledgement.partial) {
+                reconcileAfterPartialRuntimeApply(activeGateway, pending)
+                return
+            }
             handleRuntimeControlsApplyFailure(
                 activeGateway,
                 pending,
@@ -566,6 +660,10 @@ internal class CelesteViewModel(
                 }
             }
         val withAcknowledgement = if (updated != null) controls.copy(snapshot = updated) else controls
+        if (updated != null) {
+            runtimeControlsRevision += 1
+            runtimeControlsCapabilityCache = null
+        }
         val confirmed = withAcknowledgement.snapshot?.let { authoritativeRuntimeControlsMatch(it, pending) } == true
         mutableState.value = current.copy(
             runtimeControls = withAcknowledgement.copy(
@@ -603,38 +701,57 @@ internal class CelesteViewModel(
         }
     }
 
+    private fun reconcileAfterPartialRuntimeApply(
+        activeGateway: GatewayConnection,
+        pending: PendingRuntimeApply,
+    ) {
+        viewModelScope.launch {
+            val reconciliation = try {
+                reconcile(activeGateway, pending.storedSessionId)
+                true
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                false
+            }
+            if (gateway !== activeGateway) return@launch
+            pendingRuntimeApply = null
+            val current = mutableState.value
+            val target = pending.target.copy(
+                runtimeSessionId = current.runtimeControls.snapshot?.runtimeSessionId
+                    ?: pending.runtimeSessionId,
+            )
+            val nextControls = current.runtimeControls.copy(
+                pickerOpen = true,
+                draft = target,
+                operation = RuntimeControlsOperation.Idle,
+                message = if (reconciliation) {
+                    "Only part of that change was applied. Review the current setting."
+                } else {
+                    "Reconnect and review the current setting."
+                },
+                canApply = false,
+            )
+            mutableState.value = current.copy(
+                runtimeControls = nextControls.copy(
+                    canApply = if (reconciliation) {
+                        canApplyRuntimeControls(nextControls, current.turnState)
+                    } else {
+                        false
+                    },
+                ),
+            )
+            if (!reconciliation) markRuntimeControlsReconnecting("Reconnect and review the current setting.")
+        }
+    }
+
     private fun handleRuntimeControlsApplyFailure(
         activeGateway: GatewayConnection,
         pending: PendingRuntimeApply,
         error: Throwable,
     ) {
         if (error is RuntimeControlsPartialApplyException) {
-            viewModelScope.launch {
-                val reconciliation = runCatching { reconcile(activeGateway, pending.storedSessionId) }
-                if (gateway !== activeGateway) return@launch
-                pendingRuntimeApply = null
-                val current = mutableState.value
-                val nextControls = current.runtimeControls.copy(
-                    pickerOpen = true,
-                    draft = pending.target,
-                    operation = RuntimeControlsOperation.Idle,
-                    message = if (reconciliation.isSuccess) {
-                        "Only part of that change was applied. Review the current setting."
-                    } else {
-                        "Reconnect and review the current setting."
-                    },
-                    canApply = false,
-                )
-                mutableState.value = current.copy(
-                    runtimeControls = nextControls.copy(
-                        canApply = if (reconciliation.isSuccess) {
-                            canApplyRuntimeControls(nextControls, current.turnState)
-                        } else {
-                            false
-                        },
-                    ),
-                )
-            }
+            reconcileAfterPartialRuntimeApply(activeGateway, pending)
             return
         }
         if (error is GatewayRpcException) {
@@ -1211,55 +1328,63 @@ internal class CelesteViewModel(
         viewModelScope.launch {
             runCatching {
                 newGateway.connect()
-                reconciling = true
-                bufferedEvents.clear()
-                val created = newGateway.createSession(selectedProfile)
-                if (gateway !== newGateway) throw IOException("The Hermes connection changed while creating the conversation.")
-                val returnedProfile = created.profile?.takeIf(String::isNotBlank)
-                if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
-                    throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
-                }
-                currentRuntimeSessionId = created.runtimeSessionId
-                currentStoredSessionId = created.storedSessionId
-                currentSessionCanResume = false
-                val summary = StoredSession(
-                    id = created.storedSessionId,
-                    title = "New conversation",
-                    preview = "",
-                    startedAt = 0.0,
-                    messageCount = 0,
-                    source = "android",
-                    profile = selectedProfile,
-                )
-                val createdInfo = created.runtimeControls
-                val createdSnapshot = RuntimeControlsSnapshot(
-                    origin = connection.baseUrl,
-                    profile = createdInfo.profile?.takeIf(String::isNotBlank) ?: selectedProfile,
-                    storedSessionId = created.storedSessionId,
-                    runtimeSessionId = created.runtimeSessionId,
-                    provider = createdInfo.provider,
-                    model = createdInfo.model,
-                    reasoningEffort = createdInfo.reasoningEffort,
-                    reasoningEnabled = createdInfo.reasoningEnabled,
-                    running = createdInfo.running,
-                    source = RuntimeControlsSource.ResumedSnapshot,
-                )
-                val events = bufferedEvents.toList()
-                bufferedEvents.clear()
-                reconciling = false
-                mutableState.value = mutableState.value.copy(
-                    sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
-                        .filterNot { it.id == summary.id },
-                    activeSummary = summary,
-                    turnState = TurnState.Idle,
-                    runtimeControls = RuntimeControlsUiState(
-                        lifecycle = RuntimeControlsLifecycle.Available,
-                        snapshot = createdSnapshot,
-                    ),
-                    loadingMessage = null,
-                    errorMessage = null,
-                )
-                events.forEach(::applyEvent)
+                val created = withReconciliationBuffer(
+                    activeGateway = newGateway,
+                    operation = { newGateway.createSession(selectedProfile) },
+                    applySnapshot = { createdSession ->
+                        if (gateway !== newGateway) {
+                            throw IOException("The Hermes connection changed while creating the conversation.")
+                        }
+                        val returnedProfile = createdSession.profile?.takeIf(String::isNotBlank)
+                        if (returnedProfile != null &&
+                            !returnedProfile.equals(selectedProfile, ignoreCase = true)
+                        ) {
+                            throw IOException(
+                                "Hermes created this conversation in $returnedProfile instead of $selectedProfile.",
+                            )
+                        }
+                        currentRuntimeSessionId = createdSession.runtimeSessionId
+                        currentStoredSessionId = createdSession.storedSessionId
+                        currentSessionCanResume = false
+                        val summary = StoredSession(
+                            id = createdSession.storedSessionId,
+                            title = "New conversation",
+                            preview = "",
+                            startedAt = 0.0,
+                            messageCount = 0,
+                            source = "android",
+                            profile = selectedProfile,
+                        )
+                        val createdInfo = createdSession.runtimeControls
+                        val createdSnapshot = RuntimeControlsSnapshot(
+                            origin = connection.baseUrl,
+                            profile = createdInfo.profile?.takeIf(String::isNotBlank) ?: selectedProfile,
+                            storedSessionId = createdSession.storedSessionId,
+                            runtimeSessionId = createdSession.runtimeSessionId,
+                            provider = createdInfo.provider,
+                            model = createdInfo.model,
+                            reasoningEffort = createdInfo.reasoningEffort,
+                            reasoningEnabled = createdInfo.reasoningEnabled,
+                            running = createdInfo.running,
+                            source = RuntimeControlsSource.ResumedSnapshot,
+                        )
+                        runtimeControlsRevision += 1
+                        runtimeControlsCapabilityCache = null
+                        mutableState.value = mutableState.value.copy(
+                            sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
+                                .filterNot { it.id == summary.id },
+                            activeSummary = summary,
+                            turnState = TurnState.Idle,
+                            runtimeControls = RuntimeControlsUiState(
+                                lifecycle = RuntimeControlsLifecycle.Available,
+                                snapshot = createdSnapshot,
+                            ),
+                            loadingMessage = null,
+                            errorMessage = null,
+                        )
+                    },
+                ) ?: throw IOException("The Hermes connection changed while creating the conversation.")
+                created
             }.onSuccess {
                 reconnectAttempts = 0
             }.onFailure { error ->
@@ -1380,7 +1505,7 @@ internal class CelesteViewModel(
     fun onForeground() {
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: return
-        if (foregroundCheckJob?.isActive == true || reconciling) return
+        if (foregroundCheckJob?.isActive == true || reconciliationMutex.isLocked) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
             reconnectNow()
             return
@@ -1414,8 +1539,9 @@ internal class CelesteViewModel(
         gatewayEventsJob = viewModelScope.launch {
             activeGateway.events.collect { event ->
                 if (gateway !== activeGateway) return@collect
-                if (reconciling) {
-                    bufferedEvents += event
+                val reconciliation = activeReconciliation
+                if (reconciliation?.gateway === activeGateway) {
+                    reconciliation.bufferedEvents += event
                 } else {
                     applyEvent(event)
                 }
@@ -1437,22 +1563,41 @@ internal class CelesteViewModel(
         }
     }
 
-    private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
-        reconciling = true
-        bufferedEvents.clear()
+    private suspend fun <T> withReconciliationBuffer(
+        activeGateway: GatewayConnection,
+        operation: suspend () -> T,
+        applySnapshot: (T) -> Unit,
+    ): T? = reconciliationMutex.withLock {
+        if (gateway !== activeGateway) return@withLock null
+        val run = ReconciliationRun(
+            gateway = activeGateway,
+            generation = ++reconciliationGeneration,
+        )
+        activeReconciliation = run
         try {
-            val resumed = activeGateway.resumeStoredSession(storedSessionId)
-            if (gateway !== activeGateway) return
-            applyResumedSession(resumed)
-            val events = bufferedEvents.toList()
-            bufferedEvents.clear()
-            reconciling = false
-            events.forEach(::applyEvent)
-        } catch (error: Throwable) {
-            bufferedEvents.clear()
-            reconciling = false
-            throw error
+            val result = operation()
+            if (gateway !== activeGateway || activeReconciliation !== run ||
+                run.generation != reconciliationGeneration
+            ) return@withLock null
+            applySnapshot(result)
+            while (run.bufferedEvents.isNotEmpty()) {
+                val events = run.bufferedEvents.toList()
+                run.bufferedEvents.clear()
+                events.forEach(::applyEvent)
+            }
+            result
+        } finally {
+            if (activeReconciliation === run) activeReconciliation = null
+            run.bufferedEvents.clear()
         }
+    }
+
+    private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
+        withReconciliationBuffer(
+            activeGateway = activeGateway,
+            operation = { activeGateway.resumeStoredSession(storedSessionId) },
+            applySnapshot = ::applyResumedSession,
+        )
     }
 
     private fun applyResumedSession(resumed: ResumedSession) {
@@ -1520,30 +1665,43 @@ internal class CelesteViewModel(
             ?.copy(runtimeSessionId = snapshot.runtimeSessionId)
         val updatedPending = pendingRuntimeApply
         val confirmed = updatedPending?.let { authoritativeRuntimeControlsMatch(snapshot, it) } == true
+        val deferredRejected = updatedPending?.let {
+            deferredApplyWasRejected(info, it, snapshot)
+        } == true
+        val rejectedDraft = updatedPending?.target
+            ?.copy(runtimeSessionId = snapshot.runtimeSessionId)
+            ?: existingDraft
         val nextTurnState = if (resumed.running == true || resumed.hasLiveProjection) {
             TurnState.Running
         } else {
             TurnState.Idle
         }
+        runtimeControlsRevision += 1
+        runtimeControlsCapabilityCache = null
         val controls = previousControls.copy(
             lifecycle = RuntimeControlsLifecycle.Available,
             snapshot = snapshot,
-            draft = if (confirmed) null else existingDraft,
-            pickerOpen = if (confirmed) false else previousControls.pickerOpen,
+            draft = if (confirmed) null else rejectedDraft,
+            pickerOpen = when {
+                confirmed -> false
+                deferredRejected -> true
+                else -> previousControls.pickerOpen
+            },
             optionsLoading = false,
             operation = when {
-                confirmed -> RuntimeControlsOperation.Idle
+                confirmed || deferredRejected -> RuntimeControlsOperation.Idle
                 previousControls.operation == RuntimeControlsOperation.Unknown -> RuntimeControlsOperation.Idle
                 else -> previousControls.operation
             },
             message = when {
                 confirmed -> null
+                deferredRejected -> "Hermes did not apply that queued change. Review and apply again."
                 previousControls.operation == RuntimeControlsOperation.Unknown -> "Reconnect and try again."
                 else -> previousControls.message
             },
             canApply = false,
         )
-        if (confirmed) pendingRuntimeApply = null
+        if (confirmed || deferredRejected) pendingRuntimeApply = null
         mutableState.value = mutableState.value.copy(
             messages = resumed.messages,
             streamingText = streamingSuffix,
@@ -1584,15 +1742,36 @@ internal class CelesteViewModel(
             expected = expected,
         ) ?: return
         val confirmed = pending?.let { authoritativeRuntimeControlsMatch(updated, it) } == true
-        if (confirmed) pendingRuntimeApply = null
+        val deferredRejected = pending?.let {
+            deferredApplyWasRejected(info, it, updated)
+        } == true
+        if (confirmed || deferredRejected) pendingRuntimeApply = null
         val nextTurnState = info.running?.let { if (it) TurnState.Running else TurnState.Idle }
             ?: current.turnState
+        runtimeControlsRevision += 1
+        runtimeControlsCapabilityCache = null
         val nextControls = controls.copy(
             snapshot = updated,
-            operation = if (confirmed) RuntimeControlsOperation.Idle else controls.operation,
-            pickerOpen = if (confirmed) false else controls.pickerOpen,
-            draft = if (confirmed) null else controls.draft,
-            message = if (confirmed) null else controls.message,
+            operation = if (confirmed || deferredRejected) {
+                RuntimeControlsOperation.Idle
+            } else {
+                controls.operation
+            },
+            pickerOpen = when {
+                confirmed -> false
+                deferredRejected -> true
+                else -> controls.pickerOpen
+            },
+            draft = when {
+                confirmed -> null
+                deferredRejected -> pending?.target?.copy(runtimeSessionId = updated.runtimeSessionId)
+                else -> controls.draft
+            },
+            message = when {
+                confirmed -> null
+                deferredRejected -> "Hermes did not apply that queued change. Review and apply again."
+                else -> controls.message
+            },
             canApply = false,
         )
         mutableState.value = current.copy(
@@ -1679,9 +1858,25 @@ internal class CelesteViewModel(
                     TurnState.Idle
                 }
                 val controls = mutableState.value.runtimeControls
+                val capabilities = controls.snapshot?.capabilities
+                runtimeControlsRevision += 1
+                runtimeControlsCapabilityCache = null
+                val busyMessage = if (
+                    nextTurnState == TurnState.Running &&
+                    controls.operation == RuntimeControlsOperation.Idle &&
+                    capabilities?.available == true &&
+                    capabilities.canApplyWhileRunning != true
+                ) {
+                    "Apply when this response finishes."
+                } else {
+                    null
+                }
                 mutableState.value = mutableState.value.copy(
                     turnState = nextTurnState,
                     runtimeControls = controls.copy(
+                        message = busyMessage ?: controls.message.takeUnless {
+                            it == "Apply when this response finishes."
+                        },
                         canApply = canApplyRuntimeControls(controls, nextTurnState),
                     ),
                 )
@@ -1778,50 +1973,48 @@ internal class CelesteViewModel(
         profile: String,
     ) {
         val previousStoredId = currentStoredSessionId
-        reconciling = true
-        bufferedEvents.clear()
-        try {
-            val created = activeGateway.createSession(profile)
-            if (gateway !== activeGateway) return
-            currentRuntimeSessionId = created.runtimeSessionId
-            currentStoredSessionId = created.storedSessionId
-            val previousSummary = mutableState.value.activeSummary
-                ?: throw IOException("No draft conversation is open.")
-            val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
-            val createdInfo = created.runtimeControls
-            val createdSnapshot = RuntimeControlsSnapshot(
-                origin = mutableState.value.probe?.baseUrl ?: mutableState.value.dashboardUrl,
-                profile = createdInfo.profile?.takeIf(String::isNotBlank) ?: profile,
-                storedSessionId = created.storedSessionId,
-                runtimeSessionId = created.runtimeSessionId,
-                provider = createdInfo.provider,
-                model = createdInfo.model,
-                reasoningEffort = createdInfo.reasoningEffort,
-                reasoningEnabled = createdInfo.reasoningEnabled,
-                running = createdInfo.running,
-                source = RuntimeControlsSource.ResumedSnapshot,
-            )
-            mutableState.value = mutableState.value.copy(
-                activeSummary = updatedSummary,
-                sessions = mutableState.value.sessions?.map { session ->
-                    if (session.id == previousStoredId) updatedSummary else session
-                },
-                turnState = TurnState.Idle,
-                runtimeControls = RuntimeControlsUiState(
-                    lifecycle = RuntimeControlsLifecycle.Available,
-                    snapshot = createdSnapshot,
-                ),
-                errorMessage = null,
-            )
-            val events = bufferedEvents.toList()
-            bufferedEvents.clear()
-            reconciling = false
-            events.forEach(::applyEvent)
-        } catch (error: Throwable) {
-            bufferedEvents.clear()
-            reconciling = false
-            throw error
-        }
+        val created = withReconciliationBuffer(
+            activeGateway = activeGateway,
+            operation = { activeGateway.createSession(profile) },
+            applySnapshot = { createdSession ->
+                if (gateway !== activeGateway) {
+                    throw IOException("The Hermes connection changed while recreating the conversation.")
+                }
+                currentRuntimeSessionId = createdSession.runtimeSessionId
+                currentStoredSessionId = createdSession.storedSessionId
+                val previousSummary = mutableState.value.activeSummary
+                    ?: throw IOException("No draft conversation is open.")
+                val updatedSummary = previousSummary.copy(id = createdSession.storedSessionId, profile = profile)
+                val createdInfo = createdSession.runtimeControls
+                val createdSnapshot = RuntimeControlsSnapshot(
+                    origin = mutableState.value.probe?.baseUrl ?: mutableState.value.dashboardUrl,
+                    profile = createdInfo.profile?.takeIf(String::isNotBlank) ?: profile,
+                    storedSessionId = createdSession.storedSessionId,
+                    runtimeSessionId = createdSession.runtimeSessionId,
+                    provider = createdInfo.provider,
+                    model = createdInfo.model,
+                    reasoningEffort = createdInfo.reasoningEffort,
+                    reasoningEnabled = createdInfo.reasoningEnabled,
+                    running = createdInfo.running,
+                    source = RuntimeControlsSource.ResumedSnapshot,
+                )
+                runtimeControlsRevision += 1
+                runtimeControlsCapabilityCache = null
+                mutableState.value = mutableState.value.copy(
+                    activeSummary = updatedSummary,
+                    sessions = mutableState.value.sessions?.map { session ->
+                        if (session.id == previousStoredId) updatedSummary else session
+                    },
+                    turnState = TurnState.Idle,
+                    runtimeControls = RuntimeControlsUiState(
+                        lifecycle = RuntimeControlsLifecycle.Available,
+                        snapshot = createdSnapshot,
+                    ),
+                    errorMessage = null,
+                )
+            },
+        ) ?: throw IOException("The Hermes connection changed while recreating the conversation.")
+        created
     }
 
     private fun scheduleReconnect(wasRunning: Boolean, immediate: Boolean = false) {
@@ -1880,8 +2073,10 @@ internal class CelesteViewModel(
         gatewayEventsJob = null
         gatewayStateJob?.cancel()
         gatewayStateJob = null
-        reconciling = false
-        bufferedEvents.clear()
+        reconciliationGeneration += 1
+        activeReconciliation?.bufferedEvents?.clear()
+        activeReconciliation = null
+        runtimeControlsCapabilityCache = null
         currentRuntimeSessionId = null
         currentStoredSessionId = null
         currentSessionCanResume = true

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -21,11 +21,23 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
 import dev.hazydreams.hermesceleste.network.ResumedSession
+import dev.hazydreams.hermesceleste.network.RuntimeControlsApplyResult
+import dev.hazydreams.hermesceleste.network.RuntimeControlsCapabilities
+import dev.hazydreams.hermesceleste.network.RuntimeControlsDraft
+import dev.hazydreams.hermesceleste.network.RuntimeControlsInfo
+import dev.hazydreams.hermesceleste.network.RuntimeControlsPartialApplyException
+import dev.hazydreams.hermesceleste.network.RuntimeControlsSnapshot
+import dev.hazydreams.hermesceleste.network.RuntimeControlsSource
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.network.applyRuntimeControls
 import dev.hazydreams.hermesceleste.network.boolean
 import dev.hazydreams.hermesceleste.network.createSession
+import dev.hazydreams.hermesceleste.network.decodeRuntimeControlsInfo
 import dev.hazydreams.hermesceleste.network.interruptSession
+import dev.hazydreams.hermesceleste.network.readRuntimeControlsConfig
+import dev.hazydreams.hermesceleste.network.readRuntimeControlsOptions
 import dev.hazydreams.hermesceleste.network.resumeStoredSession
 import dev.hazydreams.hermesceleste.network.string
 import dev.hazydreams.hermesceleste.network.submitPrompt
@@ -52,6 +64,60 @@ internal enum class TurnState {
     Reconnecting,
 }
 
+internal enum class RuntimeControlsOperation {
+    Idle,
+    Applying,
+    Queued,
+    Checking,
+}
+
+internal enum class RuntimeControlsLifecycle {
+    Synchronizing,
+    Available,
+    Reconnecting,
+}
+
+internal data class RuntimeControlsUiState(
+    val lifecycle: RuntimeControlsLifecycle = RuntimeControlsLifecycle.Synchronizing,
+    val snapshot: RuntimeControlsSnapshot? = null,
+    val draft: RuntimeControlsDraft? = null,
+    val pickerOpen: Boolean = false,
+    val optionsLoading: Boolean = false,
+    val operation: RuntimeControlsOperation = RuntimeControlsOperation.Idle,
+    val message: String? = null,
+    val canApply: Boolean = false,
+) {
+    val modelLabel: String
+        get() {
+            val provider = snapshot?.provider?.takeIf(String::isNotBlank)
+            val model = snapshot?.model?.takeIf(String::isNotBlank)
+            return when {
+                provider != null && model != null -> "$provider / $model"
+                model != null -> model
+                provider != null -> provider
+                else -> "Model unavailable"
+            }
+        }
+
+    val reasoningLabel: String
+        get() = snapshot?.reasoningEffort?.takeIf(String::isNotBlank)?.let { effort ->
+            if (effort.equals("none", ignoreCase = true)) "Reasoning off" else "Reasoning $effort"
+        } ?: "Reasoning unavailable"
+
+    val accessibilityLabel: String
+        get() = "$modelLabel, $reasoningLabel, change settings"
+}
+
+private data class PendingRuntimeApply(
+    val origin: String,
+    val profile: String,
+    val storedSessionId: String,
+    val runtimeSessionId: String,
+    val target: RuntimeControlsDraft,
+    val modelChanged: Boolean,
+    val reasoningChanged: Boolean,
+)
+
 internal enum class ConnectionPhase {
     CheckingSavedConnection,
     ManualSetup,
@@ -77,6 +143,7 @@ internal data class CelesteUiState(
     val streamingText: String = "",
     val draft: String = "",
     val turnState: TurnState = TurnState.Idle,
+    val runtimeControls: RuntimeControlsUiState = RuntimeControlsUiState(),
     val loadingMessage: String? = null,
     val errorMessage: String? = null,
 )
@@ -118,6 +185,7 @@ internal class CelesteViewModel(
     private var reconciling = false
     private var currentSessionCanResume = true
     private val bufferedEvents = mutableListOf<GatewayEvent>()
+    private var pendingRuntimeApply: PendingRuntimeApply? = null
 
     init {
         restoreSavedConnection()
@@ -150,6 +218,481 @@ internal class CelesteViewModel(
     fun selectProfile(name: String) {
         if (mutableState.value.profiles.none { it.name == name }) return
         mutableState.value = mutableState.value.copy(selectedProfile = name)
+    }
+
+    fun openRuntimeControls() {
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        val snapshot = controls.snapshot ?: return
+        val activeGateway = gateway ?: return
+        if (controls.operation != RuntimeControlsOperation.Idle ||
+            controls.lifecycle != RuntimeControlsLifecycle.Available ||
+            activeGateway.state.value != GatewayConnectionState.Connected
+        ) {
+            return
+        }
+        val draft = controls.draft?.takeIf { draftMatchesSnapshot(it, snapshot) }
+            ?: RuntimeControlsDraft(
+                origin = snapshot.origin,
+                profile = snapshot.profile,
+                storedSessionId = snapshot.storedSessionId,
+                runtimeSessionId = snapshot.runtimeSessionId,
+                provider = snapshot.provider,
+                model = snapshot.model,
+                reasoningEffort = snapshot.reasoningEffort,
+            )
+        mutableState.value = current.copy(
+            runtimeControls = controls.copy(
+                draft = draft,
+                pickerOpen = true,
+                optionsLoading = true,
+                message = null,
+                canApply = false,
+            ),
+        )
+        val identity = RuntimeControlIdentity.from(snapshot)
+        viewModelScope.launch {
+            val optionsResult = runCatching {
+                activeGateway.readRuntimeControlsOptions(snapshot.runtimeSessionId)
+            }
+            val needsConfigFallback = snapshot.provider == null ||
+                snapshot.model == null ||
+                snapshot.reasoningEffort == null
+            val configInfo = if (needsConfigFallback) {
+                runCatching {
+                    activeGateway.readRuntimeControlsConfig(snapshot.runtimeSessionId)
+                }.getOrNull()
+            } else {
+                null
+            }
+            if (!isCurrentRuntimeControlIdentity(activeGateway, identity)) return@launch
+            var next = mutableState.value.runtimeControls
+            val nextSnapshot = next.snapshot ?: return@launch
+            optionsResult.onSuccess { capabilities ->
+                next = next.copy(
+                    snapshot = nextSnapshot.copy(capabilities = capabilities),
+                )
+            }
+            val refreshedSnapshot = next.snapshot ?: nextSnapshot
+            if (configInfo?.authoritative == true) {
+                applyRuntimeControlsInfo(
+                    info = configInfo,
+                    source = RuntimeControlsSource.SessionInfo,
+                    expected = refreshedSnapshot,
+                )?.let { merged ->
+                    next = next.copy(snapshot = merged)
+                }
+            }
+            val message = when {
+                optionsResult.isFailure -> "This gateway cannot change model or reasoning settings."
+                next.snapshot?.capabilities?.available != true -> {
+                    "Model and reasoning choices are unavailable on this gateway."
+                }
+                else -> null
+            }
+            val finalState = mutableState.value
+            val finalControls = next.copy(
+                optionsLoading = false,
+                message = message,
+                canApply = canApplyRuntimeControls(next, finalState.turnState),
+            )
+            mutableState.value = finalState.copy(runtimeControls = finalControls)
+        }
+    }
+
+    fun selectRuntimeModel(provider: String, model: String) {
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        val snapshot = controls.snapshot ?: return
+        if (!controls.pickerOpen || controls.operation != RuntimeControlsOperation.Idle) return
+        val option = snapshot.capabilities.modelOptions.firstOrNull {
+            it.provider == provider && it.model == model
+        } ?: return
+        val draft = controls.draft ?: return
+        val nextControls = controls.copy(
+            draft = draft.copy(provider = option.provider, model = option.model),
+            message = null,
+        )
+        mutableState.value = current.copy(
+            runtimeControls = nextControls.copy(
+                canApply = canApplyRuntimeControls(nextControls, current.turnState),
+            ),
+        )
+    }
+
+    fun selectRuntimeReasoning(effort: String) {
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        val snapshot = controls.snapshot ?: return
+        if (!controls.pickerOpen || controls.operation != RuntimeControlsOperation.Idle) return
+        val normalized = effort.trim().lowercase()
+        if (normalized.isBlank() || normalized !in snapshot.capabilities.reasoningEfforts) return
+        val draft = controls.draft ?: return
+        val nextControls = controls.copy(
+            draft = draft.copy(reasoningEffort = normalized),
+            message = null,
+        )
+        mutableState.value = current.copy(
+            runtimeControls = nextControls.copy(
+                canApply = canApplyRuntimeControls(nextControls, current.turnState),
+            ),
+        )
+    }
+
+    fun cancelRuntimeControls() {
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        mutableState.value = current.copy(
+            runtimeControls = if (controls.operation == RuntimeControlsOperation.Idle) {
+                controls.copy(
+                    pickerOpen = false,
+                    draft = null,
+                    message = null,
+                    canApply = false,
+                )
+            } else {
+                controls.copy(pickerOpen = false, canApply = false)
+            },
+        )
+    }
+
+    fun applyRuntimeControls() {
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        val snapshot = controls.snapshot ?: return
+        val draft = controls.draft ?: return
+        val activeGateway = gateway ?: return
+        if (!canApplyRuntimeControls(controls, current.turnState)) return
+        if (activeGateway.state.value != GatewayConnectionState.Connected) {
+            markRuntimeControlsReconnecting("Reconnect before applying this setting.")
+            return
+        }
+        val modelChanged = draft.model != snapshot.model || draft.provider != snapshot.provider
+        val reasoningChanged = draft.reasoningEffort != snapshot.reasoningEffort
+        if (!modelChanged && !reasoningChanged) return
+        val pending = PendingRuntimeApply(
+            origin = snapshot.origin,
+            profile = snapshot.profile,
+            storedSessionId = snapshot.storedSessionId,
+            runtimeSessionId = snapshot.runtimeSessionId,
+            target = draft,
+            modelChanged = modelChanged,
+            reasoningChanged = reasoningChanged,
+        )
+        pendingRuntimeApply = pending
+        mutableState.value = current.copy(
+            runtimeControls = controls.copy(
+                operation = RuntimeControlsOperation.Applying,
+                message = "Applying…",
+                canApply = false,
+            ),
+        )
+        viewModelScope.launch {
+            val result = runCatching {
+                activeGateway.applyRuntimeControls(
+                    runtimeSessionId = pending.runtimeSessionId,
+                    provider = pending.target.provider,
+                    model = pending.target.model,
+                    reasoningEffort = pending.target.reasoningEffort,
+                    applyModel = pending.modelChanged,
+                    applyReasoning = pending.reasoningChanged,
+                )
+            }
+            if (!isCurrentRuntimeControlIdentity(activeGateway, pending.identity())) return@launch
+            result.onFailure { error ->
+                handleRuntimeControlsApplyFailure(activeGateway, pending, error)
+            }.onSuccess { acknowledgement ->
+                handleRuntimeControlsAcknowledgement(activeGateway, pending, acknowledgement)
+            }
+        }
+    }
+
+    private fun canApplyRuntimeControls(
+        controls: RuntimeControlsUiState,
+        turnState: TurnState,
+    ): Boolean {
+        val snapshot = controls.snapshot ?: return false
+        val draft = controls.draft ?: return false
+        if (controls.lifecycle != RuntimeControlsLifecycle.Available ||
+            controls.optionsLoading ||
+            controls.operation != RuntimeControlsOperation.Idle ||
+            !controls.pickerOpen ||
+            !snapshot.capabilities.available ||
+            gateway?.state?.value != GatewayConnectionState.Connected
+        ) {
+            return false
+        }
+        val modelOption = snapshot.capabilities.modelOptions.firstOrNull {
+            it.provider == draft.provider && it.model == draft.model
+        }
+        if (draft.model != snapshot.model || draft.provider != snapshot.provider) {
+            if (modelOption == null) return false
+        }
+        val reasoningChanged = draft.reasoningEffort != snapshot.reasoningEffort
+        if (reasoningChanged && (
+                draft.reasoningEffort == null ||
+                    draft.reasoningEffort !in snapshot.capabilities.reasoningEfforts ||
+                    modelOption?.supportsReasoning == false
+            )
+        ) {
+            return false
+        }
+        if (draft.model == snapshot.model && draft.provider == snapshot.provider && !reasoningChanged) {
+            return false
+        }
+        return turnState != TurnState.Running || snapshot.capabilities.canApplyWhileRunning
+    }
+
+    private fun draftMatchesSnapshot(
+        draft: RuntimeControlsDraft,
+        snapshot: RuntimeControlsSnapshot,
+    ): Boolean = draft.origin == snapshot.origin &&
+        draft.profile == snapshot.profile &&
+        draft.storedSessionId == snapshot.storedSessionId
+
+    private data class RuntimeControlIdentity(
+        val origin: String,
+        val profile: String,
+        val storedSessionId: String,
+        val runtimeSessionId: String,
+    ) {
+        companion object {
+            fun from(snapshot: RuntimeControlsSnapshot) = RuntimeControlIdentity(
+                origin = snapshot.origin,
+                profile = snapshot.profile,
+                storedSessionId = snapshot.storedSessionId,
+                runtimeSessionId = snapshot.runtimeSessionId,
+            )
+
+            fun from(pending: PendingRuntimeApply) = RuntimeControlIdentity(
+                origin = pending.origin,
+                profile = pending.profile,
+                storedSessionId = pending.storedSessionId,
+                runtimeSessionId = pending.runtimeSessionId,
+            )
+        }
+    }
+
+    private fun PendingRuntimeApply.identity(): RuntimeControlIdentity =
+        RuntimeControlIdentity.from(this)
+
+    private fun isCurrentRuntimeControlIdentity(
+        activeGateway: GatewayConnection,
+        identity: RuntimeControlIdentity,
+    ): Boolean {
+        val current = mutableState.value.runtimeControls.snapshot ?: return false
+        return gateway === activeGateway &&
+            current.origin == identity.origin &&
+            current.profile == identity.profile &&
+            current.storedSessionId == identity.storedSessionId &&
+            current.runtimeSessionId == identity.runtimeSessionId &&
+            currentRuntimeSessionId == identity.runtimeSessionId
+    }
+
+    private fun applyRuntimeControlsInfo(
+        info: RuntimeControlsInfo,
+        source: RuntimeControlsSource,
+        expected: RuntimeControlsSnapshot,
+    ): RuntimeControlsSnapshot? {
+        if (!info.authoritative) return expected
+        if (info.runtimeSessionId?.takeIf(String::isNotBlank)?.let { it != expected.runtimeSessionId } == true ||
+            info.storedSessionId?.takeIf(String::isNotBlank)?.let { it != expected.storedSessionId } == true ||
+            info.profile?.takeIf(String::isNotBlank)?.let { it != expected.profile } == true
+        ) {
+            return null
+        }
+        return expected.copy(
+            provider = info.provider ?: expected.provider,
+            model = info.model ?: expected.model,
+            reasoningEffort = info.reasoningEffort ?: expected.reasoningEffort,
+            reasoningEnabled = info.reasoningEnabled ?: expected.reasoningEnabled,
+            running = info.running ?: expected.running,
+            source = source,
+        )
+    }
+
+    private fun authoritativeRuntimeControlsMatch(
+        snapshot: RuntimeControlsSnapshot,
+        pending: PendingRuntimeApply,
+    ): Boolean = (!pending.modelChanged || (
+        snapshot.model == pending.target.model && snapshot.provider == pending.target.provider
+        )) && (!pending.reasoningChanged || snapshot.reasoningEffort == pending.target.reasoningEffort)
+
+    private fun handleRuntimeControlsAcknowledgement(
+        activeGateway: GatewayConnection,
+        pending: PendingRuntimeApply,
+        acknowledgement: RuntimeControlsApplyResult,
+    ) {
+        if (!acknowledgement.acknowledged) {
+            handleRuntimeControlsApplyFailure(
+                activeGateway,
+                pending,
+                GatewayRpcException(null, "Hermes did not accept that setting."),
+            )
+            return
+        }
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        val updated = acknowledgement.authoritativeInfo?.let { info ->
+            controls.snapshot?.let { expected ->
+                applyRuntimeControlsInfo(info, RuntimeControlsSource.ApplyAcknowledgement, expected)
+            }
+        }
+        val withAcknowledgement = if (updated != null) controls.copy(snapshot = updated) else controls
+        val confirmed = withAcknowledgement.snapshot?.let { authoritativeRuntimeControlsMatch(it, pending) } == true
+        mutableState.value = current.copy(
+            runtimeControls = withAcknowledgement.copy(
+                pickerOpen = false,
+                draft = if (confirmed) null else withAcknowledgement.draft,
+                operation = when {
+                    confirmed -> RuntimeControlsOperation.Idle
+                    acknowledgement.deferred -> RuntimeControlsOperation.Queued
+                    else -> RuntimeControlsOperation.Applying
+                },
+                message = when {
+                    confirmed -> null
+                    acknowledgement.deferred -> "Queued for next response"
+                    else -> "Applying…"
+                },
+                canApply = false,
+            ),
+        )
+        if (confirmed) {
+            pendingRuntimeApply = null
+            return
+        }
+        viewModelScope.launch {
+            val reconciled = runCatching { reconcile(activeGateway, pending.storedSessionId) }
+            if (reconciled.isFailure && gateway === activeGateway) {
+                mutableState.value = mutableState.value.copy(
+                    runtimeControls = mutableState.value.runtimeControls.copy(
+                        operation = RuntimeControlsOperation.Checking,
+                        message = "Checking the current Hermes setting…",
+                        canApply = false,
+                    ),
+                )
+                markRuntimeControlsReconnecting("Reconnect and try again.")
+            }
+        }
+    }
+
+    private fun handleRuntimeControlsApplyFailure(
+        activeGateway: GatewayConnection,
+        pending: PendingRuntimeApply,
+        error: Throwable,
+    ) {
+        if (error is RuntimeControlsPartialApplyException) {
+            viewModelScope.launch {
+                val reconciliation = runCatching { reconcile(activeGateway, pending.storedSessionId) }
+                if (gateway !== activeGateway) return@launch
+                pendingRuntimeApply = null
+                val current = mutableState.value
+                val nextControls = current.runtimeControls.copy(
+                    pickerOpen = true,
+                    draft = pending.target,
+                    operation = RuntimeControlsOperation.Idle,
+                    message = if (reconciliation.isSuccess) {
+                        "Only part of that change was applied. Review the current setting."
+                    } else {
+                        "Reconnect and review the current setting."
+                    },
+                    canApply = false,
+                )
+                mutableState.value = current.copy(
+                    runtimeControls = nextControls.copy(
+                        canApply = if (reconciliation.isSuccess) {
+                            canApplyRuntimeControls(nextControls, current.turnState)
+                        } else {
+                            false
+                        },
+                    ),
+                )
+            }
+            return
+        }
+        if (error is GatewayRpcException) {
+            pendingRuntimeApply = null
+            mutableState.value = mutableState.value.copy(
+                runtimeControls = mutableState.value.runtimeControls.copy(
+                    pickerOpen = true,
+                    draft = pending.target,
+                    operation = RuntimeControlsOperation.Idle,
+                    message = runtimeControlsError(error),
+                    canApply = canApplyRuntimeControls(
+                        mutableState.value.runtimeControls.copy(
+                            draft = pending.target,
+                            operation = RuntimeControlsOperation.Idle,
+                        ),
+                        mutableState.value.turnState,
+                    ),
+                ),
+            )
+            return
+        }
+        pendingRuntimeApply = pending
+        mutableState.value = mutableState.value.copy(
+            runtimeControls = mutableState.value.runtimeControls.copy(
+                operation = RuntimeControlsOperation.Checking,
+                message = "Checking the current Hermes setting…",
+                canApply = false,
+            ),
+        )
+        if (activeGateway.state.value != GatewayConnectionState.Connected) {
+            markRuntimeControlsReconnecting("Reconnect and try again.")
+        } else {
+            viewModelScope.launch {
+                val reconciliation = runCatching { reconcile(activeGateway, pending.storedSessionId) }
+                if (gateway !== activeGateway) return@launch
+                val snapshot = mutableState.value.runtimeControls.snapshot
+                if (reconciliation.isSuccess && snapshot != null &&
+                    !authoritativeRuntimeControlsMatch(snapshot, pending)
+                ) {
+                    pendingRuntimeApply = null
+                    val current = mutableState.value
+                    val nextControls = current.runtimeControls.copy(
+                        pickerOpen = true,
+                        draft = pending.target,
+                        operation = RuntimeControlsOperation.Idle,
+                        message = "Reconnect and try again.",
+                        canApply = false,
+                    )
+                    mutableState.value = current.copy(
+                        runtimeControls = nextControls.copy(
+                            canApply = canApplyRuntimeControls(nextControls, current.turnState),
+                        ),
+                    )
+                } else if (reconciliation.isFailure) {
+                    markRuntimeControlsReconnecting("Reconnect and try again.")
+                }
+            }
+        }
+    }
+
+    private fun runtimeControlsError(error: GatewayRpcException): String {
+        val text = error.message.orEmpty().lowercase()
+        return when {
+            "busy" in text || "running" in text -> "Apply when this response finishes."
+            "unsupported" in text || "unknown method" in text || "not found" in text -> {
+                "This gateway cannot change that setting."
+            }
+            else -> "Hermes rejected that setting. Choose another supported value."
+        }
+    }
+
+    private fun markRuntimeControlsReconnecting(message: String? = null) {
+        val controls = mutableState.value.runtimeControls
+        mutableState.value = mutableState.value.copy(
+            runtimeControls = controls.copy(
+                lifecycle = RuntimeControlsLifecycle.Reconnecting,
+                operation = if (controls.operation == RuntimeControlsOperation.Applying) {
+                    RuntimeControlsOperation.Checking
+                } else {
+                    controls.operation
+                },
+                message = message ?: controls.message ?: "Reconnecting to Hermes…",
+                canApply = false,
+            ),
+        )
     }
 
     fun findDashboard() {
@@ -592,6 +1135,7 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Synchronizing,
+            runtimeControls = RuntimeControlsUiState(),
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
             errorMessage = null,
         )
@@ -629,6 +1173,7 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Synchronizing,
+            runtimeControls = RuntimeControlsUiState(),
             loadingMessage = "Starting a new $selectedProfile conversation…",
             errorMessage = null,
         )
@@ -659,6 +1204,19 @@ internal class CelesteViewModel(
                     source = "android",
                     profile = selectedProfile,
                 )
+                val createdInfo = created.runtimeControls
+                val createdSnapshot = RuntimeControlsSnapshot(
+                    origin = connection.baseUrl,
+                    profile = createdInfo.profile?.takeIf(String::isNotBlank) ?: selectedProfile,
+                    storedSessionId = created.storedSessionId,
+                    runtimeSessionId = created.runtimeSessionId,
+                    provider = createdInfo.provider,
+                    model = createdInfo.model,
+                    reasoningEffort = createdInfo.reasoningEffort,
+                    reasoningEnabled = createdInfo.reasoningEnabled,
+                    running = createdInfo.running,
+                    source = RuntimeControlsSource.ResumedSnapshot,
+                )
                 val events = bufferedEvents.toList()
                 bufferedEvents.clear()
                 reconciling = false
@@ -667,6 +1225,10 @@ internal class CelesteViewModel(
                         .filterNot { it.id == summary.id },
                     activeSummary = summary,
                     turnState = TurnState.Idle,
+                    runtimeControls = RuntimeControlsUiState(
+                        lifecycle = RuntimeControlsLifecycle.Available,
+                        snapshot = createdSnapshot,
+                    ),
                     loadingMessage = null,
                     errorMessage = null,
                 )
@@ -692,6 +1254,7 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Idle,
+            runtimeControls = RuntimeControlsUiState(),
             loadingMessage = null,
             errorMessage = null,
         )
@@ -715,6 +1278,7 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Running,
+            runtimeControls = snapshot.runtimeControls.copy(canApply = false),
             errorMessage = null,
         )
         // prompt.submit creates the durable row before work begins. From this point on,
@@ -746,6 +1310,7 @@ internal class CelesteViewModel(
         if (mutableState.value.turnState != TurnState.Running) return
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Synchronizing,
+            runtimeControls = mutableState.value.runtimeControls.copy(canApply = false),
             errorMessage = null,
         )
         viewModelScope.launch {
@@ -838,6 +1403,7 @@ internal class CelesteViewModel(
                         turnState = TurnState.Reconnecting,
                         errorMessage = connectionState.reason,
                     )
+                    markRuntimeControlsReconnecting(connectionState.reason)
                     scheduleReconnect(wasRunning)
                 }
             }
@@ -863,22 +1429,122 @@ internal class CelesteViewModel(
     }
 
     private fun applyResumedSession(resumed: ResumedSession) {
+        val previousControls = mutableState.value.runtimeControls
+        val previousSnapshot = previousControls.snapshot
+        val origin = mutableState.value.probe?.baseUrl
+            ?: mutableState.value.dashboardUrl
+        val profile = resumed.runtimeControls.profile
+            ?.takeIf(String::isNotBlank)
+            ?: mutableState.value.activeSummary?.profile
+            ?: mutableState.value.selectedProfile
+        val storedSessionId = resumed.storedSessionId
+        val sameStoredScope = previousSnapshot != null &&
+            previousSnapshot.origin == origin &&
+            previousSnapshot.profile == profile &&
+            previousSnapshot.storedSessionId == storedSessionId
+        val info = resumed.runtimeControls
+        val snapshot = RuntimeControlsSnapshot(
+            origin = origin,
+            profile = profile,
+            storedSessionId = storedSessionId,
+            runtimeSessionId = resumed.runtimeSessionId,
+            provider = info.provider ?: previousSnapshot?.takeIf { sameStoredScope }?.provider,
+            model = info.model ?: previousSnapshot?.takeIf { sameStoredScope }?.model,
+            reasoningEffort = info.reasoningEffort
+                ?: previousSnapshot?.takeIf { sameStoredScope }?.reasoningEffort,
+            reasoningEnabled = info.reasoningEnabled
+                ?: previousSnapshot?.takeIf { sameStoredScope }?.reasoningEnabled,
+            running = info.running ?: resumed.running
+                ?: previousSnapshot?.takeIf { sameStoredScope }?.running,
+            capabilities = previousSnapshot
+                ?.takeIf { sameStoredScope && it.runtimeSessionId == resumed.runtimeSessionId }
+                ?.capabilities
+                ?: RuntimeControlsCapabilities.Unavailable,
+            source = RuntimeControlsSource.ResumedSnapshot,
+        )
         currentRuntimeSessionId = resumed.runtimeSessionId
-        currentStoredSessionId = resumed.storedSessionId
+        currentStoredSessionId = storedSessionId
         currentSessionCanResume = true
+        val pending = pendingRuntimeApply
+        if (pending != null &&
+            pending.origin == snapshot.origin &&
+            pending.profile == snapshot.profile &&
+            pending.storedSessionId == snapshot.storedSessionId
+        ) {
+            pendingRuntimeApply = pending.copy(runtimeSessionId = snapshot.runtimeSessionId)
+        }
         val streamingSuffix = unpersistedInflightText(
             inflight = resumed.inflightAssistantText,
             messages = resumed.messages,
         )
+        val existingDraft = previousControls.draft
+            ?.takeIf { draftMatchesSnapshot(it, snapshot) }
+            ?.copy(runtimeSessionId = snapshot.runtimeSessionId)
+        val updatedPending = pendingRuntimeApply
+        val confirmed = updatedPending?.let { authoritativeRuntimeControlsMatch(snapshot, it) } == true
+        val nextTurnState = if (resumed.running == true || resumed.hasLiveProjection) {
+            TurnState.Running
+        } else {
+            TurnState.Idle
+        }
+        val controls = previousControls.copy(
+            lifecycle = RuntimeControlsLifecycle.Available,
+            snapshot = snapshot,
+            draft = if (confirmed) null else existingDraft,
+            pickerOpen = if (confirmed) false else previousControls.pickerOpen,
+            optionsLoading = false,
+            operation = when {
+                confirmed -> RuntimeControlsOperation.Idle
+                previousControls.operation == RuntimeControlsOperation.Checking -> RuntimeControlsOperation.Idle
+                else -> previousControls.operation
+            },
+            message = when {
+                confirmed -> null
+                previousControls.operation == RuntimeControlsOperation.Checking -> "Reconnect and try again."
+                else -> previousControls.message
+            },
+            canApply = false,
+        )
+        if (confirmed) pendingRuntimeApply = null
         mutableState.value = mutableState.value.copy(
             messages = resumed.messages,
             streamingText = streamingSuffix,
-            turnState = if (resumed.running == true || resumed.hasLiveProjection) {
-                TurnState.Running
-            } else {
-                TurnState.Idle
-            },
+            turnState = nextTurnState,
+            runtimeControls = controls.copy(
+                canApply = canApplyRuntimeControls(controls, nextTurnState),
+            ),
             errorMessage = null,
+        )
+    }
+
+    private fun applySessionInfoEvent(event: GatewayEvent) {
+        val current = mutableState.value
+        val controls = current.runtimeControls
+        val expected = controls.snapshot ?: return
+        val info = decodeRuntimeControlsInfo(event.payload, authoritative = true)
+        val updated = applyRuntimeControlsInfo(
+            info = info,
+            source = RuntimeControlsSource.SessionInfo,
+            expected = expected,
+        ) ?: return
+        val pending = pendingRuntimeApply
+        val confirmed = pending?.let { authoritativeRuntimeControlsMatch(updated, it) } == true
+        if (confirmed) pendingRuntimeApply = null
+        val nextTurnState = info.running?.let { if (it) TurnState.Running else TurnState.Idle }
+            ?: current.turnState
+        val nextControls = controls.copy(
+            snapshot = updated,
+            operation = if (confirmed) RuntimeControlsOperation.Idle else controls.operation,
+            pickerOpen = if (confirmed) false else controls.pickerOpen,
+            draft = if (confirmed) null else controls.draft,
+            message = if (confirmed) null else controls.message,
+            canApply = false,
+        )
+        mutableState.value = current.copy(
+            turnState = nextTurnState,
+            runtimeControls = nextControls.copy(
+                canApply = canApplyRuntimeControls(nextControls, nextTurnState),
+            ),
         )
     }
 
@@ -891,6 +1557,7 @@ internal class CelesteViewModel(
                 mutableState.value = mutableState.value.copy(
                     streamingText = "",
                     turnState = TurnState.Running,
+                    runtimeControls = mutableState.value.runtimeControls.copy(canApply = false),
                     errorMessage = null,
                 )
             }
@@ -901,6 +1568,7 @@ internal class CelesteViewModel(
                     mutableState.value = mutableState.value.copy(
                         streamingText = mutableState.value.streamingText + delta,
                         turnState = TurnState.Running,
+                        runtimeControls = mutableState.value.runtimeControls.copy(canApply = false),
                     )
                 }
             }
@@ -950,17 +1618,22 @@ internal class CelesteViewModel(
             }
 
             "session.busy" -> {
+                val nextTurnState = if (event.payload.boolean("busy") == true) {
+                    TurnState.Running
+                } else {
+                    TurnState.Idle
+                }
+                val controls = mutableState.value.runtimeControls
                 mutableState.value = mutableState.value.copy(
-                    turnState = if (event.payload.boolean("busy") == true) TurnState.Running else TurnState.Idle,
+                    turnState = nextTurnState,
+                    runtimeControls = controls.copy(
+                        canApply = canApplyRuntimeControls(controls, nextTurnState),
+                    ),
                 )
             }
 
             "session.info" -> {
-                event.payload.boolean("running")?.let { running ->
-                    mutableState.value = mutableState.value.copy(
-                        turnState = if (running) TurnState.Running else TurnState.Idle,
-                    )
-                }
+                applySessionInfoEvent(event)
             }
 
             "tool.start", "tool_call" -> {
@@ -978,6 +1651,7 @@ internal class CelesteViewModel(
                         pending = true,
                     ),
                     turnState = TurnState.Running,
+                    runtimeControls = mutableState.value.runtimeControls.copy(canApply = false),
                 )
             }
 
@@ -1032,10 +1706,15 @@ internal class CelesteViewModel(
                 )
             else -> currentMessages
         }
+        val nextTurnState = if (keepRunning) TurnState.Running else TurnState.Idle
+        val nextControls = mutableState.value.runtimeControls
         mutableState.value = mutableState.value.copy(
             messages = messages,
             streamingText = "",
-            turnState = if (keepRunning) TurnState.Running else TurnState.Idle,
+            turnState = nextTurnState,
+            runtimeControls = nextControls.copy(
+                canApply = canApplyRuntimeControls(nextControls, nextTurnState),
+            ),
         )
     }
 
@@ -1054,12 +1733,29 @@ internal class CelesteViewModel(
             val previousSummary = mutableState.value.activeSummary
                 ?: throw IOException("No draft conversation is open.")
             val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
+            val createdInfo = created.runtimeControls
+            val createdSnapshot = RuntimeControlsSnapshot(
+                origin = mutableState.value.probe?.baseUrl ?: mutableState.value.dashboardUrl,
+                profile = createdInfo.profile?.takeIf(String::isNotBlank) ?: profile,
+                storedSessionId = created.storedSessionId,
+                runtimeSessionId = created.runtimeSessionId,
+                provider = createdInfo.provider,
+                model = createdInfo.model,
+                reasoningEffort = createdInfo.reasoningEffort,
+                reasoningEnabled = createdInfo.reasoningEnabled,
+                running = createdInfo.running,
+                source = RuntimeControlsSource.ResumedSnapshot,
+            )
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
                 sessions = mutableState.value.sessions?.map { session ->
                     if (session.id == previousStoredId) updatedSummary else session
                 },
                 turnState = TurnState.Idle,
+                runtimeControls = RuntimeControlsUiState(
+                    lifecycle = RuntimeControlsLifecycle.Available,
+                    snapshot = createdSnapshot,
+                ),
                 errorMessage = null,
             )
             val events = bufferedEvents.toList()
@@ -1078,6 +1774,7 @@ internal class CelesteViewModel(
         val storedSessionId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
         if (reconnectJob?.isActive == true) return
         mutableState.value = mutableState.value.copy(turnState = TurnState.Reconnecting)
+        markRuntimeControlsReconnecting()
         reconnectJob = viewModelScope.launch {
             while (gateway === activeGateway) {
                 val delayMillis = if (immediate && reconnectAttempts == 0) {
@@ -1133,6 +1830,7 @@ internal class CelesteViewModel(
         currentRuntimeSessionId = null
         currentStoredSessionId = null
         currentSessionCanResume = true
+        pendingRuntimeApply = null
         activeGateway?.close()
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -91,6 +91,7 @@ data class ResumedSession(
     val status: String? = null,
     val inflightAssistantText: String = "",
     val hasLiveProjection: Boolean = false,
+    val runtimeControls: RuntimeControlsInfo = RuntimeControlsInfo(),
 )
 
 sealed interface GatewayCredential {
@@ -549,6 +550,9 @@ class DashboardClient(
                     ?: result["session_key"]?.jsonPrimitive?.contentOrNull
                     ?: storedSessionId,
                 messages = decodeGatewayMessages(result["messages"]?.jsonArray.orEmpty()),
+                running = result["running"]?.jsonPrimitive?.booleanOrNull,
+                status = result["status"]?.jsonPrimitive?.contentOrNull,
+                runtimeControls = decodeRuntimeControlsInfo(result, authoritative = true),
             )
         }
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -1,6 +1,7 @@
 package dev.hazydreams.hermesceleste.network
 
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -25,7 +26,20 @@ enum class RuntimeControlsSource {
     ResumedSnapshot,
     SessionInfo,
     ApplyAcknowledgement,
+    ConfigFallback,
 }
+
+enum class RuntimeControlsWriteStatus {
+    Accepted,
+    Deferred,
+    Rejected,
+}
+
+data class RuntimeControlsWriteOutcome(
+    val key: String,
+    val status: RuntimeControlsWriteStatus,
+    val authoritativeInfo: RuntimeControlsInfo? = null,
+)
 
 data class RuntimeModelOption(
     val provider: String,
@@ -39,6 +53,8 @@ data class RuntimeControlsCapabilities(
     val modelOptions: List<RuntimeModelOption> = emptyList(),
     val reasoningEfforts: List<String> = emptyList(),
     val canApplyWhileRunning: Boolean? = null,
+    val canChangeModel: Boolean? = null,
+    val canChangeReasoning: Boolean? = null,
 ) {
     companion object {
         val Unavailable = RuntimeControlsCapabilities(
@@ -88,7 +104,12 @@ data class RuntimeControlsApplyResult(
     val deferred: Boolean = false,
     val acknowledged: Boolean = true,
     val authoritativeInfo: RuntimeControlsInfo? = null,
-)
+    val writes: List<RuntimeControlsWriteOutcome> = emptyList(),
+) {
+    val partial: Boolean
+        get() = writes.any { it.status == RuntimeControlsWriteStatus.Rejected } &&
+            writes.any { it.status != RuntimeControlsWriteStatus.Rejected }
+}
 
 class RuntimeControlsPartialApplyException(
     val completed: RuntimeControlsApplyResult,
@@ -157,6 +178,12 @@ internal fun decodeRuntimeControlsCapabilities(element: JsonElement): RuntimeCon
         reasoningEfforts = efforts,
         canApplyWhileRunning = root.safeBoolean("can_apply_while_running")
             ?: root.safeBoolean("supports_deferred_apply"),
+        canChangeModel = root.safeBoolean("can_change_model")
+            ?: root.safeBoolean("supports_model_change")
+            ?: (root["mutability"] as? JsonObject)?.safeBoolean("model"),
+        canChangeReasoning = root.safeBoolean("can_change_reasoning")
+            ?: root.safeBoolean("supports_reasoning_change")
+            ?: (root["mutability"] as? JsonObject)?.safeBoolean("reasoning"),
     )
 }
 
@@ -236,8 +263,9 @@ internal fun decodeRuntimeControlsConfig(
     val responseRuntimeId = root.safeString("session_id")
         ?: root.safeString("runtime_session_id")
         ?: metadata?.safeString("session_id")
-    val sessionScoped = responseRuntimeId == runtimeSessionId ||
-        scope?.lowercase() in setOf("session", "runtime", "conversation")
+    val sessionScoped = scope?.lowercase() in setOf("session", "runtime", "conversation") ||
+        root.safeBoolean("session_scoped") == true ||
+        metadata?.safeBoolean("session_scoped") == true
     if (!sessionScoped) return RuntimeControlsInfo()
 
     val key = root.safeString("key") ?: metadata?.safeString("key")
@@ -293,7 +321,7 @@ suspend fun GatewayConnection.readRuntimeControlsConfig(
     require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }
     var result = RuntimeControlsInfo(runtimeSessionId = runtimeSessionId)
     for (key in listOf("model", "reasoning")) {
-        val response = runCatching {
+        val response = try {
             request(
                 method = "config.get",
                 params = buildJsonObject {
@@ -301,7 +329,11 @@ suspend fun GatewayConnection.readRuntimeControlsConfig(
                     put("session_id", runtimeSessionId)
                 },
             )
-        }.getOrNull() ?: continue
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Throwable) {
+            continue
+        }
         result = mergeRuntimeControlsInfo(
             result,
             decodeRuntimeControlsConfig(response, runtimeSessionId),
@@ -310,7 +342,10 @@ suspend fun GatewayConnection.readRuntimeControlsConfig(
     return result
 }
 
-private fun decodeRuntimeControlsApplyResult(element: JsonElement): RuntimeControlsApplyResult {
+private fun decodeRuntimeControlsApplyResult(
+    element: JsonElement,
+    key: String,
+): RuntimeControlsApplyResult {
     val result = element as? JsonObject
         ?: throw IOException("Hermes returned no control acknowledgement.")
     val info = if (
@@ -322,11 +357,24 @@ private fun decodeRuntimeControlsApplyResult(element: JsonElement): RuntimeContr
     } else {
         null
     }
+    val deferred = result.safeBoolean("deferred") == true ||
+        result.safeString("status")?.equals("deferred", ignoreCase = true) == true
+    val acknowledged = result.safeBoolean("accepted") != false && result.safeBoolean("ok") != false
     return RuntimeControlsApplyResult(
-        deferred = result.safeBoolean("deferred") == true ||
-            result.safeString("status")?.equals("deferred", ignoreCase = true) == true,
-        acknowledged = result.safeBoolean("accepted") != false && result.safeBoolean("ok") != false,
+        deferred = deferred,
+        acknowledged = acknowledged,
         authoritativeInfo = info,
+        writes = listOf(
+            RuntimeControlsWriteOutcome(
+                key = result.safeString("key") ?: key,
+                status = when {
+                    !acknowledged -> RuntimeControlsWriteStatus.Rejected
+                    deferred -> RuntimeControlsWriteStatus.Deferred
+                    else -> RuntimeControlsWriteStatus.Accepted
+                },
+                authoritativeInfo = info,
+            ),
+        ),
     )
 }
 
@@ -370,7 +418,9 @@ suspend fun GatewayConnection.applyRuntimeControls(
                     put("session_id", runtimeSessionId)
                 },
             ),
+            key = "model",
         )
+        if (!result.acknowledged) return result
     }
     if (applyReasoning) {
         val selectedEffort = reasoningEffort?.trim()?.lowercase()
@@ -386,12 +436,24 @@ suspend fun GatewayConnection.applyRuntimeControls(
                         put("session_id", runtimeSessionId)
                     },
                 ),
+                key = "reasoning",
             )
+            if (!reasoningResult.acknowledged) {
+                return RuntimeControlsApplyResult(
+                    deferred = result.deferred || reasoningResult.deferred,
+                    acknowledged = false,
+                    authoritativeInfo = reasoningResult.authoritativeInfo ?: result.authoritativeInfo,
+                    writes = result.writes + reasoningResult.writes,
+                )
+            }
             result = RuntimeControlsApplyResult(
                 deferred = result.deferred || reasoningResult.deferred,
                 acknowledged = result.acknowledged && reasoningResult.acknowledged,
                 authoritativeInfo = reasoningResult.authoritativeInfo ?: result.authoritativeInfo,
+                writes = result.writes + reasoningResult.writes,
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             throw RuntimeControlsPartialApplyException(result, error)
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -18,7 +18,378 @@ data class CreatedSession(
     val runtimeSessionId: String,
     val storedSessionId: String,
     val profile: String?,
+    val runtimeControls: RuntimeControlsInfo = RuntimeControlsInfo(),
 )
+
+enum class RuntimeControlsSource {
+    ResumedSnapshot,
+    SessionInfo,
+    ApplyAcknowledgement,
+}
+
+data class RuntimeModelOption(
+    val provider: String,
+    val model: String,
+    val supportsReasoning: Boolean = true,
+    val supportsFast: Boolean = false,
+)
+
+private val DEFAULT_REASONING_EFFORTS = listOf(
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "ultra",
+)
+
+data class RuntimeControlsCapabilities(
+    val available: Boolean,
+    val modelOptions: List<RuntimeModelOption> = emptyList(),
+    val reasoningEfforts: List<String> = DEFAULT_REASONING_EFFORTS,
+    val canApplyWhileRunning: Boolean = true,
+) {
+    companion object {
+        val Unavailable = RuntimeControlsCapabilities(
+            available = false,
+            reasoningEfforts = DEFAULT_REASONING_EFFORTS,
+            canApplyWhileRunning = false,
+        )
+    }
+}
+
+data class RuntimeControlsInfo(
+    val runtimeSessionId: String? = null,
+    val storedSessionId: String? = null,
+    val profile: String? = null,
+    val provider: String? = null,
+    val model: String? = null,
+    val reasoningEffort: String? = null,
+    val reasoningEnabled: Boolean? = null,
+    val running: Boolean? = null,
+    val authoritative: Boolean = false,
+)
+
+data class RuntimeControlsSnapshot(
+    val origin: String,
+    val profile: String,
+    val storedSessionId: String,
+    val runtimeSessionId: String,
+    val provider: String? = null,
+    val model: String? = null,
+    val reasoningEffort: String? = null,
+    val reasoningEnabled: Boolean? = null,
+    val running: Boolean? = null,
+    val capabilities: RuntimeControlsCapabilities = RuntimeControlsCapabilities.Unavailable,
+    val source: RuntimeControlsSource = RuntimeControlsSource.ResumedSnapshot,
+)
+
+data class RuntimeControlsDraft(
+    val origin: String,
+    val profile: String,
+    val storedSessionId: String,
+    val runtimeSessionId: String,
+    val provider: String?,
+    val model: String?,
+    val reasoningEffort: String?,
+)
+
+data class RuntimeControlsApplyResult(
+    val deferred: Boolean = false,
+    val acknowledged: Boolean = true,
+    val authoritativeInfo: RuntimeControlsInfo? = null,
+)
+
+class RuntimeControlsPartialApplyException(
+    val completed: RuntimeControlsApplyResult,
+    cause: Throwable,
+) : IOException("Hermes applied only part of the conversation control change.", cause)
+
+internal fun decodeRuntimeControlsCapabilities(element: JsonElement): RuntimeControlsCapabilities {
+    val root = element as? JsonObject ?: return RuntimeControlsCapabilities.Unavailable
+    val providers = root["providers"] as? JsonArray ?: return RuntimeControlsCapabilities.Unavailable
+    val options = providers.flatMap { providerElement ->
+        val provider = providerElement as? JsonObject
+            ?: return@flatMap emptyList<RuntimeModelOption>()
+        val providerId = provider.safeString("slug")
+            ?: provider.safeString("id")
+            ?: provider.safeString("name")
+            ?: return@flatMap emptyList<RuntimeModelOption>()
+        val models = provider["models"] as? JsonArray ?: return@flatMap emptyList<RuntimeModelOption>()
+        val providerCapabilities = provider["capabilities"] as? JsonObject
+        models.mapNotNull { modelElement ->
+            val modelObject = modelElement as? JsonObject
+            val model = (modelElement as? JsonPrimitive)
+                ?.takeIf(JsonPrimitive::isString)
+                ?.contentOrNull
+                ?.takeIf(String::isNotBlank)
+                ?: modelObject?.safeString("slug")
+                ?: modelObject?.safeString("id")
+                ?: modelObject?.safeString("name")
+                ?: return@mapNotNull null
+            val capability = (modelObject?.get("capabilities") as? JsonObject)
+                ?: (providerCapabilities?.get(model) as? JsonObject)
+            RuntimeModelOption(
+                provider = providerId,
+                model = model,
+                supportsReasoning = capability?.safeBoolean("reasoning")
+                    ?: modelObject?.safeBoolean("reasoning")
+                    ?: provider.safeBoolean("reasoning")
+                    ?: true,
+                supportsFast = capability?.safeBoolean("fast")
+                    ?: modelObject?.safeBoolean("fast")
+                    ?: provider.safeBoolean("fast")
+                    ?: false,
+            )
+        }
+    }.distinctBy { it.provider to it.model }
+    if (options.isEmpty()) return RuntimeControlsCapabilities.Unavailable
+
+    val reasoningObject = root["reasoning"] as? JsonObject
+    val efforts = sequenceOf(
+        root["reasoning_efforts"],
+        root["efforts"],
+        reasoningObject?.get("efforts"),
+    ).filterIsInstance<JsonArray>().firstOrNull()
+        ?.mapNotNull { value ->
+            (value as? JsonPrimitive)
+                ?.takeIf(JsonPrimitive::isString)
+                ?.contentOrNull
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
+                ?.lowercase()
+        }
+        ?.distinct()
+        ?.takeIf(List<String>::isNotEmpty)
+        ?: DEFAULT_REASONING_EFFORTS
+    return RuntimeControlsCapabilities(
+        available = true,
+        modelOptions = options,
+        reasoningEfforts = efforts,
+        canApplyWhileRunning = root.safeBoolean("can_apply_while_running")
+            ?: root.safeBoolean("supports_deferred_apply")
+            ?: true,
+    )
+}
+
+internal fun decodeRuntimeControlsInfo(
+    result: JsonObject,
+    authoritative: Boolean = false,
+): RuntimeControlsInfo {
+    val info = result["info"] as? JsonObject ?: result["snapshot"] as? JsonObject
+    val reasoning = result["reasoning"] as? JsonObject ?: info?.get("reasoning") as? JsonObject
+    fun pickString(vararg keys: String): String? = keys.asSequence()
+        .mapNotNull { key -> result.safeString(key) ?: info?.safeString(key) }
+        .firstOrNull(String::isNotBlank)
+    fun pickBoolean(vararg keys: String): Boolean? = keys.asSequence()
+        .mapNotNull { key -> result.safeBoolean(key) ?: info?.safeBoolean(key) }
+        .firstOrNull()
+    return RuntimeControlsInfo(
+        runtimeSessionId = pickString("session_id", "runtime_session_id"),
+        storedSessionId = pickString("resumed", "stored_session_id", "session_key"),
+        profile = pickString("profile", "profile_id", "profile_name"),
+        provider = pickString("provider", "model_provider")
+            ?: reasoning?.safeString("provider"),
+        model = pickString("model", "model_id"),
+        reasoningEffort = pickString("reasoning_effort", "effort")
+            ?: reasoning?.safeString("effort")
+            ?: reasoning?.safeString("reasoning_effort"),
+        reasoningEnabled = pickBoolean("reasoning_enabled", "reasoning_present")
+            ?: reasoning?.safeBoolean("enabled"),
+        running = pickBoolean("running", "busy"),
+        authoritative = authoritative,
+    )
+}
+
+private fun JsonObject.safeString(key: String): String? =
+    (this[key] as? JsonPrimitive)
+        ?.takeIf(JsonPrimitive::isString)
+        ?.contentOrNull
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+
+private fun JsonObject.safeBoolean(key: String): Boolean? =
+    (this[key] as? JsonPrimitive)?.booleanOrNull
+
+private fun decodeConfigModel(value: String): Pair<String?, String?> {
+    val provider = Regex("--provider\\s+([^\\s]+)").find(value)?.groupValues?.getOrNull(1)
+    val model = value.substringBefore(" --").trim().takeIf(String::isNotBlank)
+    return model to provider
+}
+
+internal fun decodeRuntimeControlsConfig(
+    element: JsonElement,
+    runtimeSessionId: String,
+): RuntimeControlsInfo {
+    val root = element as? JsonObject ?: return RuntimeControlsInfo()
+    val metadata = root["meta"] as? JsonObject
+    val scope = root.safeString("scope") ?: metadata?.safeString("scope")
+    val responseRuntimeId = root.safeString("session_id")
+        ?: root.safeString("runtime_session_id")
+        ?: metadata?.safeString("session_id")
+    val sessionScoped = responseRuntimeId == runtimeSessionId ||
+        scope?.lowercase() in setOf("session", "runtime", "conversation")
+    if (!sessionScoped) return RuntimeControlsInfo()
+
+    val key = root.safeString("key") ?: metadata?.safeString("key")
+    val value = root["value"]
+    val valueObject = value as? JsonObject
+    val valueText = (value as? JsonPrimitive)
+        ?.takeIf(JsonPrimitive::isString)
+        ?.contentOrNull
+    val modelFromValue = valueText?.let(::decodeConfigModel)
+    val model = valueObject?.safeString("model")
+        ?: root.safeString("model")
+        ?: modelFromValue?.first
+    val provider = valueObject?.safeString("provider")
+        ?: root.safeString("provider")
+        ?: modelFromValue?.second
+    val reasoning = valueObject?.safeString("reasoning_effort")
+        ?: valueObject?.safeString("effort")
+        ?: root.safeString("reasoning_effort")
+        ?: root.safeString("effort")
+        ?: valueText?.takeIf { key.equals("reasoning", ignoreCase = true) }
+    val enabled = valueObject?.safeBoolean("enabled") ?: root.safeBoolean("reasoning_enabled")
+    return RuntimeControlsInfo(
+        runtimeSessionId = responseRuntimeId ?: runtimeSessionId,
+        storedSessionId = root.safeString("stored_session_id") ?: metadata?.safeString("stored_session_id"),
+        profile = root.safeString("profile") ?: metadata?.safeString("profile"),
+        provider = provider,
+        model = model,
+        reasoningEffort = reasoning,
+        reasoningEnabled = enabled,
+        authoritative = model != null || provider != null || reasoning != null || enabled != null,
+    )
+}
+
+private fun mergeRuntimeControlsInfo(
+    first: RuntimeControlsInfo,
+    second: RuntimeControlsInfo,
+): RuntimeControlsInfo = RuntimeControlsInfo(
+    runtimeSessionId = second.runtimeSessionId ?: first.runtimeSessionId,
+    storedSessionId = second.storedSessionId ?: first.storedSessionId,
+    profile = second.profile ?: first.profile,
+    provider = second.provider ?: first.provider,
+    model = second.model ?: first.model,
+    reasoningEffort = second.reasoningEffort ?: first.reasoningEffort,
+    reasoningEnabled = second.reasoningEnabled ?: first.reasoningEnabled,
+    running = second.running ?: first.running,
+    authoritative = first.authoritative || second.authoritative,
+)
+
+suspend fun GatewayConnection.readRuntimeControlsConfig(
+    runtimeSessionId: String,
+): RuntimeControlsInfo {
+    require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }
+    var result = RuntimeControlsInfo(runtimeSessionId = runtimeSessionId)
+    for (key in listOf("model", "reasoning")) {
+        val response = runCatching {
+            request(
+                method = "config.get",
+                params = buildJsonObject {
+                    put("key", key)
+                    put("session_id", runtimeSessionId)
+                },
+            )
+        }.getOrNull() ?: continue
+        result = mergeRuntimeControlsInfo(
+            result,
+            decodeRuntimeControlsConfig(response, runtimeSessionId),
+        )
+    }
+    return result
+}
+
+private fun decodeRuntimeControlsApplyResult(element: JsonElement): RuntimeControlsApplyResult {
+    val result = element as? JsonObject
+        ?: throw IOException("Hermes returned no control acknowledgement.")
+    val info = if (
+        result["info"] is JsonObject ||
+        result["snapshot"] is JsonObject ||
+        listOf("model", "provider", "reasoning_effort", "running").any(result::containsKey)
+    ) {
+        decodeRuntimeControlsInfo(result, authoritative = true)
+    } else {
+        null
+    }
+    return RuntimeControlsApplyResult(
+        deferred = result.safeBoolean("deferred") == true ||
+            result.safeString("status")?.equals("deferred", ignoreCase = true) == true,
+        acknowledged = result.safeBoolean("accepted") != false && result.safeBoolean("ok") != false,
+        authoritativeInfo = info,
+    )
+}
+
+suspend fun GatewayConnection.readRuntimeControlsOptions(
+    runtimeSessionId: String,
+): RuntimeControlsCapabilities {
+    require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }
+    return decodeRuntimeControlsCapabilities(
+        request(
+            method = "model.options",
+            params = buildJsonObject { put("session_id", runtimeSessionId) },
+        ),
+    )
+}
+
+suspend fun GatewayConnection.applyRuntimeControls(
+    runtimeSessionId: String,
+    provider: String?,
+    model: String?,
+    reasoningEffort: String?,
+    applyModel: Boolean,
+    applyReasoning: Boolean,
+): RuntimeControlsApplyResult {
+    require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }
+    var result = RuntimeControlsApplyResult()
+    if (applyModel) {
+        val selectedModel = model?.trim()?.takeIf(String::isNotBlank)
+            ?: throw IllegalArgumentException("Choose a supported model.")
+        val selectedProvider = provider?.trim().orEmpty()
+        val value = buildString {
+            append(selectedModel)
+            if (selectedProvider.isNotBlank()) append(" --provider ").append(selectedProvider)
+            append(" --session")
+        }
+        result = decodeRuntimeControlsApplyResult(
+            request(
+                method = "config.set",
+                params = buildJsonObject {
+                    put("key", "model")
+                    put("value", value)
+                    put("session_id", runtimeSessionId)
+                },
+            ),
+        )
+    }
+    if (applyReasoning) {
+        val selectedEffort = reasoningEffort?.trim()?.lowercase()
+            ?.takeIf(String::isNotBlank)
+            ?: throw IllegalArgumentException("Choose a supported reasoning setting.")
+        try {
+            val reasoningResult = decodeRuntimeControlsApplyResult(
+                request(
+                    method = "config.set",
+                    params = buildJsonObject {
+                        put("key", "reasoning")
+                        put("value", selectedEffort)
+                        put("session_id", runtimeSessionId)
+                    },
+                ),
+            )
+            result = RuntimeControlsApplyResult(
+                deferred = result.deferred || reasoningResult.deferred,
+                acknowledged = result.acknowledged && reasoningResult.acknowledged,
+                authoritativeInfo = reasoningResult.authoritativeInfo ?: result.authoritativeInfo,
+            )
+        } catch (error: Throwable) {
+            throw RuntimeControlsPartialApplyException(result, error)
+        }
+    }
+    return result
+}
 
 suspend fun GatewayConnection.createSession(profile: String): CreatedSession {
     val selectedProfile = profile.trim().ifEmpty { "default" }
@@ -43,6 +414,7 @@ suspend fun GatewayConnection.createSession(profile: String): CreatedSession {
         profile = result.string("profile")
             ?: result.string("profile_id")
             ?: info?.string("profile_name"),
+        runtimeControls = decodeRuntimeControlsInfo(result, authoritative = true),
     )
 }
 
@@ -78,6 +450,7 @@ suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): Resu
         status = status,
         inflightAssistantText = inflightAssistantText(inflight),
         hasLiveProjection = inflight.isTruthy() || queued.isTruthy(),
+        runtimeControls = decodeRuntimeControlsInfo(result, authoritative = true),
     )
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -30,32 +30,19 @@ enum class RuntimeControlsSource {
 data class RuntimeModelOption(
     val provider: String,
     val model: String,
-    val supportsReasoning: Boolean = true,
+    val supportsReasoning: Boolean = false,
     val supportsFast: Boolean = false,
-)
-
-private val DEFAULT_REASONING_EFFORTS = listOf(
-    "none",
-    "minimal",
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-    "ultra",
 )
 
 data class RuntimeControlsCapabilities(
     val available: Boolean,
     val modelOptions: List<RuntimeModelOption> = emptyList(),
-    val reasoningEfforts: List<String> = DEFAULT_REASONING_EFFORTS,
-    val canApplyWhileRunning: Boolean = true,
+    val reasoningEfforts: List<String> = emptyList(),
+    val canApplyWhileRunning: Boolean? = null,
 ) {
     companion object {
         val Unavailable = RuntimeControlsCapabilities(
             available = false,
-            reasoningEfforts = DEFAULT_REASONING_EFFORTS,
-            canApplyWhileRunning = false,
         )
     }
 }
@@ -69,6 +56,7 @@ data class RuntimeControlsInfo(
     val reasoningEffort: String? = null,
     val reasoningEnabled: Boolean? = null,
     val running: Boolean? = null,
+    val pendingModelSwitch: Boolean? = null,
     val authoritative: Boolean = false,
 )
 
@@ -137,7 +125,7 @@ internal fun decodeRuntimeControlsCapabilities(element: JsonElement): RuntimeCon
                 supportsReasoning = capability?.safeBoolean("reasoning")
                     ?: modelObject?.safeBoolean("reasoning")
                     ?: provider.safeBoolean("reasoning")
-                    ?: true,
+                    ?: false,
                 supportsFast = capability?.safeBoolean("fast")
                     ?: modelObject?.safeBoolean("fast")
                     ?: provider.safeBoolean("fast")
@@ -162,15 +150,13 @@ internal fun decodeRuntimeControlsCapabilities(element: JsonElement): RuntimeCon
                 ?.lowercase()
         }
         ?.distinct()
-        ?.takeIf(List<String>::isNotEmpty)
-        ?: DEFAULT_REASONING_EFFORTS
+        .orEmpty()
     return RuntimeControlsCapabilities(
         available = true,
         modelOptions = options,
         reasoningEfforts = efforts,
         canApplyWhileRunning = root.safeBoolean("can_apply_while_running")
-            ?: root.safeBoolean("supports_deferred_apply")
-            ?: true,
+            ?: root.safeBoolean("supports_deferred_apply"),
     )
 }
 
@@ -186,6 +172,9 @@ internal fun decodeRuntimeControlsInfo(
     fun pickBoolean(vararg keys: String): Boolean? = keys.asSequence()
         .mapNotNull { key -> result.safeBoolean(key) ?: info?.safeBoolean(key) }
         .firstOrNull()
+    fun pickPendingModelSwitch(): Boolean? = sequenceOf(result, info)
+        .mapNotNull { value -> value?.pendingModelSwitch() }
+        .firstOrNull()
     return RuntimeControlsInfo(
         runtimeSessionId = pickString("session_id", "runtime_session_id"),
         storedSessionId = pickString("resumed", "stored_session_id", "session_key"),
@@ -199,6 +188,7 @@ internal fun decodeRuntimeControlsInfo(
         reasoningEnabled = pickBoolean("reasoning_enabled", "reasoning_present")
             ?: reasoning?.safeBoolean("enabled"),
         running = pickBoolean("running", "busy"),
+        pendingModelSwitch = pickPendingModelSwitch(),
         authoritative = authoritative,
     )
 }
@@ -212,6 +202,23 @@ private fun JsonObject.safeString(key: String): String? =
 
 private fun JsonObject.safeBoolean(key: String): Boolean? =
     (this[key] as? JsonPrimitive)?.booleanOrNull
+
+private fun JsonObject.pendingModelSwitch(): Boolean? {
+    val value = this["pending_model_switch"] ?: this["model_switch_pending"] ?: return null
+    return when (value) {
+        JsonNull -> false
+        is JsonObject, is JsonArray -> true
+        is JsonPrimitive -> value.booleanOrNull
+            ?: value.contentOrNull?.let { text ->
+                when {
+                    text.equals("true", ignoreCase = true) -> true
+                    text.equals("false", ignoreCase = true) -> false
+                    else -> null
+                }
+            }
+        else -> null
+    }
+}
 
 private fun decodeConfigModel(value: String): Pair<String?, String?> {
     val provider = Regex("--provider\\s+([^\\s]+)").find(value)?.groupValues?.getOrNull(1)
@@ -276,6 +283,7 @@ private fun mergeRuntimeControlsInfo(
     reasoningEffort = second.reasoningEffort ?: first.reasoningEffort,
     reasoningEnabled = second.reasoningEnabled ?: first.reasoningEnabled,
     running = second.running ?: first.running,
+    pendingModelSwitch = second.pendingModelSwitch ?: first.pendingModelSwitch,
     authoritative = first.authoritative || second.authoritative,
 )
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -85,12 +85,18 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     streamingText = ui.streamingText,
                     draft = ui.draft,
                     turnState = ui.turnState,
+                    runtimeControls = ui.runtimeControls,
                     loadingMessage = ui.loadingMessage,
                     errorMessage = ui.errorMessage,
                     onDraftChange = viewModel::updateDraft,
                     onSend = viewModel::sendMessage,
                     onInterrupt = viewModel::interrupt,
                     onReconnect = viewModel::reconnectNow,
+                    onRuntimeControlsOpen = viewModel::openRuntimeControls,
+                    onRuntimeModelSelected = viewModel::selectRuntimeModel,
+                    onRuntimeReasoningSelected = viewModel::selectRuntimeReasoning,
+                    onRuntimeControlsApply = viewModel::applyRuntimeControls,
+                    onRuntimeControlsCancel = viewModel::cancelRuntimeControls,
                     onBack = viewModel::leaveConversation,
                 )
             }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -41,13 +41,21 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -98,6 +106,8 @@ internal fun ConversationScreen(
 ) {
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
+    val runtimeControlsFocusRequester = remember { FocusRequester() }
+    var pickerWasOpen by remember { mutableStateOf(false) }
     val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
     val visibleMessageCount = messages.size + if (streamingText.isNotBlank()) 1 else 0
     val safeDrawingInsets = WindowInsets.safeDrawing
@@ -107,6 +117,12 @@ internal fun ConversationScreen(
     )
     LaunchedEffect(visibleMessageCount, streamingText.length) {
         if (visibleMessageCount > 0) listState.animateScrollToItem(visibleMessageCount - 1)
+    }
+    LaunchedEffect(runtimeControls.pickerOpen) {
+        if (shouldRestoreRuntimeControlsFocus(pickerWasOpen, runtimeControls.pickerOpen)) {
+            runtimeControlsFocusRequester.requestFocus()
+        }
+        pickerWasOpen = runtimeControls.pickerOpen
     }
 
     CelesteBackdrop(showOrnament = false) {
@@ -204,6 +220,7 @@ internal fun ConversationScreen(
                 RuntimeControlsPill(
                     state = runtimeControls,
                     onClick = onRuntimeControlsOpen,
+                    focusRequester = runtimeControlsFocusRequester,
                 )
                 runtimeControls.message?.let { message ->
                     Text(
@@ -217,7 +234,10 @@ internal fun ConversationScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = 6.dp)
-                            .semantics { stateDescription = message },
+                            .semantics {
+                                stateDescription = message
+                                liveRegion = LiveRegionMode.Polite
+                            },
                     )
                 }
                 Spacer(Modifier.height(8.dp))
@@ -333,6 +353,7 @@ internal fun ConversationScreen(
 private fun RuntimeControlsPill(
     state: RuntimeControlsUiState,
     onClick: () -> Unit,
+    focusRequester: FocusRequester,
 ) {
     val enabled = state.snapshot != null &&
         state.lifecycle == RuntimeControlsLifecycle.Available &&
@@ -342,6 +363,8 @@ private fun RuntimeControlsPill(
         enabled = enabled,
         modifier = Modifier
             .fillMaxWidth()
+            .focusRequester(focusRequester)
+            .testTag("runtime-controls-pill")
             .semantics {
                 contentDescription = state.accessibilityLabel
                 stateDescription = when {
@@ -349,7 +372,7 @@ private fun RuntimeControlsPill(
                     state.lifecycle == RuntimeControlsLifecycle.Synchronizing -> "Synchronizing"
                     state.operation == RuntimeControlsOperation.Applying -> "Applying"
                     state.operation == RuntimeControlsOperation.Queued -> "Queued for next response"
-                    state.operation == RuntimeControlsOperation.Checking -> "Checking current setting"
+                    state.operation == RuntimeControlsOperation.Unknown -> "Unknown result; reconnect to verify"
                     state.snapshot?.capabilities?.available != true -> "Unavailable"
                     else -> "Available"
                 }
@@ -397,6 +420,7 @@ private fun RuntimeControlsSheet(
         modifier = Modifier
             .fillMaxWidth()
             .verticalScroll(scrollState)
+            .testTag("runtime-controls-sheet")
             .padding(horizontal = 24.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
@@ -449,6 +473,7 @@ private fun RuntimeControlsSheet(
                     enabled = inputsEnabled,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .testTag("runtime-controls-model-${option.provider}-${option.model}")
                         .semantics {
                             role = Role.RadioButton
                             stateDescription = if (selected) "Selected" else "Not selected"
@@ -482,6 +507,7 @@ private fun RuntimeControlsSheet(
                     enabled = inputsEnabled,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .testTag("runtime-controls-reasoning-$effort")
                         .semantics {
                             role = Role.RadioButton
                             stateDescription = if (selected) "Selected" else "Not selected"
@@ -507,11 +533,30 @@ private fun RuntimeControlsSheet(
             TextButton(
                 onClick = onCancel,
                 enabled = true,
+                modifier = Modifier
+                    .testTag("runtime-controls-cancel")
+                    .semantics {
+                        contentDescription = "Cancel runtime control changes"
+                        role = Role.Button
+                    },
             ) { Text("Cancel") }
             Spacer(Modifier.size(8.dp))
             Button(
                 onClick = onApply,
                 enabled = state.canApply && state.operation == RuntimeControlsOperation.Idle,
+                modifier = Modifier
+                    .testTag("runtime-controls-apply")
+                    .semantics {
+                        contentDescription = if (state.operation == RuntimeControlsOperation.Applying) {
+                            "Applying runtime control changes"
+                        } else {
+                            "Apply runtime control changes"
+                        }
+                        state.operationAnnouncement?.let { announcement ->
+                            stateDescription = announcement
+                        }
+                        role = Role.Button
+                    },
                 colors = ButtonDefaults.buttonColors(
                     containerColor = CelesteInk,
                     contentColor = CelestePaper,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.verticalScroll
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -30,11 +32,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -42,11 +46,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hazydreams.hermesceleste.RuntimeControlsLifecycle
+import dev.hazydreams.hermesceleste.RuntimeControlsOperation
+import dev.hazydreams.hermesceleste.RuntimeControlsUiState
 import dev.hazydreams.hermesceleste.TurnState
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.StoredSession
@@ -70,12 +82,18 @@ internal fun ConversationScreen(
     streamingText: String,
     draft: String,
     turnState: TurnState,
+    runtimeControls: RuntimeControlsUiState,
     loadingMessage: String?,
     errorMessage: String?,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
     onInterrupt: () -> Unit,
     onReconnect: () -> Unit,
+    onRuntimeControlsOpen: () -> Unit,
+    onRuntimeModelSelected: (String, String) -> Unit,
+    onRuntimeReasoningSelected: (String) -> Unit,
+    onRuntimeControlsApply: () -> Unit,
+    onRuntimeControlsCancel: () -> Unit,
     onBack: () -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -183,6 +201,26 @@ internal fun ConversationScreen(
                     .imePadding()
                     .padding(horizontal = 16.dp, vertical = 14.dp),
             ) {
+                RuntimeControlsPill(
+                    state = runtimeControls,
+                    onClick = onRuntimeControlsOpen,
+                )
+                runtimeControls.message?.let { message ->
+                    Text(
+                        text = message,
+                        color = if (runtimeControls.operation == RuntimeControlsOperation.Idle) {
+                            CelesteMuted
+                        } else {
+                            CelesteGoldText
+                        },
+                        fontSize = 11.sp,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 6.dp)
+                            .semantics { stateDescription = message },
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = draft,
                     onValueChange = onDraftChange,
@@ -271,6 +309,224 @@ internal fun ConversationScreen(
                             ),
                         ) { Text("Send  →", fontWeight = FontWeight.Bold) }
                     }
+                }
+            }
+        }
+        if (runtimeControls.pickerOpen) {
+            ModalBottomSheet(
+                onDismissRequest = onRuntimeControlsCancel,
+                sheetState = rememberModalBottomSheetState(),
+            ) {
+                RuntimeControlsSheet(
+                    state = runtimeControls,
+                    onModelSelected = onRuntimeModelSelected,
+                    onReasoningSelected = onRuntimeReasoningSelected,
+                    onApply = onRuntimeControlsApply,
+                    onCancel = onRuntimeControlsCancel,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RuntimeControlsPill(
+    state: RuntimeControlsUiState,
+    onClick: () -> Unit,
+) {
+    val enabled = state.snapshot != null &&
+        state.lifecycle == RuntimeControlsLifecycle.Available &&
+        state.operation == RuntimeControlsOperation.Idle
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                contentDescription = state.accessibilityLabel
+                stateDescription = when {
+                    state.lifecycle == RuntimeControlsLifecycle.Reconnecting -> "Reconnecting"
+                    state.lifecycle == RuntimeControlsLifecycle.Synchronizing -> "Synchronizing"
+                    state.operation == RuntimeControlsOperation.Applying -> "Applying"
+                    state.operation == RuntimeControlsOperation.Queued -> "Queued for next response"
+                    state.operation == RuntimeControlsOperation.Checking -> "Checking current setting"
+                    state.snapshot?.capabilities?.available != true -> "Unavailable"
+                    else -> "Available"
+                }
+            },
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 9.dp),
+        shape = RoundedCornerShape(18.dp),
+        border = androidx.compose.foundation.BorderStroke(1.dp, CelesteHairline),
+        colors = ButtonDefaults.outlinedButtonColors(
+            contentColor = CelesteInk,
+            disabledContentColor = CelesteMuted,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "${state.modelLabel}  ·  ${state.reasoningLabel}",
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text("Change", color = CelesteBlue, fontSize = 11.sp)
+        }
+    }
+}
+
+@Composable
+private fun RuntimeControlsSheet(
+    state: RuntimeControlsUiState,
+    onModelSelected: (String, String) -> Unit,
+    onReasoningSelected: (String) -> Unit,
+    onApply: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val snapshot = state.snapshot
+    val draft = state.draft
+    val inputsEnabled = state.operation == RuntimeControlsOperation.Idle &&
+        state.lifecycle == RuntimeControlsLifecycle.Available &&
+        !state.optionsLoading
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .padding(horizontal = 24.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text("Conversation settings", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            "Effective now",
+            color = CelesteMuted,
+            fontSize = 12.sp,
+        )
+        Text(
+            text = "${state.modelLabel}  ·  ${state.reasoningLabel}",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.semantics {
+                contentDescription = "Effective ${state.accessibilityLabel}"
+            },
+        )
+        if (state.optionsLoading) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 1.7.dp,
+                    color = CelesteBlue,
+                )
+                Spacer(Modifier.size(8.dp))
+                Text("Checking supported settings…", color = CelesteMuted, fontSize = 12.sp)
+            }
+        }
+        state.message?.let { message ->
+            Text(
+                text = message,
+                color = CelesteGoldText,
+                modifier = Modifier.semantics { stateDescription = message },
+            )
+        }
+        Text("Model", style = MaterialTheme.typography.titleSmall)
+        val modelOptions = snapshot?.capabilities?.modelOptions.orEmpty()
+        if (modelOptions.isEmpty()) {
+            Text(
+                "Unavailable on this gateway. The current effective value remains readable above.",
+                color = CelesteMuted,
+                fontSize = 12.sp,
+            )
+        } else {
+            modelOptions.forEach { option ->
+                val selected = draft?.let {
+                    it.provider == option.provider && it.model == option.model
+                } == true
+                TextButton(
+                    onClick = { onModelSelected(option.provider, option.model) },
+                    enabled = inputsEnabled,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            role = Role.RadioButton
+                            stateDescription = if (selected) "Selected" else "Not selected"
+                            contentDescription = "${option.provider} ${option.model}"
+                        },
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = if (selected) "✓ ${option.provider} / ${option.model}" else {
+                            "${option.provider} / ${option.model}"
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = if (selected) CelesteInk else CelesteMuted,
+                    )
+                }
+            }
+        }
+        Text("Reasoning", style = MaterialTheme.typography.titleSmall)
+        val efforts = snapshot?.capabilities?.reasoningEfforts.orEmpty()
+        if (efforts.isEmpty() || snapshot?.capabilities?.available != true) {
+            Text(
+                "Unavailable on this gateway.",
+                color = CelesteMuted,
+                fontSize = 12.sp,
+            )
+        } else {
+            efforts.forEach { effort ->
+                val selected = draft?.reasoningEffort.equals(effort, ignoreCase = true)
+                TextButton(
+                    onClick = { onReasoningSelected(effort) },
+                    enabled = inputsEnabled,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            role = Role.RadioButton
+                            stateDescription = if (selected) "Selected" else "Not selected"
+                            contentDescription = "Reasoning $effort"
+                        },
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = if (selected) "✓ ${effort.replaceFirstChar(Char::uppercase)}" else {
+                            effort.replaceFirstChar(Char::uppercase)
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = if (selected) CelesteInk else CelesteMuted,
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 18.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(
+                onClick = onCancel,
+                enabled = true,
+            ) { Text("Cancel") }
+            Spacer(Modifier.size(8.dp))
+            Button(
+                onClick = onApply,
+                enabled = state.canApply && state.operation == RuntimeControlsOperation.Idle,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = CelesteInk,
+                    contentColor = CelestePaper,
+                    disabledContainerColor = CelesteHairline,
+                    disabledContentColor = CelesteMuted,
+                ),
+            ) {
+                if (state.operation == RuntimeControlsOperation.Applying) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 1.7.dp,
+                        color = CelestePaper,
+                    )
+                } else {
+                    Text("Apply")
                 }
             }
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -392,6 +392,7 @@ private fun RuntimeControlsPill(
         ) {
             Text(
                 text = "${state.modelLabel}  ·  ${state.reasoningLabel}",
+                modifier = Modifier.weight(1f),
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 fontSize = 12.sp,

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -8,6 +8,10 @@ import dev.hazydreams.hermesceleste.network.AuthProvider
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardProfile
+import dev.hazydreams.hermesceleste.network.RuntimeControlsCapabilities
+import dev.hazydreams.hermesceleste.network.RuntimeControlsDraft
+import dev.hazydreams.hermesceleste.network.RuntimeControlsSnapshot
+import dev.hazydreams.hermesceleste.network.RuntimeModelOption
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
 import dev.hazydreams.hermesceleste.ui.conversation.ConversationScreen
@@ -72,6 +76,66 @@ private val previewMessages = listOf(
         text = "Compared the current Hermes gateway contract with the mobile reference client.",
         id = "preview-tool-1",
     ),
+)
+
+private val previewRuntimeCapabilities = RuntimeControlsCapabilities(
+    available = true,
+    modelOptions = listOf(
+        RuntimeModelOption(provider = "nous", model = "gpt-5.6-sol", supportsReasoning = true),
+        RuntimeModelOption(provider = "nous", model = "gpt-5.6-fast", supportsReasoning = true),
+    ),
+    reasoningEfforts = listOf("none", "high", "xhigh"),
+    canApplyWhileRunning = true,
+)
+
+private val previewRuntimeSnapshot = RuntimeControlsSnapshot(
+    origin = "https://hermes.example.net",
+    profile = "work",
+    storedSessionId = "preview-runtime-session",
+    runtimeSessionId = "preview-runtime",
+    provider = "nous",
+    model = "gpt-5.6-sol",
+    reasoningEffort = "high",
+    capabilities = previewRuntimeCapabilities,
+)
+
+private val previewRuntimeDraft = RuntimeControlsDraft(
+    origin = previewRuntimeSnapshot.origin,
+    profile = previewRuntimeSnapshot.profile,
+    storedSessionId = previewRuntimeSnapshot.storedSessionId,
+    runtimeSessionId = previewRuntimeSnapshot.runtimeSessionId,
+    provider = "nous",
+    model = "gpt-5.6-fast",
+    reasoningEffort = "xhigh",
+)
+
+private val previewUnavailableRuntimeSnapshot = previewRuntimeSnapshot.copy(
+    provider = null,
+    model = null,
+    reasoningEffort = null,
+    capabilities = RuntimeControlsCapabilities.Unavailable,
+)
+
+private val previewOlderGatewayRuntimeSnapshot = previewRuntimeSnapshot.copy(
+    capabilities = RuntimeControlsCapabilities.Unavailable,
+)
+
+private fun previewRuntimeControls(
+    lifecycle: RuntimeControlsLifecycle = RuntimeControlsLifecycle.Available,
+    operation: RuntimeControlsOperation = RuntimeControlsOperation.Idle,
+    pickerOpen: Boolean = false,
+    snapshot: RuntimeControlsSnapshot = previewRuntimeSnapshot,
+    draft: RuntimeControlsDraft? = previewRuntimeDraft,
+    message: String? = null,
+    canApply: Boolean = false,
+) = RuntimeControlsUiState(
+    lifecycle = lifecycle,
+    snapshot = snapshot,
+    draft = draft,
+    pickerOpen = pickerOpen,
+    operation = operation,
+    message = message,
+    canApply = canApply,
 )
 
 private val gatewaySetupState = GatewaySettingsUiState(
@@ -340,6 +404,100 @@ fun ReconnectingPreviewScreenshot() {
             draft = "This draft stays here while the connection recovers.",
             turnState = TurnState.Reconnecting,
             errorMessage = "The dashboard connection closed before Hermes finished responding.",
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "14 · Runtime controls known", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun RuntimeControlsKnownPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                pickerOpen = true,
+                canApply = true,
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "15 · Runtime controls unavailable", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun RuntimeControlsUnavailablePreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                snapshot = previewUnavailableRuntimeSnapshot,
+                pickerOpen = true,
+                message = "Model and reasoning choices are unavailable on this gateway.",
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "16 · Runtime controls applying", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun RuntimeControlsApplyingPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                operation = RuntimeControlsOperation.Applying,
+                message = "Applying…",
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "17 · Runtime controls queued", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun RuntimeControlsQueuedPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                operation = RuntimeControlsOperation.Queued,
+                message = "Queued for next response",
+            ),
+            turnState = TurnState.Running,
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "18 · Runtime controls reconnecting", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun RuntimeControlsReconnectingPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                lifecycle = RuntimeControlsLifecycle.Reconnecting,
+                message = "Reconnecting to Hermes…",
+            ),
+            turnState = TurnState.Reconnecting,
+            errorMessage = "The dashboard connection closed before Hermes finished responding.",
+        )
+    }
+}
+
+@PreviewTest
+@Preview(name = "19 · Runtime controls older gateway", widthDp = 390, heightDp = 844, showBackground = true)
+@Composable
+fun RuntimeControlsOlderGatewayPreviewScreenshot() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                snapshot = previewOlderGatewayRuntimeSnapshot,
+                draft = null,
+                pickerOpen = true,
+                message = "This gateway cannot change that setting.",
+            ),
+            turnState = TurnState.Idle,
         )
     }
 }

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -502,6 +502,45 @@ fun RuntimeControlsOlderGatewayPreviewScreenshot() {
     }
 }
 
+@Preview(
+    name = "20 · Runtime controls large font",
+    widthDp = 390,
+    heightDp = 844,
+    fontScale = 1.5f,
+    showBackground = true,
+)
+@Composable
+fun RuntimeControlsLargeFontPreview() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                pickerOpen = true,
+                canApply = true,
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
+@Preview(
+    name = "21 · Runtime controls landscape",
+    widthDp = 844,
+    heightDp = 390,
+    showBackground = true,
+)
+@Composable
+fun RuntimeControlsLandscapePreview() {
+    HermesCelesteTheme {
+        PreviewConversation(
+            runtimeControls = previewRuntimeControls(
+                pickerOpen = true,
+                canApply = true,
+            ),
+            turnState = TurnState.Idle,
+        )
+    }
+}
+
 @Composable
 private fun PreviewConversation(
     summary: StoredSession = previewSessions[1],

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -351,6 +351,7 @@ private fun PreviewConversation(
     streamingText: String = "",
     draft: String = "",
     turnState: TurnState,
+    runtimeControls: RuntimeControlsUiState = RuntimeControlsUiState(),
     errorMessage: String? = null,
 ) {
     ConversationScreen(
@@ -359,12 +360,18 @@ private fun PreviewConversation(
         streamingText = streamingText,
         draft = draft,
         turnState = turnState,
+        runtimeControls = runtimeControls,
         loadingMessage = null,
         errorMessage = errorMessage,
         onDraftChange = {},
         onSend = {},
         onInterrupt = {},
         onReconnect = {},
+        onRuntimeControlsOpen = {},
+        onRuntimeModelSelected = { _, _ -> },
+        onRuntimeReasoningSelected = {},
+        onRuntimeControlsApply = {},
+        onRuntimeControlsCancel = {},
         onBack = {},
     )
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsAccessibilityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsAccessibilityTest.kt
@@ -1,0 +1,32 @@
+package dev.hazydreams.hermesceleste
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuntimeControlsAccessibilityTest {
+    @Test
+    fun focusRestoresOnlyWhenThePickerTransitionsFromOpenToClosed() {
+        assertTrue(shouldRestoreRuntimeControlsFocus(wasPickerOpen = true, pickerOpen = false))
+        assertFalse(shouldRestoreRuntimeControlsFocus(wasPickerOpen = false, pickerOpen = false))
+        assertFalse(shouldRestoreRuntimeControlsFocus(wasPickerOpen = false, pickerOpen = true))
+        assertFalse(shouldRestoreRuntimeControlsFocus(wasPickerOpen = true, pickerOpen = true))
+    }
+
+    @Test
+    fun operationAnnouncementsCoverApplyingQueuedAndUnknownOutcomes() {
+        assertEquals(
+            "Applying",
+            RuntimeControlsUiState(operation = RuntimeControlsOperation.Applying).operationAnnouncement,
+        )
+        assertEquals(
+            "Queued for next response",
+            RuntimeControlsUiState(operation = RuntimeControlsOperation.Queued).operationAnnouncement,
+        )
+        assertEquals(
+            "Unknown result; reconnect to verify",
+            RuntimeControlsUiState(operation = RuntimeControlsOperation.Unknown).operationAnnouncement,
+        )
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsViewModelTest.kt
@@ -111,10 +111,19 @@ class RuntimeControlsViewModelTest {
 
         gateway.emit(
             type = "session.info",
-            payload = """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"high"}""",
+            payload = """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"high","running":true,"pending_model_switch":true}""",
+        )
+        advanceUntilIdle()
+        assertEquals(RuntimeControlsOperation.Queued, viewModel.state.value.runtimeControls.operation)
+        assertEquals("gpt-5.6-sol", viewModel.state.value.runtimeControls.snapshot?.model)
+
+        gateway.emit(
+            type = "session.info",
+            payload = """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"high","running":false,"pending_model_switch":false}""",
         )
         advanceUntilIdle()
         assertEquals(RuntimeControlsOperation.Idle, viewModel.state.value.runtimeControls.operation)
+        assertEquals("gpt-5.6-fast", viewModel.state.value.runtimeControls.snapshot?.model)
         viewModel.leaveConversation()
     }
 
@@ -160,9 +169,32 @@ class RuntimeControlsViewModelTest {
 
         assertTrue(viewModel.state.value.runtimeControls.pickerOpen)
         assertFalse(viewModel.state.value.runtimeControls.canApply)
-        assertEquals("Model unavailable", viewModel.state.value.runtimeControls.modelLabel)
-        assertEquals("Reasoning unavailable", viewModel.state.value.runtimeControls.reasoningLabel)
+        assertEquals("nous / gpt-5.6-sol", viewModel.state.value.runtimeControls.modelLabel)
+        assertEquals("Reasoning high", viewModel.state.value.runtimeControls.reasoningLabel)
         viewModel.cancelRuntimeControls()
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun uncertainApplyUsesUnknownAndRetainsDraftUntilReconciled() = runTest {
+        val gateway = ControlGateway(
+            applyFailure = IOException("request timed out"),
+            failResumeAfter = 1,
+        )
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+
+        val controls = viewModel.state.value.runtimeControls
+        assertEquals(RuntimeControlsOperation.Unknown, controls.operation)
+        assertEquals(RuntimeControlsLifecycle.Reconnecting, controls.lifecycle)
+        assertEquals("gpt-5.6-sol", controls.snapshot?.model)
+        assertEquals("gpt-5.6-fast", controls.draft?.model)
+        assertTrue(controls.pickerOpen)
         viewModel.leaveConversation()
     }
 
@@ -218,12 +250,15 @@ class RuntimeControlsViewModelTest {
         private val deferredModelApply: Boolean = false,
         private val resumeIncludesEffectiveFields: Boolean = true,
         private val optionsFailure: Throwable? = null,
+        private val applyFailure: Throwable? = null,
+        private val failResumeAfter: Int? = null,
     ) : GatewayConnection {
         private val mutableState = MutableStateFlow<GatewayConnectionState>(GatewayConnectionState.Idle)
         private val mutableEvents = MutableSharedFlow<GatewayEvent>(extraBufferCapacity = 32)
         override val state: StateFlow<GatewayConnectionState> = mutableState
         override val events: SharedFlow<GatewayEvent> = mutableEvents
         val methods = mutableListOf<String>()
+        private var resumeCalls = 0
 
         override suspend fun connect() {
             mutableState.value = GatewayConnectionState.Connected
@@ -232,17 +267,26 @@ class RuntimeControlsViewModelTest {
         override suspend fun request(method: String, params: JsonObject, timeoutMillis: Long): JsonElement {
             methods += method
             return when (method) {
-                "session.resume" -> resumePayload()
+                "session.resume" -> {
+                    resumeCalls += 1
+                    if (failResumeAfter != null && resumeCalls > failResumeAfter) {
+                        throw IOException("resume timed out")
+                    }
+                    resumePayload()
+                }
                 "model.options" -> {
                     optionsFailure?.let { throw it }
                     Json.parseToJsonElement(
-                        """{"providers":[{"slug":"nous","name":"Nous","models":["gpt-5.6-sol","gpt-5.6-fast"],"capabilities":{"gpt-5.6-sol":{"reasoning":true},"gpt-5.6-fast":{"reasoning":true}}}]}""",
+                        """{"providers":[{"slug":"nous","name":"Nous","models":["gpt-5.6-sol","gpt-5.6-fast"],"capabilities":{"gpt-5.6-sol":{"reasoning":true},"gpt-5.6-fast":{"reasoning":true}}}],"reasoning_efforts":["none","high"],"can_apply_while_running":true}""",
                     )
                 }
-                "config.set" -> buildJsonObject {
-                    put("key", params["key"]?.jsonPrimitive?.content.orEmpty())
-                    put("value", params["value"]?.jsonPrimitive?.content.orEmpty())
-                    if (deferredModelApply && params["key"]?.jsonPrimitive?.content == "model") put("deferred", true)
+                "config.set" -> {
+                    applyFailure?.let { throw it }
+                    buildJsonObject {
+                        put("key", params["key"]?.jsonPrimitive?.content.orEmpty())
+                        put("value", params["value"]?.jsonPrimitive?.content.orEmpty())
+                        if (deferredModelApply && params["key"]?.jsonPrimitive?.content == "model") put("deferred", true)
+                    }
                 }
                 "session.list" -> buildJsonObject {}
                 else -> buildJsonObject {}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsViewModelTest.kt
@@ -1,0 +1,274 @@
+package dev.hazydreams.hermesceleste
+
+import java.io.IOException
+import dev.hazydreams.hermesceleste.network.AuthProvider
+import dev.hazydreams.hermesceleste.network.DashboardProbeResult
+import dev.hazydreams.hermesceleste.network.DashboardProfile
+import dev.hazydreams.hermesceleste.network.DashboardService
+import dev.hazydreams.hermesceleste.network.GatewayConnection
+import dev.hazydreams.hermesceleste.network.GatewayConnectionState
+import dev.hazydreams.hermesceleste.network.GatewayCredential
+import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.StoredSession
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RuntimeControlsViewModelTest {
+    private val mainDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun cancelClosesDraftWithoutSendingConfigSet() = runTest {
+        val gateway = ControlGateway()
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        viewModel.cancelRuntimeControls()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.runtimeControls.pickerOpen)
+        assertNull(viewModel.state.value.runtimeControls.draft)
+        assertEquals(0, gateway.methods.count { it == "config.set" })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun applyKeepsOldEffectiveValueUntilAuthoritativeSessionInfo() = runTest {
+        val gateway = ControlGateway()
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+
+        assertEquals("gpt-5.6-sol", viewModel.state.value.runtimeControls.snapshot?.model)
+        assertEquals(RuntimeControlsOperation.Applying, viewModel.state.value.runtimeControls.operation)
+        assertEquals(1, gateway.methods.count { it == "config.set" })
+
+        gateway.emit(
+            type = "session.info",
+            payload = """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"high"}""",
+        )
+        advanceUntilIdle()
+
+        assertEquals("gpt-5.6-fast", viewModel.state.value.runtimeControls.snapshot?.model)
+        assertEquals(RuntimeControlsOperation.Idle, viewModel.state.value.runtimeControls.operation)
+        assertNull(viewModel.state.value.runtimeControls.draft)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun deferredRunningApplyShowsQueuedAndDoesNotInventAnEffectiveChange() = runTest {
+        val gateway = ControlGateway(deferredModelApply = true)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+        gateway.emit("session.busy", """{"busy":true}""")
+        advanceUntilIdle()
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+
+        assertEquals(RuntimeControlsOperation.Queued, viewModel.state.value.runtimeControls.operation)
+        assertEquals("gpt-5.6-sol", viewModel.state.value.runtimeControls.snapshot?.model)
+        assertEquals("Queued for next response", viewModel.state.value.runtimeControls.message)
+
+        gateway.emit(
+            type = "session.info",
+            payload = """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"high"}""",
+        )
+        advanceUntilIdle()
+        assertEquals(RuntimeControlsOperation.Idle, viewModel.state.value.runtimeControls.operation)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun staleRuntimeEventCannotOverwriteTheActivePill() = runTest {
+        val gateway = ControlGateway()
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        gateway.emit(
+            type = "session.info",
+            sessionId = "old-runtime",
+            payload = """{"profile_name":"work","model":"wrong-model","provider":"wrong-provider"}""",
+        )
+        advanceUntilIdle()
+
+        assertEquals("gpt-5.6-sol", viewModel.state.value.runtimeControls.snapshot?.model)
+        assertEquals("nous", viewModel.state.value.runtimeControls.snapshot?.provider)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun missingEffectiveFieldsRemainUnavailableInsteadOfUsingProfileDefault() = runTest {
+        val gateway = ControlGateway(resumeIncludesEffectiveFields = false)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        val snapshot = viewModel.state.value.runtimeControls.snapshot
+        assertNull(snapshot?.model)
+        assertNull(snapshot?.provider)
+        assertEquals("Model unavailable", viewModel.state.value.runtimeControls.modelLabel)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun olderGatewayLeavesEffectiveStateReadableButDisablesPickerApply() = runTest {
+        val gateway = ControlGateway(optionsFailure = IOException("unknown method"))
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.runtimeControls.pickerOpen)
+        assertFalse(viewModel.state.value.runtimeControls.canApply)
+        assertEquals("Model unavailable", viewModel.state.value.runtimeControls.modelLabel)
+        assertEquals("Reasoning unavailable", viewModel.state.value.runtimeControls.reasoningLabel)
+        viewModel.cancelRuntimeControls()
+        viewModel.leaveConversation()
+    }
+
+    private suspend fun openConversation(
+        dashboard: ControlDashboard,
+        gateway: ControlGateway,
+    ): CelesteViewModel {
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+        return viewModel
+    }
+
+    private class ControlDashboard(
+        private val gateway: ControlGateway,
+    ) : DashboardService {
+        val session = StoredSession(
+            id = "stored-42",
+            title = "Shared conversation",
+            preview = "",
+            startedAt = 1.0,
+            messageCount = 0,
+            source = "desktop",
+            profile = "work",
+        )
+
+        override suspend fun probe(rawBaseUrl: String) = DashboardProbeResult(
+            baseUrl = rawBaseUrl,
+            authRequired = false,
+            providers = emptyList<AuthProvider>(),
+            version = "test",
+        )
+
+        override suspend fun passwordLogin(baseUrl: String, provider: String, username: String, password: String) = Unit
+
+        override suspend fun listSessions(baseUrl: String, credential: GatewayCredential, limit: Int) = listOf(session)
+
+        override suspend fun listProfiles(baseUrl: String, credential: GatewayCredential) = listOf(
+            DashboardProfile(name = "default", isDefault = true, model = "profile-default", provider = "profile-provider"),
+            DashboardProfile(name = "work", model = "work-default", provider = "work-provider"),
+        )
+
+        override fun createGateway(baseUrl: String, credential: GatewayCredential): GatewayConnection = gateway
+    }
+
+    private class ControlGateway(
+        private val deferredModelApply: Boolean = false,
+        private val resumeIncludesEffectiveFields: Boolean = true,
+        private val optionsFailure: Throwable? = null,
+    ) : GatewayConnection {
+        private val mutableState = MutableStateFlow<GatewayConnectionState>(GatewayConnectionState.Idle)
+        private val mutableEvents = MutableSharedFlow<GatewayEvent>(extraBufferCapacity = 32)
+        override val state: StateFlow<GatewayConnectionState> = mutableState
+        override val events: SharedFlow<GatewayEvent> = mutableEvents
+        val methods = mutableListOf<String>()
+
+        override suspend fun connect() {
+            mutableState.value = GatewayConnectionState.Connected
+        }
+
+        override suspend fun request(method: String, params: JsonObject, timeoutMillis: Long): JsonElement {
+            methods += method
+            return when (method) {
+                "session.resume" -> resumePayload()
+                "model.options" -> {
+                    optionsFailure?.let { throw it }
+                    Json.parseToJsonElement(
+                        """{"providers":[{"slug":"nous","name":"Nous","models":["gpt-5.6-sol","gpt-5.6-fast"],"capabilities":{"gpt-5.6-sol":{"reasoning":true},"gpt-5.6-fast":{"reasoning":true}}}]}""",
+                    )
+                }
+                "config.set" -> buildJsonObject {
+                    put("key", params["key"]?.jsonPrimitive?.content.orEmpty())
+                    put("value", params["value"]?.jsonPrimitive?.content.orEmpty())
+                    if (deferredModelApply && params["key"]?.jsonPrimitive?.content == "model") put("deferred", true)
+                }
+                "session.list" -> buildJsonObject {}
+                else -> buildJsonObject {}
+            }
+        }
+
+        override fun close() {
+            mutableState.value = GatewayConnectionState.Closed
+        }
+
+        fun emit(type: String, payload: String = "{}", sessionId: String = "runtime-7") {
+            mutableEvents.tryEmit(
+                GatewayEvent(
+                    type = type,
+                    sessionId = sessionId,
+                    payload = Json.parseToJsonElement(payload) as JsonObject,
+                ),
+            )
+        }
+
+        private fun resumePayload(): JsonObject = Json.parseToJsonElement(
+            if (resumeIncludesEffectiveFields) {
+                """{"session_id":"runtime-7","resumed":"stored-42","running":false,"status":"idle","info":{"profile_name":"work","model":"gpt-5.6-sol","provider":"nous","reasoning_effort":"high"},"messages":[]}"""
+            } else {
+                """{"session_id":"runtime-7","resumed":"stored-42","running":false,"status":"idle","info":{"profile_name":"work"},"messages":[]}"""
+            },
+        ) as JsonObject
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/RuntimeControlsViewModelTest.kt
@@ -12,6 +12,7 @@ import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.StoredSession
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -128,6 +129,89 @@ class RuntimeControlsViewModelTest {
     }
 
     @Test
+    fun clearedDeferredSwitchReopensPickerWithRetryableDraft() = runTest {
+        val gateway = ControlGateway(deferredModelApply = true)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+        gateway.emit("session.busy", """{"busy":true}""")
+        advanceUntilIdle()
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+
+        gateway.emit(
+            type = "session.info",
+            payload = """{"profile_name":"work","model":"gpt-5.6-sol","provider":"nous","reasoning_effort":"high","running":true,"pending_model_switch":false}""",
+        )
+        advanceUntilIdle()
+
+        val controls = viewModel.state.value.runtimeControls
+        assertEquals(RuntimeControlsOperation.Idle, controls.operation)
+        assertTrue(controls.pickerOpen)
+        assertEquals("gpt-5.6-fast", controls.draft?.model)
+        assertTrue(controls.canApply)
+        assertEquals("Hermes did not apply that queued change. Review and apply again.", controls.message)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun explicitPartialAcknowledgementReconcilesBeforeReopeningPicker() = runTest {
+        val gateway = ControlGateway(rejectReasoningApply = true)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        viewModel.selectRuntimeReasoning("none")
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+
+        val controls = viewModel.state.value.runtimeControls
+        assertEquals(2, gateway.methods.count { it == "config.set" })
+        assertEquals(RuntimeControlsOperation.Idle, controls.operation)
+        assertTrue(controls.pickerOpen)
+        assertEquals("gpt-5.6-fast", controls.draft?.model)
+        assertEquals("Only part of that change was applied. Review the current setting.", controls.message)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun modelAndExistingReasoningMustBeAdvertisedAsACompatiblePair() = runTest {
+        val gateway = ControlGateway(fastModelSupportsReasoning = false)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.runtimeControls.canApply)
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+        assertEquals(0, gateway.methods.count { it == "config.set" })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun busyUnsupportedApplyExplainsHowToRetry() = runTest {
+        val gateway = ControlGateway(canApplyWhileRunning = false)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+        gateway.emit("session.busy", """{"busy":true}""")
+        advanceUntilIdle()
+
+        viewModel.openRuntimeControls()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.state.value.runtimeControls.canApply)
+        assertEquals("Apply when this response finishes.", viewModel.state.value.runtimeControls.message)
+        viewModel.cancelRuntimeControls()
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun staleRuntimeEventCannotOverwriteTheActivePill() = runTest {
         val gateway = ControlGateway()
         val dashboard = ControlDashboard(gateway)
@@ -142,6 +226,58 @@ class RuntimeControlsViewModelTest {
 
         assertEquals("gpt-5.6-sol", viewModel.state.value.runtimeControls.snapshot?.model)
         assertEquals("nous", viewModel.state.value.runtimeControls.snapshot?.provider)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun staleCapabilityReadIsDiscardedAndRefreshedAgainstTheNewSnapshot() = runTest {
+        val optionsGate = CompletableDeferred<Unit>()
+        val gateway = ControlGateway(optionsGate = optionsGate)
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        gateway.emit(
+            type = "session.info",
+            payload = """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"high"}""",
+        )
+        optionsGate.complete(Unit)
+        advanceUntilIdle()
+
+        val controls = viewModel.state.value.runtimeControls
+        assertEquals("gpt-5.6-fast", controls.snapshot?.model)
+        assertFalse(controls.optionsLoading)
+        assertEquals(2, gateway.methods.count { it == "model.options" })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun overlappingReconciliationsSerializeResumeAndDoNotRunConcurrently() = runTest {
+        val resumeGate = CompletableDeferred<Unit>()
+        val gateway = ControlGateway(
+            resumeGate = resumeGate,
+            blockResumeAfter = 2,
+        )
+        val dashboard = ControlDashboard(gateway)
+        val viewModel = openConversation(dashboard, gateway)
+
+        viewModel.openRuntimeControls()
+        viewModel.selectRuntimeModel("nous", "gpt-5.6-fast")
+        viewModel.applyRuntimeControls()
+        advanceUntilIdle()
+
+        viewModel.updateDraft("A message that is unrelated to the control reconciliation")
+        viewModel.sendMessage()
+        viewModel.interrupt()
+        advanceUntilIdle()
+
+        assertEquals(1, gateway.activeResumeCalls)
+        assertEquals(1, gateway.maxConcurrentResumeCalls)
+        resumeGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(3, gateway.methods.count { it == "session.resume" })
+        assertEquals(1, gateway.maxConcurrentResumeCalls)
         viewModel.leaveConversation()
     }
 
@@ -252,12 +388,22 @@ class RuntimeControlsViewModelTest {
         private val optionsFailure: Throwable? = null,
         private val applyFailure: Throwable? = null,
         private val failResumeAfter: Int? = null,
+        private val optionsGate: CompletableDeferred<Unit>? = null,
+        private val rejectReasoningApply: Boolean = false,
+        private val fastModelSupportsReasoning: Boolean = true,
+        private val canApplyWhileRunning: Boolean = true,
+        private val resumeGate: CompletableDeferred<Unit>? = null,
+        private val blockResumeAfter: Int? = null,
     ) : GatewayConnection {
         private val mutableState = MutableStateFlow<GatewayConnectionState>(GatewayConnectionState.Idle)
         private val mutableEvents = MutableSharedFlow<GatewayEvent>(extraBufferCapacity = 32)
         override val state: StateFlow<GatewayConnectionState> = mutableState
         override val events: SharedFlow<GatewayEvent> = mutableEvents
         val methods = mutableListOf<String>()
+        var activeResumeCalls = 0
+            private set
+        var maxConcurrentResumeCalls = 0
+            private set
         private var resumeCalls = 0
 
         override suspend fun connect() {
@@ -272,20 +418,38 @@ class RuntimeControlsViewModelTest {
                     if (failResumeAfter != null && resumeCalls > failResumeAfter) {
                         throw IOException("resume timed out")
                     }
+                    val gate = resumeGate
+                    if (gate != null &&
+                        (blockResumeAfter == null || resumeCalls >= blockResumeAfter)
+                    ) {
+                        activeResumeCalls += 1
+                        maxConcurrentResumeCalls = maxOf(maxConcurrentResumeCalls, activeResumeCalls)
+                        try {
+                            gate.await()
+                        } finally {
+                            activeResumeCalls -= 1
+                        }
+                    }
                     resumePayload()
                 }
                 "model.options" -> {
+                    optionsGate?.await()
                     optionsFailure?.let { throw it }
                     Json.parseToJsonElement(
-                        """{"providers":[{"slug":"nous","name":"Nous","models":["gpt-5.6-sol","gpt-5.6-fast"],"capabilities":{"gpt-5.6-sol":{"reasoning":true},"gpt-5.6-fast":{"reasoning":true}}}],"reasoning_efforts":["none","high"],"can_apply_while_running":true}""",
+                        """{"providers":[{"slug":"nous","name":"Nous","models":["gpt-5.6-sol","gpt-5.6-fast"],"capabilities":{"gpt-5.6-sol":{"reasoning":true},"gpt-5.6-fast":{"reasoning":$fastModelSupportsReasoning}}}],"reasoning_efforts":["none","high"],"can_apply_while_running":$canApplyWhileRunning}""",
                     )
                 }
                 "config.set" -> {
                     applyFailure?.let { throw it }
+                    val key = params["key"]?.jsonPrimitive?.content.orEmpty()
                     buildJsonObject {
                         put("key", params["key"]?.jsonPrimitive?.content.orEmpty())
                         put("value", params["value"]?.jsonPrimitive?.content.orEmpty())
                         if (deferredModelApply && params["key"]?.jsonPrimitive?.content == "model") put("deferred", true)
+                        if (rejectReasoningApply && key == "reasoning") {
+                            put("accepted", false)
+                            put("ok", false)
+                        }
                     }
                 }
                 "session.list" -> buildJsonObject {}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/RuntimeControlsProtocolTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/RuntimeControlsProtocolTest.kt
@@ -1,0 +1,189 @@
+package dev.hazydreams.hermesceleste.network
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuntimeControlsProtocolTest {
+    @Test
+    fun modelOptionsDecodeCapabilitiesAndIgnoreUnknownFields() {
+        val capabilities = decodeRuntimeControlsCapabilities(
+            Json.parseToJsonElement(
+                """
+                {
+                  "providers": [
+                    {
+                      "slug": "nous",
+                      "name": "Nous Portal",
+                      "models": ["gpt-5.6-sol", "gpt-5.6-fast"],
+                      "capabilities": {
+                        "gpt-5.6-sol": {"reasoning": true, "fast": false},
+                        "gpt-5.6-fast": {"reasoning": false, "fast": true}
+                      },
+                      "future_field": {"ignore": true}
+                    }
+                  ],
+                  "can_apply_while_running": true,
+                  "future_root_field": "ignore"
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertTrue(capabilities.available)
+        assertTrue(capabilities.canApplyWhileRunning)
+        assertEquals(
+            listOf("gpt-5.6-sol", "gpt-5.6-fast"),
+            capabilities.modelOptions.map(RuntimeModelOption::model),
+        )
+        assertTrue(capabilities.modelOptions.first().supportsReasoning)
+        assertFalse(capabilities.modelOptions.last().supportsReasoning)
+        assertTrue(capabilities.modelOptions.last().supportsFast)
+    }
+
+    @Test
+    fun malformedOptionsBecomeUnavailableInsteadOfInventingChoices() {
+        val capabilities = decodeRuntimeControlsCapabilities(
+            Json.parseToJsonElement("{\"providers\": [{\"slug\": 7, \"models\": [true]}]}") ,
+        )
+
+        assertFalse(capabilities.available)
+        assertTrue(capabilities.modelOptions.isEmpty())
+    }
+
+    @Test
+    fun resumeAndSessionInfoDecodeEffectiveFieldsWithoutUsingCatalogDefaults() {
+        val resumed = decodeRuntimeControlsInfo(
+            Json.parseToJsonElement(
+                """
+                {
+                  "session_id": "runtime-7",
+                  "resumed": "stored-42",
+                  "info": {
+                    "profile_name": "work",
+                    "model": "gpt-5.6-sol",
+                    "provider": "nous",
+                    "reasoning_effort": "xhigh"
+                  },
+                  "running": false,
+                  "profile_default": {"model": "profile-default"}
+                }
+                """.trimIndent(),
+            ) as JsonObject,
+            authoritative = true,
+        )
+        val event = decodeRuntimeControlsInfo(
+            Json.parseToJsonElement(
+                """{"profile_name":"work","model":"gpt-5.6-fast","provider":"nous","reasoning_effort":"none"}""",
+            ) as JsonObject,
+            authoritative = true,
+        )
+
+        assertEquals("work", resumed.profile)
+        assertEquals("stored-42", resumed.storedSessionId)
+        assertEquals("gpt-5.6-sol", resumed.model)
+        assertEquals("nous", resumed.provider)
+        assertEquals("xhigh", resumed.reasoningEffort)
+        assertEquals("gpt-5.6-fast", event.model)
+        assertEquals("none", event.reasoningEffort)
+    }
+
+    @Test
+    fun applyUsesSessionScopedOfficialConfigSetAndReportsDeferred() = runBlocking {
+        val gateway = RecordingGateway(
+            responses = ArrayDeque(
+                listOf(
+                    Json.parseToJsonElement(
+                        """{"key":"model","value":"gpt-5.6-fast","deferred":true}""",
+                    ),
+                    Json.parseToJsonElement("""{"key":"reasoning","value":"high"}"""),
+                ),
+            ),
+        )
+
+        val result = gateway.applyRuntimeControls(
+            runtimeSessionId = "runtime-7",
+            provider = "nous",
+            model = "gpt-5.6-fast",
+            reasoningEffort = "high",
+            applyModel = true,
+            applyReasoning = true,
+        )
+
+        assertTrue(result.deferred)
+        assertEquals(listOf("config.set", "config.set"), gateway.methods)
+        assertEquals("model", gateway.requests[0]["key"]?.jsonPrimitive?.content)
+        assertEquals(
+            "gpt-5.6-fast --provider nous --session",
+            gateway.requests[0]["value"]?.jsonPrimitive?.content,
+        )
+        assertEquals("runtime-7", gateway.requests[0]["session_id"]?.jsonPrimitive?.content)
+        assertEquals("reasoning", gateway.requests[1]["key"]?.jsonPrimitive?.content)
+        assertEquals("high", gateway.requests[1]["value"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun secondOfficialWriteFailureIsMarkedPartial() = runBlocking {
+        val gateway = RecordingGateway(
+            responses = ArrayDeque(
+                listOf(
+                    Json.parseToJsonElement("""{"key":"model","value":"new-model"}"""),
+                ),
+            ),
+            failure = GatewayRpcException(4002, "reasoning rejected"),
+        )
+
+        val failure = runCatching {
+            gateway.applyRuntimeControls(
+                runtimeSessionId = "runtime-7",
+                provider = "nous",
+                model = "new-model",
+                reasoningEffort = "high",
+                applyModel = true,
+                applyReasoning = true,
+            )
+        }.exceptionOrNull()
+
+        assertNotNull(failure)
+        assertTrue(failure is RuntimeControlsPartialApplyException)
+        assertEquals(2, gateway.methods.size)
+    }
+
+    private class RecordingGateway(
+        private val responses: ArrayDeque<JsonElement>,
+        private val failure: Throwable? = null,
+    ) : GatewayConnection {
+        private val mutableState = MutableStateFlow<GatewayConnectionState>(GatewayConnectionState.Connected)
+        private val mutableEvents = MutableSharedFlow<GatewayEvent>(extraBufferCapacity = 4)
+        override val state = mutableState
+        override val events = mutableEvents
+        val methods = mutableListOf<String>()
+        val requests = mutableListOf<JsonObject>()
+
+        override suspend fun connect() = Unit
+
+        override suspend fun request(
+            method: String,
+            params: JsonObject,
+            timeoutMillis: Long,
+        ): JsonElement {
+            methods += method
+            requests += params
+            failure?.let { throw it }
+            return responses.removeFirstOrNull() ?: buildJsonObject {}
+        }
+
+        override fun close() = Unit
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/RuntimeControlsProtocolTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/RuntimeControlsProtocolTest.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -42,7 +43,8 @@ class RuntimeControlsProtocolTest {
         )
 
         assertTrue(capabilities.available)
-        assertTrue(capabilities.canApplyWhileRunning)
+        assertEquals(true, capabilities.canApplyWhileRunning)
+        assertTrue(capabilities.reasoningEfforts.isEmpty())
         assertEquals(
             listOf("gpt-5.6-sol", "gpt-5.6-fast"),
             capabilities.modelOptions.map(RuntimeModelOption::model),
@@ -55,11 +57,25 @@ class RuntimeControlsProtocolTest {
     @Test
     fun malformedOptionsBecomeUnavailableInsteadOfInventingChoices() {
         val capabilities = decodeRuntimeControlsCapabilities(
-            Json.parseToJsonElement("{\"providers\": [{\"slug\": 7, \"models\": [true]}]}") ,
+            Json.parseToJsonElement("{\"providers\": [{\"slug\": 7, \"models\": [true]}]}"),
         )
 
         assertFalse(capabilities.available)
         assertTrue(capabilities.modelOptions.isEmpty())
+    }
+
+    @Test
+    fun omittedCapabilityFieldsDoNotEnableUnsupportedRuntimeChanges() {
+        val capabilities = decodeRuntimeControlsCapabilities(
+            Json.parseToJsonElement(
+                """{"providers":[{"slug":"nous","models":["gpt-5.6-sol"]}]}""",
+            ),
+        )
+
+        assertTrue(capabilities.available)
+        assertFalse(capabilities.modelOptions.single().supportsReasoning)
+        assertTrue(capabilities.reasoningEfforts.isEmpty())
+        assertNull(capabilities.canApplyWhileRunning)
     }
 
     @Test
@@ -141,6 +157,7 @@ class RuntimeControlsProtocolTest {
                     Json.parseToJsonElement("""{"key":"model","value":"new-model"}"""),
                 ),
             ),
+            failureOnRequest = 2,
             failure = GatewayRpcException(4002, "reasoning rejected"),
         )
 
@@ -162,6 +179,7 @@ class RuntimeControlsProtocolTest {
 
     private class RecordingGateway(
         private val responses: ArrayDeque<JsonElement>,
+        private val failureOnRequest: Int? = null,
         private val failure: Throwable? = null,
     ) : GatewayConnection {
         private val mutableState = MutableStateFlow<GatewayConnectionState>(GatewayConnectionState.Connected)
@@ -180,7 +198,7 @@ class RuntimeControlsProtocolTest {
         ): JsonElement {
             methods += method
             requests += params
-            failure?.let { throw it }
+            if (failureOnRequest == methods.size) failure?.let { throw it }
             return responses.removeFirstOrNull() ?: buildJsonObject {}
         }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/RuntimeControlsProtocolTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/RuntimeControlsProtocolTest.kt
@@ -79,6 +79,18 @@ class RuntimeControlsProtocolTest {
     }
 
     @Test
+    fun explicitMutabilityCapabilitiesAreDecoded() {
+        val capabilities = decodeRuntimeControlsCapabilities(
+            Json.parseToJsonElement(
+                """{"providers":[{"slug":"nous","models":["gpt-5.6-sol"]}],"mutability":{"model":false,"reasoning":true}}""",
+            ),
+        )
+
+        assertEquals(false, capabilities.canChangeModel)
+        assertEquals(true, capabilities.canChangeReasoning)
+    }
+
+    @Test
     fun resumeAndSessionInfoDecodeEffectiveFieldsWithoutUsingCatalogDefaults() {
         val resumed = decodeRuntimeControlsInfo(
             Json.parseToJsonElement(
@@ -147,6 +159,82 @@ class RuntimeControlsProtocolTest {
         assertEquals("runtime-7", gateway.requests[0]["session_id"]?.jsonPrimitive?.content)
         assertEquals("reasoning", gateway.requests[1]["key"]?.jsonPrimitive?.content)
         assertEquals("high", gateway.requests[1]["value"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun definiteFirstWriteRejectionStopsBeforeTheSecondWrite() = runBlocking {
+        val gateway = RecordingGateway(
+            responses = ArrayDeque(
+                listOf(
+                    Json.parseToJsonElement("""{"key":"model","accepted":false,"ok":false}"""),
+                    Json.parseToJsonElement("""{"key":"reasoning","accepted":true}"""),
+                ),
+            ),
+        )
+
+        val result = gateway.applyRuntimeControls(
+            runtimeSessionId = "runtime-7",
+            provider = "nous",
+            model = "new-model",
+            reasoningEffort = "high",
+            applyModel = true,
+            applyReasoning = true,
+        )
+
+        assertFalse(result.acknowledged)
+        assertFalse(result.partial)
+        assertEquals(listOf("config.set"), gateway.methods)
+        assertEquals(RuntimeControlsWriteStatus.Rejected, result.writes.single().status)
+    }
+
+    @Test
+    fun explicitSecondWriteRejectionIsReportedAsPartial() = runBlocking {
+        val gateway = RecordingGateway(
+            responses = ArrayDeque(
+                listOf(
+                    Json.parseToJsonElement("""{"key":"model","accepted":true}"""),
+                    Json.parseToJsonElement("""{"key":"reasoning","accepted":false,"ok":false}"""),
+                ),
+            ),
+        )
+
+        val result = gateway.applyRuntimeControls(
+            runtimeSessionId = "runtime-7",
+            provider = "nous",
+            model = "new-model",
+            reasoningEffort = "high",
+            applyModel = true,
+            applyReasoning = true,
+        )
+
+        assertFalse(result.acknowledged)
+        assertTrue(result.partial)
+        assertEquals(listOf("config.set", "config.set"), gateway.methods)
+        assertEquals(
+            listOf(RuntimeControlsWriteStatus.Accepted, RuntimeControlsWriteStatus.Rejected),
+            result.writes.map { it.status },
+        )
+    }
+
+    @Test
+    fun configFallbackRequiresAnExplicitSessionScopeMarker() {
+        val profileDefault = decodeRuntimeControlsConfig(
+            Json.parseToJsonElement(
+                """{"session_id":"runtime-7","scope":"profile","model":"profile-default"}""",
+            ),
+            runtimeSessionId = "runtime-7",
+        )
+        val sessionValue = decodeRuntimeControlsConfig(
+            Json.parseToJsonElement(
+                """{"session_id":"runtime-7","scope":"session","model":"session-model"}""",
+            ),
+            runtimeSessionId = "runtime-7",
+        )
+
+        assertFalse(profileDefault.authoritative)
+        assertNull(profileDefault.model)
+        assertTrue(sessionValue.authoritative)
+        assertEquals("session-model", sessionValue.model)
     }
 
     @Test


### PR DESCRIPTION
## DF-04 scope
- Adds the DF-04 conversation model and reasoning controls across the Celeste conversation flow, including dashboard/gateway wiring, UI/state handling, and coverage.
- This branch also carries the paired DF-04/CF-04 specs and the temporary backlog tracker.

## Luna review status
- Luna spec: PASS.
- Luna quality: APPROVED through commit `5b12e163ba4b206492ca1c6ecc37d280551d4f34`.

## Validation limits
- Local Gradle, unit, lint, screenshot, Android, device, and APK gates were not run on the constrained VPS.
- Large-font and landscape screenshot acceptance remains owner-gated; these are ordinary `@Preview` scenarios, and no accepted PNG references were changed.

## Merge
- No merge requested.