### PR TITLE
fix: preserve conversation context above the keyboard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,14 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
 
+    androidTestImplementation("androidx.activity:activity-compose:1.13.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.compose.material3:material3")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test:rules:1.7.0")
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
+
     screenshotTestImplementation(composeBom)
     screenshotTestImplementation("androidx.compose.ui:ui-tooling")
     screenshotTestImplementation("com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha16")

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="dev.hazydreams.hermesceleste.ui.conversation.ConversationViewportTestActivity"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertHasScrollAction
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasSetTextAction
@@ -13,6 +14,7 @@ import androidx.compose.ui.test.onNode
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -154,6 +156,125 @@ class ConversationViewportDeviceTest {
         assertTerminalClearsDock()
     }
 
+    @Test
+    fun repeatedAndCancelledImeTransitionsRetryUntilInsetsSettle() {
+        updateContent {
+            setContentInsets(bottom = 320, settled = false)
+        }
+        updateContent {
+            setContentInsets(bottom = 0, settled = false)
+        }
+        updateContent {
+            setContentInsets(bottom = 48, settled = true)
+        }
+
+        composeRule.onNodeWithContentDescription("Message composer").assertIsDisplayed()
+        assertTerminalClearsDock()
+    }
+
+    @Test
+    fun streamingAndTallRowsFollowLatestButPreserveAHistoryReader() {
+        composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
+
+        updateContent {
+            setContentStreamingText(longStreamingText())
+        }
+        composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
+        assertTerminalClearsDock()
+
+        val transcript = composeRule.onNodeWithContentDescription("Conversation transcript")
+        transcript.performScrollToIndex(5)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(syntheticRowText(5)).assertIsDisplayed()
+
+        updateContent {
+            setContentStreamingText(longStreamingText() + " newer delta")
+        }
+        composeRule.onNodeWithText(syntheticRowText(5)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+    }
+
+    @Test
+    fun removedHistoryAnchorFallsBackSafelyAndKeepsJumpRecoveryAvailable() {
+        composeRule.onNodeWithContentDescription("Conversation transcript")
+            .performScrollToIndex(18)
+        composeRule.waitForIdle()
+
+        updateContent {
+            setContentMessages(syntheticMessages.take(4))
+            setContentProjectionGeneration(1L)
+        }
+
+        composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertDoesNotExist()
+    }
+
+    @Test
+    fun reconnectProjectionGenerationCancelsStaleTransitionAndPreservesHistory() {
+        composeRule.onNodeWithContentDescription("Conversation transcript")
+            .performScrollToIndex(6)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(syntheticRowText(6)).assertIsDisplayed()
+
+        updateContent {
+            setContentInsets(bottom = 320, settled = false)
+            setContentProjectionGeneration(1L)
+        }
+        updateContent {
+            setContentProjectionGeneration(2L)
+            setContentInsets(bottom = 48, settled = true)
+        }
+
+        composeRule.onNodeWithText(syntheticRowText(6)).assertIsDisplayed()
+    }
+
+    @Test
+    fun switchingSessionsDisposesPendingJumpWorkBeforeRenderingTheNewList() {
+        composeRule.onNodeWithContentDescription("Conversation transcript")
+            .performScrollToIndex(4)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Jump to latest").performClick()
+
+        updateContent {
+            setContentSummary(
+                syntheticSummary.copy(
+                    id = "instrumentation-session-two",
+                    title = "Second synthetic conversation",
+                ),
+            )
+            setContentMessages(syntheticMessages.takeLast(6))
+        }
+
+        composeRule.onNodeWithText("Second synthetic conversation").assertIsDisplayed()
+        composeRule.onNodeWithText("Synthetic conversation").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
+    }
+
+    @Test
+    fun reconnectErrorKeepsDraftAndRetryActionReachable() {
+        composeRule.onNodeWithContentDescription("Conversation transcript")
+            .performScrollToIndex(5)
+        composeRule.waitForIdle()
+        updateContent {
+            setContentDraft("draft survives reconnect")
+            setContentTurnState(TurnState.Reconnecting)
+            setContentStatus(
+                loading = "Reconnecting to Hermes…",
+                error = "Synthetic reconnect error",
+            )
+        }
+
+        composeRule.onNodeWithText("draft survives reconnect").assertIsDisplayed()
+        composeRule.onNodeWithText("Synthetic reconnect error").assertIsDisplayed()
+        composeRule.onNodeWithText(syntheticRowText(5)).assertIsDisplayed()
+        composeRule.onNodeWithText("Retry").performClick()
+        assertEquals(1, composeRule.activity.reconnectCalls)
+    }
+
     private fun setSyntheticContent(bottomInsetPx: Int, topInsetPx: Int = 0) {
         composeRule.setContent {
             HermesCelesteTheme {
@@ -178,6 +299,21 @@ class ConversationViewportDeviceTest {
         }
         composeRule.waitForIdle()
     }
+
+    private fun updateContent(update: ConversationViewportTestActivity.() -> Unit) {
+        composeRule.runOnUiThread {
+            composeRule.activity.update()
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun syntheticRowText(index: Int): String =
+        "Synthetic transcript row $index. This content exists only to exercise viewport geometry."
+
+    private fun longStreamingText(): String =
+        (0 until 80).joinToString(" ") { index ->
+            "Synthetic streaming paragraph $index grows the terminal row."
+        }
 
     private fun assertTerminalClearsDock() {
         val terminalBottom = composeRule.onNodeWithContentDescription("Terminal transcript row")

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
@@ -1,0 +1,204 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+import android.os.Build
+import android.view.WindowInsets as AndroidWindowInsets
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertHasScrollAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNode
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import dev.hazydreams.hermesceleste.TurnState
+import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ConversationViewportDeviceTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ConversationViewportTestActivity>()
+
+    private val device: UiDevice by lazy {
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    }
+
+    @Test
+    fun visibleImeInsetKeepsComposerAndTerminalRowSeparated() {
+        setSyntheticContent(bottomInsetPx = 320, topInsetPx = 24)
+        assertTerminalClearsDock()
+        composeRule.onNodeWithContentDescription("Message composer").assertIsDisplayed()
+    }
+
+    @Test
+    fun navigationOnlyInsetUsesOneBottomOwner() {
+        setSyntheticContent(bottomInsetPx = 48)
+        assertTerminalClearsDock()
+        composeRule.onNodeWithContentDescription("Conversation transcript").assertHasScrollAction()
+    }
+
+    @Test
+    fun cutoutSafeDrawingKeepsHeaderAndActionsReachable() {
+        setSyntheticContent(bottomInsetPx = 48, topInsetPx = 56)
+        composeRule.onNodeWithText("←  Back").assertIsDisplayed()
+        composeRule.onNodeWithText("Synthetic conversation").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Message composer").assertIsDisplayed()
+    }
+
+    @Test
+    fun transcriptAndComposerExposeTalkBackSemantics() {
+        composeRule.onNodeWithContentDescription("Conversation transcript").assertHasScrollAction()
+        composeRule.onNodeWithContentDescription("Message composer").assertIsDisplayed()
+        composeRule.onNodeWithText("←  Back").assertIsDisplayed()
+        composeRule.onNodeWithText("Send  →").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
+    }
+
+    @Test
+    fun largeFontScaleKeepsAllComposerActionsContentSized() {
+        composeRule.runOnUiThread { composeRule.activity.setContentFontScale(2f) }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Send  →").assertIsDisplayed()
+
+        composeRule.runOnUiThread {
+            composeRule.activity.setContentTurnState(TurnState.Running)
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Stop").assertIsDisplayed()
+
+        composeRule.runOnUiThread {
+            composeRule.activity.setContentTurnState(TurnState.Reconnecting)
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Retry").assertIsDisplayed()
+    }
+
+    @Test
+    fun systemBackDismissesImeBeforeLeavingConversation() {
+        val composer = composeRule.onNode(hasSetTextAction())
+        composer.performClick()
+        composer.performTextInput("synthetic keyboard text")
+        composeRule.waitForIdle()
+
+        var imeVisible = false
+        composeRule.runOnIdle {
+            imeVisible = composeRule.activity.window.decorView.rootWindowInsets
+                ?.isVisible(AndroidWindowInsets.Type.ime()) == true
+        }
+        assumeTrue("This gate requires a real visible IME.", imeVisible)
+
+        device.pressBack()
+        composeRule.waitForIdle()
+        assertEquals("The first system Back must stay in the conversation.", 0, composeRule.activity.backCalls)
+
+        device.pressBack()
+        composeRule.waitForIdle()
+        assertEquals("The second system Back delegates to the route.", 1, composeRule.activity.backCalls)
+    }
+
+    @Test
+    fun rotationKeepsTheMeasuredDockAndTranscriptUsable() {
+        try {
+            device.setOrientationLeft()
+            composeRule.waitForIdle()
+            composeRule.onNodeWithContentDescription("Message composer").assertIsDisplayed()
+            composeRule.onNodeWithContentDescription("Conversation transcript").assertIsDisplayed()
+        } finally {
+            device.unfreezeRotation()
+            device.setOrientationNatural()
+        }
+    }
+
+    @Test
+    fun cutoutDeviceKeepsSafeDrawingHeaderClearance() {
+        assumeTrue("This gate requires a display cutout device.", Build.VERSION.SDK_INT >= 28)
+        var hasCutout = false
+        composeRule.runOnIdle {
+            hasCutout = composeRule.activity.window.decorView.rootWindowInsets?.displayCutout != null
+        }
+        assumeTrue("This gate requires a display cutout configuration.", hasCutout)
+        composeRule.onNodeWithText("←  Back").assertIsDisplayed()
+        composeRule.onNodeWithText("Synthetic conversation").assertIsDisplayed()
+    }
+
+    @Test
+    fun gestureNavigationUsesTheMeasuredGestureCategory() {
+        val insets = currentRootInsetsOrSkip()
+        val navigationBottom = insets.getInsets(AndroidWindowInsets.Type.navigationBars()).bottom
+        val gestureBottom = insets.getInsets(AndroidWindowInsets.Type.systemGestures()).bottom
+        assumeTrue("This gate requires gesture navigation.", gestureBottom > navigationBottom)
+        assertTrue(activeBottomOcclusionPx(0, navigationBottom, gestureBottom) >= gestureBottom)
+        assertTerminalClearsDock()
+    }
+
+    @Test
+    fun threeButtonNavigationUsesTheMeasuredNavigationCategory() {
+        val insets = currentRootInsetsOrSkip()
+        val navigationBottom = insets.getInsets(AndroidWindowInsets.Type.navigationBars()).bottom
+        val gestureBottom = insets.getInsets(AndroidWindowInsets.Type.systemGestures()).bottom
+        assumeTrue("This gate requires three-button navigation.", navigationBottom > gestureBottom)
+        assertTrue(activeBottomOcclusionPx(0, navigationBottom, gestureBottom) >= navigationBottom)
+        assertTerminalClearsDock()
+    }
+
+    private fun setSyntheticContent(bottomInsetPx: Int, topInsetPx: Int = 0) {
+        composeRule.setContent {
+            HermesCelesteTheme {
+                val draft = remember { mutableStateOf("synthetic draft") }
+                ConversationScreen(
+                    summary = syntheticSummary,
+                    messages = syntheticMessages,
+                    streamingText = "",
+                    draft = draft.value,
+                    turnState = TurnState.Idle,
+                    loadingMessage = null,
+                    errorMessage = null,
+                    onDraftChange = { draft.value = it },
+                    onSend = {},
+                    onInterrupt = {},
+                    onReconnect = {},
+                    onBack = {},
+                    bottomOcclusion = WindowInsets(0, 0, 0, bottomInsetPx),
+                    safeDrawingInsets = WindowInsets(16, topInsetPx, 16, 0),
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun assertTerminalClearsDock() {
+        val terminalBottom = composeRule.onNodeWithContentDescription("Terminal transcript row")
+            .getUnclippedBoundsInRoot()
+            .bottom
+        val dockTop = composeRule.onNodeWithContentDescription("Message composer")
+            .getUnclippedBoundsInRoot()
+            .top
+        assertTrue(
+            "The terminal row must clear the measured composer dock.",
+            terminalBottom <= dockTop,
+        )
+    }
+
+    private fun currentRootInsetsOrSkip(): android.view.WindowInsets {
+        assumeTrue("Navigation mode inspection requires API 30+.", Build.VERSION.SDK_INT >= 30)
+        var insets: android.view.WindowInsets? = null
+        composeRule.runOnIdle {
+            insets = composeRule.activity.window.decorView.rootWindowInsets
+        }
+        assumeTrue("The test window did not report WindowInsets.", insets != null)
+        return insets!!
+    }
+}

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
@@ -277,6 +277,27 @@ class ConversationViewportDeviceTest {
     }
 
     @Test
+    fun accessibilityScrollAwayInterruptsAnActiveJumpAndPreservesHistoryMode() {
+        val transcript = composeRule.onNodeWithContentDescription("Conversation transcript")
+        transcript.performScrollToIndex(6)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+
+        // Do not wait for idle between the explicit jump and the accessibility
+        // scroll. This deliberately interrupts the active programmatic
+        // generation instead of testing only the settled end state.
+        composeRule.onNodeWithContentDescription("Jump to latest").performClick()
+        transcript.performScrollToIndex(5)
+        composeRule.waitForIdle()
+
+        updateContent {
+            setContentStreamingText(longStreamingText())
+        }
+        composeRule.onNodeWithText(syntheticRowText(5)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+    }
+
+    @Test
     fun streamingAndTallRowsFollowLatestButPreserveAHistoryReader() {
         composeRule.onNodeWithContentDescription("Terminal transcript row").assertIsDisplayed()
 

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
@@ -90,6 +90,8 @@ class ConversationViewportDeviceTest {
 
     @Test
     fun systemBackDismissesImeBeforeLeavingConversation() {
+        composeRule.runOnUiThread { composeRule.activity.useProductionInsets() }
+        composeRule.waitForIdle()
         val composer = composeRule.onNode(hasSetTextAction())
         composer.performClick()
         composer.performTextInput("synthetic keyboard text")
@@ -109,6 +111,45 @@ class ConversationViewportDeviceTest {
         device.pressBack()
         composeRule.waitForIdle()
         assertEquals("The second system Back delegates to the route.", 1, composeRule.activity.backCalls)
+    }
+
+    @Test
+    fun productionInsetsTrackImeOpenAndClose() {
+        composeRule.runOnUiThread { composeRule.activity.useProductionInsets() }
+        composeRule.waitForIdle()
+        val composer = composeRule.onNode(hasSetTextAction())
+        composer.performClick()
+        composer.performTextInput("production inset keyboard text")
+        composeRule.waitForIdle()
+
+        var imeVisible = false
+        composeRule.runOnIdle {
+            imeVisible = composeRule.activity.window.decorView.rootWindowInsets
+                ?.isVisible(AndroidWindowInsets.Type.ime()) == true
+        }
+        assumeTrue("This gate requires a real visible IME.", imeVisible)
+        assertProductionBoundsAgainstWindowInsets()
+
+        device.pressBack()
+        composeRule.waitForIdle()
+        var imeHidden = false
+        composeRule.runOnIdle {
+            imeHidden = composeRule.activity.window.decorView.rootWindowInsets
+                ?.isVisible(AndroidWindowInsets.Type.ime()) == false
+        }
+        assertTrue("The production IME inset must settle after Back.", imeHidden)
+        assertProductionBoundsAgainstWindowInsets()
+    }
+
+    @Test
+    fun productionInsetsKeepComposerGrowthAndTerminalBoundsUsable() {
+        composeRule.runOnUiThread {
+            composeRule.activity.useProductionInsets()
+            composeRule.activity.setContentDraft(longComposerDraft())
+        }
+        composeRule.waitForIdle()
+        assertTerminalClearsDock()
+        assertProductionBoundsAgainstWindowInsets()
     }
 
     @Test
@@ -146,6 +187,8 @@ class ConversationViewportDeviceTest {
     @Test
     fun cutoutDeviceKeepsSafeDrawingHeaderClearance() {
         assumeTrue("This gate requires a display cutout device.", Build.VERSION.SDK_INT >= 28)
+        composeRule.runOnUiThread { composeRule.activity.useProductionInsets() }
+        composeRule.waitForIdle()
         var hasCutout = false
         composeRule.runOnIdle {
             hasCutout = composeRule.activity.window.decorView.rootWindowInsets?.displayCutout != null
@@ -157,22 +200,28 @@ class ConversationViewportDeviceTest {
 
     @Test
     fun gestureNavigationUsesTheMeasuredGestureCategory() {
+        composeRule.runOnUiThread { composeRule.activity.useProductionInsets() }
+        composeRule.waitForIdle()
         val insets = currentRootInsetsOrSkip()
         val navigationBottom = insets.getInsets(AndroidWindowInsets.Type.navigationBars()).bottom
         val gestureBottom = insets.getInsets(AndroidWindowInsets.Type.systemGestures()).bottom
         assumeTrue("This gate requires gesture navigation.", gestureBottom > navigationBottom)
         assertTrue(activeBottomOcclusionPx(0, navigationBottom, gestureBottom) >= gestureBottom)
         assertTerminalClearsDock()
+        assertProductionBoundsAgainstWindowInsets()
     }
 
     @Test
     fun threeButtonNavigationUsesTheMeasuredNavigationCategory() {
+        composeRule.runOnUiThread { composeRule.activity.useProductionInsets() }
+        composeRule.waitForIdle()
         val insets = currentRootInsetsOrSkip()
         val navigationBottom = insets.getInsets(AndroidWindowInsets.Type.navigationBars()).bottom
         val gestureBottom = insets.getInsets(AndroidWindowInsets.Type.systemGestures()).bottom
         assumeTrue("This gate requires three-button navigation.", navigationBottom > gestureBottom)
         assertTrue(activeBottomOcclusionPx(0, navigationBottom, gestureBottom) >= navigationBottom)
         assertTerminalClearsDock()
+        assertProductionBoundsAgainstWindowInsets()
     }
 
     @Test
@@ -310,6 +359,19 @@ class ConversationViewportDeviceTest {
     }
 
     @Test
+    fun scrollingToEndRelatchesAgainstTheMeasuredDockBoundary() {
+        setSyntheticContent(bottomInsetPx = 48)
+        val transcript = composeRule.onNodeWithContentDescription("Conversation transcript")
+        transcript.performScrollToIndex(6)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+
+        transcript.performScrollToIndex(syntheticMessages.lastIndex)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertDoesNotExist()
+    }
+
+    @Test
     fun reconnectErrorKeepsDraftAndRetryActionReachable() {
         composeRule.onNodeWithContentDescription("Conversation transcript")
             .performScrollToIndex(5)
@@ -382,6 +444,36 @@ class ConversationViewportDeviceTest {
             terminalBottom <= dockTop,
         )
     }
+
+    private fun assertProductionBoundsAgainstWindowInsets() {
+        assumeTrue("Production inset bounds require API 30+.", Build.VERSION.SDK_INT >= 30)
+        var rootHeight = 0
+        var rootInsets: android.view.WindowInsets? = null
+        composeRule.runOnIdle {
+            rootHeight = composeRule.activity.window.decorView.height
+            rootInsets = composeRule.activity.window.decorView.rootWindowInsets
+        }
+        assumeTrue("The production test window did not report WindowInsets.", rootInsets != null)
+        val insets = rootInsets!!
+        val activeBottom = activeBottomOcclusionPx(
+            imeBottomPx = insets.getInsets(AndroidWindowInsets.Type.ime()).bottom,
+            navigationBottomPx = insets.getInsets(AndroidWindowInsets.Type.navigationBars()).bottom,
+            systemGesturesBottomPx = insets.getInsets(AndroidWindowInsets.Type.systemGestures()).bottom,
+        )
+        val usableBottom = rootHeight - activeBottom
+        val composerBounds = composeRule.onNodeWithContentDescription("Message composer")
+            .getUnclippedBoundsInRoot()
+        val fieldBounds = composeRule.onNode(hasSetTextAction()).getUnclippedBoundsInRoot()
+        val sendBounds = composeRule.onNodeWithText("Send  →").getUnclippedBoundsInRoot()
+        val terminalBounds = composeRule.onNodeWithContentDescription("Terminal transcript row")
+            .getUnclippedBoundsInRoot()
+        assertTrue("The text field must remain above the real bottom occlusion.", fieldBounds.bottom <= usableBottom + 2f)
+        assertTrue("The composer action must remain above the real bottom occlusion.", sendBounds.bottom <= usableBottom + 2f)
+        assertTrue("The terminal row must clear the measured production dock.", terminalBounds.bottom <= composerBounds.top + 2f)
+    }
+
+    private fun longComposerDraft(): String =
+        (1..5).joinToString("\n") { "Synthetic composer line $it" }
 
     private fun currentRootInsetsOrSkip(): android.view.WindowInsets {
         assumeTrue("Navigation mode inspection requires API 30+.", Build.VERSION.SDK_INT >= 30)

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportDeviceTest.kt
@@ -125,6 +125,25 @@ class ConversationViewportDeviceTest {
     }
 
     @Test
+    fun rotationRestoresHistoryModeAndAnchorForTheSameSession() {
+        composeRule.onNodeWithContentDescription("Conversation transcript")
+            .performScrollToIndex(6)
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(syntheticRowText(6)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+
+        try {
+            device.setOrientationLeft()
+            composeRule.waitForIdle()
+            composeRule.onNodeWithText(syntheticRowText(6)).assertIsDisplayed()
+            composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
+        } finally {
+            device.unfreezeRotation()
+            device.setOrientationNatural()
+        }
+    }
+
+    @Test
     fun cutoutDeviceKeepsSafeDrawingHeaderClearance() {
         assumeTrue("This gate requires a display cutout device.", Build.VERSION.SDK_INT >= 28)
         var hasCutout = false
@@ -170,6 +189,42 @@ class ConversationViewportDeviceTest {
 
         composeRule.onNodeWithContentDescription("Message composer").assertIsDisplayed()
         assertTerminalClearsDock()
+    }
+
+    @Test
+    fun earlyAccessibilityScrollAwayInvalidatesInitialLatestSettling() {
+        val settled = mutableStateOf(false)
+        composeRule.setContent {
+            HermesCelesteTheme {
+                val draft = remember { mutableStateOf("synthetic draft") }
+                ConversationScreen(
+                    summary = syntheticSummary,
+                    messages = syntheticMessages,
+                    streamingText = "",
+                    draft = draft.value,
+                    turnState = TurnState.Idle,
+                    loadingMessage = null,
+                    errorMessage = null,
+                    onDraftChange = { draft.value = it },
+                    onSend = {},
+                    onInterrupt = {},
+                    onReconnect = {},
+                    onBack = {},
+                    bottomOcclusion = WindowInsets(0, 0, 0, 48),
+                    safeDrawingInsets = WindowInsets(16, 0, 16, 0),
+                    bottomOcclusionSettled = settled.value,
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Conversation transcript")
+            .performScrollToIndex(6)
+        composeRule.waitForIdle()
+        composeRule.runOnUiThread { settled.value = true }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(syntheticRowText(6)).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Jump to latest").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportTestActivity.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportTestActivity.kt
@@ -7,8 +7,9 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
@@ -23,6 +24,16 @@ internal class ConversationViewportTestActivity : ComponentActivity() {
 
     private var contentFontScale by mutableFloatStateOf(1f)
     private var contentTurnState by mutableStateOf(TurnState.Idle)
+    private var contentSummary by mutableStateOf(syntheticSummary)
+    private var contentMessages by mutableStateOf(syntheticMessages)
+    private var contentStreamingText by mutableStateOf("")
+    private var contentProjectionGeneration by mutableLongStateOf(0L)
+    private var contentDraft by mutableStateOf("")
+    private var contentLoadingMessage by mutableStateOf<String?>(null)
+    private var contentErrorMessage by mutableStateOf<String?>(null)
+    private var contentBottomInsetPx by mutableIntStateOf(0)
+    private var contentTopInsetPx by mutableIntStateOf(0)
+    private var contentBottomInsetsSettled by mutableStateOf(true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,20 +44,33 @@ internal class ConversationViewportTestActivity : ComponentActivity() {
                 LocalDensity provides Density(baseDensity.density, contentFontScale),
             ) {
                 HermesCelesteTheme {
-                    var draft by remember { mutableStateOf("") }
                     ConversationScreen(
-                        summary = syntheticSummary,
-                        messages = syntheticMessages,
-                        streamingText = "",
-                        draft = draft,
+                        summary = contentSummary,
+                        messages = contentMessages,
+                        streamingText = contentStreamingText,
+                        projectionGeneration = contentProjectionGeneration,
+                        draft = contentDraft,
                         turnState = contentTurnState,
-                        loadingMessage = null,
-                        errorMessage = null,
-                        onDraftChange = { draft = it },
-                        onSend = {},
-                        onInterrupt = {},
-                        onReconnect = {},
+                        loadingMessage = contentLoadingMessage,
+                        errorMessage = contentErrorMessage,
+                        onDraftChange = { contentDraft = it },
+                        onSend = { sendCalls += 1 },
+                        onInterrupt = { interruptCalls += 1 },
+                        onReconnect = { reconnectCalls += 1 },
                         onBack = { backCalls += 1 },
+                        bottomOcclusion = androidx.compose.foundation.layout.WindowInsets(
+                            0,
+                            0,
+                            0,
+                            contentBottomInsetPx,
+                        ),
+                        safeDrawingInsets = androidx.compose.foundation.layout.WindowInsets(
+                            16,
+                            contentTopInsetPx,
+                            16,
+                            0,
+                        ),
+                        bottomOcclusionSettled = contentBottomInsetsSettled,
                     )
                 }
             }
@@ -60,6 +84,53 @@ internal class ConversationViewportTestActivity : ComponentActivity() {
     fun setContentTurnState(value: TurnState) {
         contentTurnState = value
     }
+
+    fun setContentMessages(value: List<ConversationMessage>) {
+        contentMessages = value
+    }
+
+    fun setContentStreamingText(value: String) {
+        contentStreamingText = value
+    }
+
+    fun setContentProjectionGeneration(value: Long) {
+        contentProjectionGeneration = value
+    }
+
+    fun setContentDraft(value: String) {
+        contentDraft = value
+    }
+
+    fun setContentStatus(loading: String?, error: String?) {
+        contentLoadingMessage = loading
+        contentErrorMessage = error
+    }
+
+    fun setContentInsets(bottom: Int, top: Int = contentTopInsetPx, settled: Boolean = true) {
+        contentBottomInsetPx = bottom
+        contentTopInsetPx = top
+        contentBottomInsetsSettled = settled
+    }
+
+    fun setContentSummary(value: StoredSession) {
+        contentSummary = value
+    }
+
+    fun resetActionCounts() {
+        backCalls = 0
+        sendCalls = 0
+        interruptCalls = 0
+        reconnectCalls = 0
+    }
+
+    var sendCalls: Int = 0
+        private set
+
+    var interruptCalls: Int = 0
+        private set
+
+    var reconnectCalls: Int = 0
+        private set
 }
 
 internal val syntheticSummary = StoredSession(

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportTestActivity.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportTestActivity.kt
@@ -34,6 +34,7 @@ internal class ConversationViewportTestActivity : ComponentActivity() {
     private var contentBottomInsetPx by mutableIntStateOf(0)
     private var contentTopInsetPx by mutableIntStateOf(0)
     private var contentBottomInsetsSettled by mutableStateOf(true)
+    private var contentUseProductionInsets by mutableStateOf(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,19 +59,31 @@ internal class ConversationViewportTestActivity : ComponentActivity() {
                         onInterrupt = { interruptCalls += 1 },
                         onReconnect = { reconnectCalls += 1 },
                         onBack = { backCalls += 1 },
-                        bottomOcclusion = androidx.compose.foundation.layout.WindowInsets(
-                            0,
-                            0,
-                            0,
-                            contentBottomInsetPx,
-                        ),
-                        safeDrawingInsets = androidx.compose.foundation.layout.WindowInsets(
-                            16,
-                            contentTopInsetPx,
-                            16,
-                            0,
-                        ),
-                        bottomOcclusionSettled = contentBottomInsetsSettled,
+                        bottomOcclusion = if (contentUseProductionInsets) {
+                            null
+                        } else {
+                            androidx.compose.foundation.layout.WindowInsets(
+                                0,
+                                0,
+                                0,
+                                contentBottomInsetPx,
+                            )
+                        },
+                        safeDrawingInsets = if (contentUseProductionInsets) {
+                            null
+                        } else {
+                            androidx.compose.foundation.layout.WindowInsets(
+                                16,
+                                contentTopInsetPx,
+                                16,
+                                0,
+                            )
+                        },
+                        bottomOcclusionSettled = if (contentUseProductionInsets) {
+                            null
+                        } else {
+                            contentBottomInsetsSettled
+                        },
                     )
                 }
             }
@@ -110,6 +123,10 @@ internal class ConversationViewportTestActivity : ComponentActivity() {
         contentBottomInsetPx = bottom
         contentTopInsetPx = top
         contentBottomInsetsSettled = settled
+    }
+
+    fun useProductionInsets(enabled: Boolean = true) {
+        contentUseProductionInsets = enabled
     }
 
     fun setContentSummary(value: StoredSession) {

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportTestActivity.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationViewportTestActivity.kt
@@ -1,0 +1,80 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import dev.hazydreams.hermesceleste.TurnState
+import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
+
+internal class ConversationViewportTestActivity : ComponentActivity() {
+    var backCalls: Int = 0
+        private set
+
+    private var contentFontScale by mutableFloatStateOf(1f)
+    private var contentTurnState by mutableStateOf(TurnState.Idle)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            val baseDensity = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(baseDensity.density, contentFontScale),
+            ) {
+                HermesCelesteTheme {
+                    var draft by remember { mutableStateOf("") }
+                    ConversationScreen(
+                        summary = syntheticSummary,
+                        messages = syntheticMessages,
+                        streamingText = "",
+                        draft = draft,
+                        turnState = contentTurnState,
+                        loadingMessage = null,
+                        errorMessage = null,
+                        onDraftChange = { draft = it },
+                        onSend = {},
+                        onInterrupt = {},
+                        onReconnect = {},
+                        onBack = { backCalls += 1 },
+                    )
+                }
+            }
+        }
+    }
+
+    fun setContentFontScale(value: Float) {
+        contentFontScale = value
+    }
+
+    fun setContentTurnState(value: TurnState) {
+        contentTurnState = value
+    }
+}
+
+internal val syntheticSummary = StoredSession(
+    id = "instrumentation-session",
+    title = "Synthetic conversation",
+    preview = "",
+    startedAt = 0.0,
+    messageCount = 24,
+    source = "instrumentation",
+)
+
+internal val syntheticMessages = (0 until 24).map { index ->
+    ConversationMessage(
+        role = if (index % 2 == 0) "user" else "assistant",
+        text = "Synthetic transcript row $index. This content exists only to exercise viewport geometry.",
+        id = "instrumentation-row-$index",
+    )
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -79,6 +79,7 @@ internal data class CelesteUiState(
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
     val errorMessage: String? = null,
+    val conversationProjectionGeneration: Long = 0L,
 )
 
 private data class LoadedDashboard(
@@ -591,6 +592,7 @@ internal class CelesteViewModel(
             messages = emptyList(),
             streamingText = "",
             draft = "",
+            conversationProjectionGeneration = mutableState.value.conversationProjectionGeneration + 1,
             turnState = TurnState.Synchronizing,
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
             errorMessage = null,
@@ -628,6 +630,7 @@ internal class CelesteViewModel(
             messages = emptyList(),
             streamingText = "",
             draft = "",
+            conversationProjectionGeneration = snapshot.conversationProjectionGeneration + 1,
             turnState = TurnState.Synchronizing,
             loadingMessage = "Starting a new $selectedProfile conversation…",
             errorMessage = null,
@@ -691,6 +694,7 @@ internal class CelesteViewModel(
             messages = emptyList(),
             streamingText = "",
             draft = "",
+            conversationProjectionGeneration = mutableState.value.conversationProjectionGeneration + 1,
             turnState = TurnState.Idle,
             loadingMessage = null,
             errorMessage = null,
@@ -837,6 +841,8 @@ internal class CelesteViewModel(
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
                         errorMessage = connectionState.reason,
+                        conversationProjectionGeneration =
+                            mutableState.value.conversationProjectionGeneration + 1,
                     )
                     scheduleReconnect(wasRunning)
                 }
@@ -873,6 +879,8 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             messages = resumed.messages,
             streamingText = streamingSuffix,
+            conversationProjectionGeneration =
+                mutableState.value.conversationProjectionGeneration + 1,
             turnState = if (resumed.running == true || resumed.hasLiveProjection) {
                 TurnState.Running
             } else {
@@ -1059,6 +1067,8 @@ internal class CelesteViewModel(
                 sessions = mutableState.value.sessions?.map { session ->
                     if (session.id == previousStoredId) updatedSummary else session
                 },
+                conversationProjectionGeneration =
+                    mutableState.value.conversationProjectionGeneration + 1,
                 turnState = TurnState.Idle,
                 errorMessage = null,
             )
@@ -1077,7 +1087,11 @@ internal class CelesteViewModel(
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
         if (reconnectJob?.isActive == true) return
-        mutableState.value = mutableState.value.copy(turnState = TurnState.Reconnecting)
+        mutableState.value = mutableState.value.copy(
+            turnState = TurnState.Reconnecting,
+            conversationProjectionGeneration =
+                mutableState.value.conversationProjectionGeneration + 1,
+        )
         reconnectJob = viewModelScope.launch {
             while (gateway === activeGateway) {
                 val delayMillis = if (immediate && reconnectAttempts == 0) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -78,7 +78,6 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
 
         CelesteDestination.Content -> when {
             activeSummary != null -> {
-                BackHandler(onBack = viewModel::leaveConversation)
                 ConversationScreen(
                     summary = activeSummary,
                     messages = ui.messages,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -282,8 +282,14 @@ internal fun EditorialDivider(modifier: Modifier = Modifier) {
 }
 
 @Composable
-internal fun StatusMessage(message: String, color: Color, showSpinner: Boolean = false) {
+internal fun StatusMessage(
+    message: String,
+    color: Color,
+    showSpinner: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
     Row(
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(9.dp),
     ) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -91,6 +91,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     onInterrupt = viewModel::interrupt,
                     onReconnect = viewModel::reconnectNow,
                     onBack = viewModel::leaveConversation,
+                    projectionGeneration = ui.conversationProjectionGeneration,
                 )
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.onDispose
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
@@ -299,7 +300,7 @@ private fun ConversationViewport(
 ) {
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
-    val listState = remember(summaryId) { LazyListState() }
+    val listState = rememberSaveable(summaryId, saver = LazyListState.Saver) { LazyListState() }
     val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
     val hasStreamingRow = streamingText.isNotBlank()
     val itemCount = messages.size + if (hasStreamingRow) 1 else 0
@@ -307,12 +308,22 @@ private fun ConversationViewport(
         if (hasStreamingRow) transcriptKeys + STREAMING_TRANSCRIPT_KEY else transcriptKeys
     }
     val policy = remember(summaryId) { ConversationScrollPolicy() }
-    var followsLatest by remember(summaryId) { mutableStateOf(true) }
+    var followsLatest by rememberSaveable(summaryId) { mutableStateOf(true) }
     var transitionGeneration by remember(summaryId) { mutableLongStateOf(0L) }
     var transitionActive by remember(summaryId) { mutableStateOf(false) }
     var initialProjectionHandled by remember(summaryId) { mutableStateOf(false) }
-    var pendingAnchor by remember(summaryId) { mutableStateOf<TranscriptAnchor?>(null) }
-    var lastHistoryAnchor by remember(summaryId) { mutableStateOf<TranscriptAnchor?>(null) }
+    var savedAnchorKey by rememberSaveable(summaryId) { mutableStateOf<String?>(null) }
+    var savedAnchorIndex by rememberSaveable(summaryId) { mutableIntStateOf(-1) }
+    var savedAnchorOffsetPx by rememberSaveable(summaryId) { mutableIntStateOf(0) }
+    val restoredHistoryAnchor = savedAnchorKey?.let { key ->
+        TranscriptAnchor(
+            key = key,
+            index = savedAnchorIndex,
+            relativeOffsetPx = savedAnchorOffsetPx,
+        )
+    }
+    var pendingAnchor by remember(summaryId) { mutableStateOf(restoredHistoryAnchor) }
+    var lastHistoryAnchor by remember(summaryId) { mutableStateOf(restoredHistoryAnchor) }
     var recoveryNeeded by remember(summaryId) { mutableStateOf(false) }
     var programmaticScrollGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
     var activeScrollJob by remember(summaryId) { mutableStateOf<Job?>(null) }
@@ -320,6 +331,12 @@ private fun ConversationViewport(
     var previousItemKeys by remember(summaryId) { mutableStateOf<List<String>?>(null) }
     var previousProjectionGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
     var geometryRetryTick by remember(summaryId) { mutableLongStateOf(0L) }
+
+    fun persistHistoryAnchor(anchor: TranscriptAnchor?) {
+        savedAnchorKey = anchor?.key
+        savedAnchorIndex = anchor?.index ?: -1
+        savedAnchorOffsetPx = anchor?.relativeOffsetPx ?: 0
+    }
 
     // rememberCoroutineScope() survives a summary-key change. Dispose the
     // previous summary's explicit jump/restore job before its list state is
@@ -355,6 +372,10 @@ private fun ConversationViewport(
     fun markHistoryReading() {
         activeScrollJob?.cancel()
         activeScrollJob = null
+        // Deliberate drag/accessibility scroll owns the viewport immediately.
+        // Mark the initial settle handled before it can resume after geometry
+        // becomes usable, then advance the generation to invalidate its work.
+        initialProjectionHandled = true
         val decision = policy.decide(
             ScrollPolicyInput(
                 followsLatest = followsLatest,
@@ -369,6 +390,7 @@ private fun ConversationViewport(
             if (anchor != null) {
                 lastHistoryAnchor = anchor
                 pendingAnchor = anchor
+                persistHistoryAnchor(anchor)
             }
         }
         followsLatest = decision.followsLatest
@@ -402,6 +424,7 @@ private fun ConversationViewport(
         followsLatest = decision.followsLatest
         recoveryNeeded = false
         pendingAnchor = null
+        persistHistoryAnchor(null)
         transitionActive = false
         transitionGeneration = decision.transitionGeneration + 1
         val generation = transitionGeneration
@@ -419,7 +442,10 @@ private fun ConversationViewport(
             .filterNotNull()
             .distinctUntilChanged()
             .collect { anchor ->
-                if (!followsLatest) lastHistoryAnchor = anchor
+                if (!followsLatest) {
+                    lastHistoryAnchor = anchor
+                    persistHistoryAnchor(anchor)
+                }
             }
     }
 
@@ -442,8 +468,11 @@ private fun ConversationViewport(
             val movedTowardHistory = previousPosition?.let {
                 position.isEarlierThan(it)
             } == true
+            val deliberateScrollBeforeInitialSettle = !initialProjectionHandled &&
+                previousPosition != null &&
+                position != previousPosition
             if (position.isScrollInProgress &&
-                movedTowardHistory &&
+                (movedTowardHistory || deliberateScrollBeforeInitialSettle) &&
                 programmaticScrollGeneration == null
             ) {
                 markHistoryReading()
@@ -471,8 +500,16 @@ private fun ConversationViewport(
         }
     }
 
-    LaunchedEffect(itemCount, summaryId, geometry, projectionGeneration, geometryRetryTick) {
+    LaunchedEffect(
+        itemCount,
+        summaryId,
+        geometry,
+        projectionGeneration,
+        geometryRetryTick,
+        transitionGeneration,
+    ) {
         if (initialProjectionHandled || itemCount == 0) return@LaunchedEffect
+        val settlingGeneration = transitionGeneration
         snapshotFlow {
             listState.layoutInfo.totalItemsCount == itemCount &&
                 hasUsableViewportGeometry(
@@ -486,22 +523,54 @@ private fun ConversationViewport(
             geometryRetryTick += 1
             return@LaunchedEffect
         }
-        if (initialProjectionHandled) return@LaunchedEffect
+        // A deliberate drag/accessibility scroll can happen while the first
+        // usable geometry is settling. Its generation owns the viewport now;
+        // never let this older initial-latest attempt relatch after that input.
+        if (initialProjectionHandled || settlingGeneration != transitionGeneration) {
+            return@LaunchedEffect
+        }
+        val restoringHistory = !followsLatest
+        val anchor = pendingAnchor ?: lastHistoryAnchor
+        val anchorCanBeRestored = anchor != null && (
+            itemKeys.contains(anchor.key) || anchor.index in itemKeys.indices
+        )
         val decision = policy.decide(
             ScrollPolicyInput(
                 followsLatest = followsLatest,
-                initialProjectionReady = true,
-                transitionGeneration = transitionGeneration,
+                restorationPending = restoringHistory,
+                anchorAvailable = anchorCanBeRestored,
+                initialProjectionReady = !restoringHistory,
+                transitionGeneration = settlingGeneration,
+                pendingGeneration = settlingGeneration,
                 hasItems = true,
             ),
         )
+        if (decision.command == ScrollCommand.CancelPendingFollow) return@LaunchedEffect
         initialProjectionHandled = true
         followsLatest = decision.followsLatest
-        if (decision.command == ScrollCommand.FollowLatest) {
-            val generation = decision.transitionGeneration
-            scrollForGeneration(generation) {
-                settleTerminalRow(listState, itemCount)
+        when (decision.command) {
+            ScrollCommand.FollowLatest -> {
+                scrollForGeneration(decision.transitionGeneration) {
+                    settleTerminalRow(listState, itemCount)
+                }
             }
+
+            ScrollCommand.RestoreAnchor -> {
+                scrollForGeneration(decision.transitionGeneration) {
+                    val restored = restoreTranscriptAnchor(
+                        listState = listState,
+                        itemKeys = itemKeys,
+                        anchor = anchor,
+                    )
+                    if (decision.fallbackToLatest || !restored) {
+                        settleTerminalRow(listState, itemCount)
+                        recoveryNeeded = true
+                    }
+                }
+                pendingAnchor = null
+            }
+
+            else -> Unit
         }
     }
 
@@ -512,11 +581,14 @@ private fun ConversationViewport(
         summaryId,
         itemCount,
         followsLatest,
+        initialProjectionHandled,
         transitionGeneration,
         transitionActive,
         projectionGeneration,
     ) {
-        if (!followsLatest || itemCount == 0) return@LaunchedEffect
+        if (!followsLatest || !initialProjectionHandled || itemCount == 0) {
+            return@LaunchedEffect
+        }
         snapshotFlow {
             terminalLayoutSignature(listState.layoutInfo, itemCount)
         }.distinctUntilChanged().collectLatest {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -1,5 +1,6 @@
 package dev.hazydreams.hermesceleste.ui.conversation
 
+import android.animation.ValueAnimator
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.scrollBy
@@ -53,7 +54,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.onDispose
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.retain.retain
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
@@ -68,8 +69,11 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
@@ -94,14 +98,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 private const val GEOMETRY_RETRY_DELAY_MS = 96L
+private const val MAX_RETAINED_ANCHOR_KEY_LENGTH = 256
 
 @Composable
 internal fun conversationBottomOcclusionInsets(): WindowInsets =
@@ -212,7 +214,20 @@ internal fun ConversationScreen(
                     overflow = TextOverflow.Ellipsis,
                 )
                 Spacer(Modifier.height(6.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            liveRegion = LiveRegionMode.Polite
+                            stateDescription = when (turnState) {
+                                TurnState.Idle -> "Connected"
+                                TurnState.Running -> "Responding"
+                                TurnState.Synchronizing -> "Synchronizing"
+                                TurnState.Reconnecting -> "Reconnecting"
+                            }
+                        },
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     androidx.compose.foundation.layout.Box(
                         Modifier.size(6.dp).background(
                             turnStateColor(turnState),
@@ -239,7 +254,16 @@ internal fun ConversationScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    errorMessage?.let {
+                        StatusMessage(
+                            message = it,
+                            color = CelesteError,
+                            modifier = Modifier.semantics {
+                                liveRegion = LiveRegionMode.Polite
+                                stateDescription = "Terminal error"
+                            },
+                        )
+                    }
                 }
             }
 
@@ -280,6 +304,16 @@ internal fun ConversationScreen(
     }
 }
 
+private class RetainedConversationViewportState {
+    // `retain` survives configuration recreation without entering SavedStateRegistry. A process
+    // restart therefore starts with a fresh latest policy and never restores a server row key.
+    // Only the list position, follow policy, and one bounded in-memory anchor cross rotation;
+    // transient jobs and transition guards are rebuilt after the new geometry settles.
+    val listState = LazyListState()
+    val followsLatest = mutableStateOf(true)
+    val lastHistoryAnchor = mutableStateOf<TranscriptAnchor?>(null)
+}
+
 @Composable
 private fun ConversationViewport(
     summaryId: String,
@@ -300,7 +334,9 @@ private fun ConversationViewport(
 ) {
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
-    val listState = rememberSaveable(summaryId, saver = LazyListState.Saver) { LazyListState() }
+    val retainedViewportState = retain(summaryId) { RetainedConversationViewportState() }
+    val listState = retainedViewportState.listState
+    var followsLatest by retainedViewportState.followsLatest
     val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
     val hasStreamingRow = streamingText.isNotBlank()
     val itemCount = messages.size + if (hasStreamingRow) 1 else 0
@@ -308,22 +344,11 @@ private fun ConversationViewport(
         if (hasStreamingRow) transcriptKeys + STREAMING_TRANSCRIPT_KEY else transcriptKeys
     }
     val policy = remember(summaryId) { ConversationScrollPolicy() }
-    var followsLatest by rememberSaveable(summaryId) { mutableStateOf(true) }
     var transitionGeneration by remember(summaryId) { mutableLongStateOf(0L) }
     var transitionActive by remember(summaryId) { mutableStateOf(false) }
     var initialProjectionHandled by remember(summaryId) { mutableStateOf(false) }
-    var savedAnchorKey by rememberSaveable(summaryId) { mutableStateOf<String?>(null) }
-    var savedAnchorIndex by rememberSaveable(summaryId) { mutableIntStateOf(-1) }
-    var savedAnchorOffsetPx by rememberSaveable(summaryId) { mutableIntStateOf(0) }
-    val restoredHistoryAnchor = savedAnchorKey?.let { key ->
-        TranscriptAnchor(
-            key = key,
-            index = savedAnchorIndex,
-            relativeOffsetPx = savedAnchorOffsetPx,
-        )
-    }
-    var pendingAnchor by remember(summaryId) { mutableStateOf(restoredHistoryAnchor) }
-    var lastHistoryAnchor by remember(summaryId) { mutableStateOf(restoredHistoryAnchor) }
+    var pendingAnchor by remember(summaryId) { mutableStateOf<TranscriptAnchor?>(null) }
+    var lastHistoryAnchor by retainedViewportState.lastHistoryAnchor
     var recoveryNeeded by remember(summaryId) { mutableStateOf(false) }
     var programmaticScrollGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
     var activeScrollJob by remember(summaryId) { mutableStateOf<Job?>(null) }
@@ -332,18 +357,15 @@ private fun ConversationViewport(
     var previousProjectionGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
     var geometryRetryTick by remember(summaryId) { mutableLongStateOf(0L) }
 
-    fun persistHistoryAnchor(anchor: TranscriptAnchor?) {
-        savedAnchorKey = anchor?.key
-        savedAnchorIndex = anchor?.index ?: -1
-        savedAnchorOffsetPx = anchor?.relativeOffsetPx ?: 0
-    }
-
-    // rememberCoroutineScope() survives a summary-key change. Dispose the
-    // previous summary's explicit jump/restore job before its list state is
-    // discarded, otherwise a late completion can move the next conversation.
-    DisposableEffect(summaryId) {
+    // Explicit scroll jobs are composition-scoped. The retained state only carries settled UI
+    // policy and the list position across configuration recreation.
+    DisposableEffect(summaryId, retainedViewportState) {
         onDispose {
             activeScrollJob?.cancel()
+            activeScrollJob = null
+            transitionActive = false
+            pendingAnchor = null
+            programmaticScrollGeneration = null
         }
     }
 
@@ -359,9 +381,14 @@ private fun ConversationViewport(
         configurationOrientation = configurationOrientation,
         configurationFontScale = configurationFontScale,
     )
-    val terminalDistanceDp by remember(listState, itemCount, density) {
+    val terminalDistanceDp by remember(listState, itemCount, density, geometry.dockHeightPx) {
         derivedStateOf {
-            terminalDistanceDp(listState.layoutInfo, itemCount, density)
+            terminalDistanceDp(
+                layoutInfo = listState.layoutInfo,
+                itemCount = itemCount,
+                density = density,
+                dockHeightPx = geometry.dockHeightPx,
+            )
         }
     }
     val showJumpToLatest = itemCount > 0 && !followsLatest &&
@@ -390,7 +417,6 @@ private fun ConversationViewport(
             if (anchor != null) {
                 lastHistoryAnchor = anchor
                 pendingAnchor = anchor
-                persistHistoryAnchor(anchor)
             }
         }
         followsLatest = decision.followsLatest
@@ -399,11 +425,12 @@ private fun ConversationViewport(
         programmaticScrollGeneration = null
     }
 
-    suspend fun scrollForGeneration(generation: Long, action: suspend () -> Unit) {
-        if (generation != transitionGeneration) return
+    suspend fun scrollForGeneration(generation: Long, action: suspend () -> Unit): Boolean {
+        if (generation != transitionGeneration) return false
         programmaticScrollGeneration = generation
         try {
             action()
+            return true
         } finally {
             if (programmaticScrollGeneration == generation) {
                 programmaticScrollGeneration = null
@@ -424,29 +451,24 @@ private fun ConversationViewport(
         followsLatest = decision.followsLatest
         recoveryNeeded = false
         pendingAnchor = null
-        persistHistoryAnchor(null)
         transitionActive = false
         transitionGeneration = decision.transitionGeneration + 1
         val generation = transitionGeneration
         activeScrollJob?.cancel()
         activeScrollJob = scope.launch {
             scrollForGeneration(generation) {
-                listState.animateScrollToItem(itemCount - 1)
-                settleTerminalRow(listState, itemCount)
+                if (ValueAnimator.areAnimatorsEnabled()) {
+                    listState.animateScrollToItem(itemCount - 1)
+                } else {
+                    listState.scrollToItem(itemCount - 1)
+                }
+                settleTerminalRow(
+                    listState = listState,
+                    itemCount = itemCount,
+                    dockHeightPx = geometry.dockHeightPx,
+                )
             }
         }
-    }
-
-    LaunchedEffect(listState, summaryId, followsLatest) {
-        snapshotFlow { captureTranscriptAnchor(listState) }
-            .filterNotNull()
-            .distinctUntilChanged()
-            .collect { anchor ->
-                if (!followsLatest) {
-                    lastHistoryAnchor = anchor
-                    persistHistoryAnchor(anchor)
-                }
-            }
     }
 
     LaunchedEffect(
@@ -494,6 +516,10 @@ private fun ConversationViewport(
                 if (decision.command == ScrollCommand.RelatchLatest) {
                     followsLatest = decision.followsLatest
                     transitionGeneration = decision.transitionGeneration + 1
+                } else if (!followsLatest) {
+                    // Capture the live anchor once the gesture settles, rather than writing
+                    // pixel offsets into state for every scroll sample.
+                    captureAnchor()?.let { lastHistoryAnchor = it }
                 }
             }
             previousPosition = position
@@ -510,32 +536,21 @@ private fun ConversationViewport(
     ) {
         if (initialProjectionHandled || itemCount == 0) return@LaunchedEffect
         val settlingGeneration = transitionGeneration
-        snapshotFlow {
-            listState.layoutInfo.totalItemsCount == itemCount &&
-                hasUsableViewportGeometry(
-                    dockHeightPx = geometry.dockHeightPx,
-                    viewportStartOffsetPx = listState.layoutInfo.viewportStartOffset,
-                    viewportEndOffsetPx = listState.layoutInfo.viewportEndOffset,
-                )
-        }.filter { it }.first()
-        if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
-            delay(GEOMETRY_RETRY_DELAY_MS)
-            geometryRetryTick += 1
-            return@LaunchedEffect
-        }
-        // A deliberate drag/accessibility scroll can happen while the first
-        // usable geometry is settling. Its generation owns the viewport now;
-        // never let this older initial-latest attempt relatch after that input.
-        if (initialProjectionHandled || settlingGeneration != transitionGeneration) {
-            return@LaunchedEffect
-        }
         val restoringHistory = !followsLatest
         val anchor = pendingAnchor ?: lastHistoryAnchor
         val anchorCanBeRestored = anchor != null && (
-            itemKeys.contains(anchor.key) || anchor.index in itemKeys.indices
+            (anchor.key.isNotEmpty() && itemKeys.contains(anchor.key)) ||
+                anchor.index in itemKeys.indices
         )
-        val decision = policy.decide(
-            ScrollPolicyInput(
+        val settlement = settleViewportTransition(
+            listState = listState,
+            itemCount = itemCount,
+            itemKeys = itemKeys,
+            geometry = geometry,
+            bottomOcclusion = bottomOcclusion,
+            density = density,
+            policy = policy,
+            input = ScrollPolicyInput(
                 followsLatest = followsLatest,
                 restorationPending = restoringHistory,
                 anchorAvailable = anchorCanBeRestored,
@@ -544,34 +559,27 @@ private fun ConversationViewport(
                 pendingGeneration = settlingGeneration,
                 hasItems = true,
             ),
+            anchor = anchor,
+            withGeneration = { generation, action ->
+                scrollForGeneration(generation, action)
+            },
         )
-        if (decision.command == ScrollCommand.CancelPendingFollow) return@LaunchedEffect
+        if (settlement.pendingGeometry) {
+            delay(GEOMETRY_RETRY_DELAY_MS)
+            if (settlingGeneration == transitionGeneration) geometryRetryTick += 1
+            return@LaunchedEffect
+        }
+        if (initialProjectionHandled || settlingGeneration != transitionGeneration) {
+            return@LaunchedEffect
+        }
+        val decision = settlement.decision ?: return@LaunchedEffect
+        if (!settlement.completed || decision.command == ScrollCommand.CancelPendingFollow) {
+            return@LaunchedEffect
+        }
         initialProjectionHandled = true
         followsLatest = decision.followsLatest
-        when (decision.command) {
-            ScrollCommand.FollowLatest -> {
-                scrollForGeneration(decision.transitionGeneration) {
-                    settleTerminalRow(listState, itemCount)
-                }
-            }
-
-            ScrollCommand.RestoreAnchor -> {
-                scrollForGeneration(decision.transitionGeneration) {
-                    val restored = restoreTranscriptAnchor(
-                        listState = listState,
-                        itemKeys = itemKeys,
-                        anchor = anchor,
-                    )
-                    if (decision.fallbackToLatest || !restored) {
-                        settleTerminalRow(listState, itemCount)
-                        recoveryNeeded = true
-                    }
-                }
-                pendingAnchor = null
-            }
-
-            else -> Unit
-        }
+        if (settlement.recoveryNeeded) recoveryNeeded = true
+        if (decision.command == ScrollCommand.RestoreAnchor) pendingAnchor = null
     }
 
     // A single immediate settle handles append, streaming deltas, and terminal-row
@@ -611,7 +619,11 @@ private fun ConversationViewport(
             withFrameNanos { }
             val generation = transitionGeneration
             scrollForGeneration(generation) {
-                settleTerminalRow(listState, itemCount)
+                settleTerminalRow(
+                    listState = listState,
+                    itemCount = itemCount,
+                    dockHeightPx = geometry.dockHeightPx,
+                )
             }
         }
     }
@@ -657,53 +669,44 @@ private fun ConversationViewport(
         // report settled inset state. A zero/stale inset or cancelled IME
         // animation must retry from a later sample, not clear the guard after
         // a fixed frame budget and lose the pending restoration.
-        if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
-            delay(GEOMETRY_RETRY_DELAY_MS)
-            if (generation == transitionGeneration) geometryRetryTick += 1
-            return@LaunchedEffect
-        }
-        if (generation != transitionGeneration) return@LaunchedEffect
-
         val anchor = pendingAnchor
         val anchorCanBeRestored = anchor != null && (
-            itemKeys.contains(anchor.key) || anchor.index in itemKeys.indices
+            (anchor.key.isNotEmpty() && itemKeys.contains(anchor.key)) ||
+                anchor.index in itemKeys.indices
         )
-        val decision = policy.decide(
-            ScrollPolicyInput(
+        val settlement = settleViewportTransition(
+            listState = listState,
+            itemCount = itemCount,
+            itemKeys = itemKeys,
+            geometry = geometry,
+            bottomOcclusion = bottomOcclusion,
+            density = density,
+            policy = policy,
+            input = ScrollPolicyInput(
                 followsLatest = followsLatest,
                 imeOrInsetTransition = true,
                 restorationPending = shouldRestoreAnchor,
                 anchorAvailable = anchorCanBeRestored,
                 transitionSettled = true,
                 transitionGeneration = generation,
-                hasItems = itemCount > 0,
+                hasItems = true,
             ),
+            anchor = anchor,
+            withGeneration = { actionGeneration, action ->
+                scrollForGeneration(actionGeneration, action)
+            },
         )
-        transitionActive = false
-        when (decision.command) {
-            ScrollCommand.FollowLatest -> {
-                scrollForGeneration(generation) {
-                    settleTerminalRow(listState, itemCount)
-                }
-            }
-
-            ScrollCommand.RestoreAnchor -> {
-                scrollForGeneration(generation) {
-                    val restored = restoreTranscriptAnchor(
-                        listState = listState,
-                        itemKeys = itemKeys,
-                        anchor = anchor,
-                    )
-                    if (decision.fallbackToLatest || !restored) {
-                        settleTerminalRow(listState, itemCount)
-                        recoveryNeeded = true
-                    }
-                }
-                pendingAnchor = null
-            }
-
-            else -> Unit
+        if (settlement.pendingGeometry) {
+            delay(GEOMETRY_RETRY_DELAY_MS)
+            if (generation == transitionGeneration) geometryRetryTick += 1
+            return@LaunchedEffect
         }
+        if (generation != transitionGeneration) return@LaunchedEffect
+        val decision = settlement.decision ?: return@LaunchedEffect
+        if (!settlement.completed) return@LaunchedEffect
+        transitionActive = false
+        if (settlement.recoveryNeeded) recoveryNeeded = true
+        if (decision.command == ScrollCommand.RestoreAnchor) pendingAnchor = null
     }
 
     Box(modifier) {
@@ -925,8 +928,9 @@ private data class TerminalLayoutSignature(
 private fun captureTranscriptAnchor(listState: LazyListState): TranscriptAnchor? {
     val layoutInfo = listState.layoutInfo
     val item = layoutInfo.visibleItemsInfo.firstOrNull() ?: return null
+    val anchorKey = item.key.toString()
     return TranscriptAnchor(
-        key = item.key.toString(),
+        key = anchorKey.takeIf { it.length <= MAX_RETAINED_ANCHOR_KEY_LENGTH } ?: "",
         index = item.index,
         relativeOffsetPx = item.offset - layoutInfo.viewportStartOffset,
     )
@@ -938,7 +942,7 @@ private suspend fun restoreTranscriptAnchor(
     anchor: TranscriptAnchor?,
 ): Boolean {
     if (anchor == null || itemKeys.isEmpty()) return false
-    val exactIndex = itemKeys.indexOf(anchor.key)
+    val exactIndex = anchor.key.takeIf { it.isNotEmpty() }?.let(itemKeys::indexOf) ?: -1
     val targetIndex = if (exactIndex >= 0) {
         exactIndex
     } else {
@@ -952,6 +956,71 @@ private suspend fun restoreTranscriptAnchor(
         listState.scrollBy((currentOffset - anchor.relativeOffsetPx).toFloat())
     }
     return true
+}
+
+private data class ViewportSettlement(
+    val pendingGeometry: Boolean,
+    val decision: ScrollPolicyDecision? = null,
+    val recoveryNeeded: Boolean = false,
+    val completed: Boolean = false,
+)
+
+/**
+ * The single settled-transition owner for initial projection, inset changes,
+ * composer growth, reconnect projection, and configuration changes. Geometry
+ * must settle before the policy is allowed to issue a scroll command.
+ */
+private suspend fun settleViewportTransition(
+    listState: LazyListState,
+    itemCount: Int,
+    itemKeys: List<String>,
+    geometry: ViewportGeometry,
+    bottomOcclusion: WindowInsets,
+    density: androidx.compose.ui.unit.Density,
+    policy: ConversationScrollPolicy,
+    input: ScrollPolicyInput,
+    anchor: TranscriptAnchor?,
+    withGeneration: suspend (Long, suspend () -> Unit) -> Boolean,
+): ViewportSettlement {
+    if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
+        return ViewportSettlement(pendingGeometry = true)
+    }
+
+    val decision = policy.decide(input.copy(transitionSettled = true))
+    var recoveryNeeded = false
+    val completed = when (decision.command) {
+        ScrollCommand.FollowLatest -> withGeneration(decision.transitionGeneration) {
+            settleTerminalRow(
+                listState = listState,
+                itemCount = itemCount,
+                dockHeightPx = geometry.dockHeightPx,
+            )
+        }
+
+        ScrollCommand.RestoreAnchor -> withGeneration(decision.transitionGeneration) {
+            val restored = restoreTranscriptAnchor(
+                listState = listState,
+                itemKeys = itemKeys,
+                anchor = anchor,
+            )
+            if (decision.fallbackToLatest || !restored) {
+                settleTerminalRow(
+                    listState = listState,
+                    itemCount = itemCount,
+                    dockHeightPx = geometry.dockHeightPx,
+                )
+                recoveryNeeded = true
+            }
+        }
+
+        else -> true
+    }
+    return ViewportSettlement(
+        pendingGeometry = false,
+        decision = decision,
+        recoveryNeeded = recoveryNeeded,
+        completed = completed,
+    )
 }
 
 private data class GeometrySample(
@@ -1011,6 +1080,7 @@ private suspend fun awaitStableUsableGeometry(
 private suspend fun settleTerminalRow(
     listState: LazyListState,
     itemCount: Int,
+    dockHeightPx: Int,
 ) {
     if (itemCount == 0) return
     listState.scrollToItem(itemCount - 1)
@@ -1022,6 +1092,8 @@ private suspend fun settleTerminalRow(
         terminalOffsetPx = terminal.offset,
         terminalSizePx = terminal.size,
         viewportEndOffsetPx = layoutInfo.viewportEndOffset,
+        afterContentPaddingPx = layoutInfo.afterContentPadding,
+        dockHeightPx = dockHeightPx,
     )
     if (clearance < 0) {
         listState.scrollBy(-clearance.toFloat())
@@ -1046,11 +1118,20 @@ private fun terminalDistanceDp(
     layoutInfo: LazyListLayoutInfo,
     itemCount: Int,
     density: androidx.compose.ui.unit.Density,
+    dockHeightPx: Int,
 ): Float? {
     if (itemCount == 0) return null
     val terminal = layoutInfo.visibleItemsInfo.firstOrNull { it.index == itemCount - 1 }
         ?: return null
-    val distancePx = abs(layoutInfo.viewportEndOffset - (terminal.offset + terminal.size))
+    val distancePx = abs(
+        terminalBottomClearancePx(
+            terminalOffsetPx = terminal.offset,
+            terminalSizePx = terminal.size,
+            viewportEndOffsetPx = layoutInfo.viewportEndOffset,
+            afterContentPaddingPx = layoutInfo.afterContentPadding,
+            dockHeightPx = dockHeightPx,
+        ),
+    )
     return with(density) { distancePx.toDp().value }
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -43,11 +44,13 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.onDispose
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -93,8 +96,11 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+
+private const val GEOMETRY_RETRY_DELAY_MS = 96L
 
 @Composable
 internal fun conversationBottomOcclusionInsets(): WindowInsets =
@@ -102,6 +108,7 @@ internal fun conversationBottomOcclusionInsets(): WindowInsets =
         .union(WindowInsets.navigationBars)
         .union(WindowInsets.systemGestures)
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun ConversationScreen(
     summary: StoredSession,
@@ -119,6 +126,7 @@ internal fun ConversationScreen(
     projectionGeneration: Long = 0L,
     bottomOcclusion: WindowInsets? = null,
     safeDrawingInsets: WindowInsets? = null,
+    bottomOcclusionSettled: Boolean? = null,
 ) {
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -127,6 +135,16 @@ internal fun ConversationScreen(
     val configuration = LocalConfiguration.current
     val activeBottomOcclusion = bottomOcclusion ?: conversationBottomOcclusionInsets()
     val activeSafeDrawingInsets = safeDrawingInsets ?: WindowInsets.safeDrawing
+    val activeBottomOcclusionSettled = bottomOcclusionSettled ?: if (bottomOcclusion == null) {
+        val currentImeBottom = WindowInsets.ime.getBottom(density)
+        val sourceImeBottom = WindowInsets.imeAnimationSource.getBottom(density)
+        val targetImeBottom = WindowInsets.imeAnimationTarget.getBottom(density)
+        currentImeBottom == sourceImeBottom && currentImeBottom == targetImeBottom
+    } else {
+        // Explicit inset seams are deterministic fixtures rather than the
+        // platform animation stream, so their caller owns the settled bit.
+        true
+    }
     val safeDrawingPadding = activeSafeDrawingInsets.asPaddingValues()
     val safeTopPadding = safeDrawingPadding.calculateTopPadding()
     val headerTopPadding = maxOf(34.dp - safeTopPadding, 10.dp)
@@ -231,6 +249,7 @@ internal fun ConversationScreen(
                     streamingText = streamingText,
                     projectionGeneration = projectionGeneration,
                     bottomOcclusion = activeBottomOcclusion,
+                    bottomInsetsSettled = activeBottomOcclusionSettled,
                     dockClearance = with(density) { dockHeightPx.toDp() },
                     safeTopInsetPx = activeSafeDrawingInsets.getTop(density),
                     safeLeftInsetPx = activeSafeDrawingInsets.getLeft(density, layoutDirection),
@@ -267,6 +286,7 @@ private fun ConversationViewport(
     streamingText: String,
     projectionGeneration: Long,
     bottomOcclusion: WindowInsets,
+    bottomInsetsSettled: Boolean,
     dockClearance: Dp,
     safeTopInsetPx: Int,
     safeLeftInsetPx: Int,
@@ -299,9 +319,21 @@ private fun ConversationViewport(
     var previousGeometry by remember(summaryId) { mutableStateOf<ViewportGeometry?>(null) }
     var previousItemKeys by remember(summaryId) { mutableStateOf<List<String>?>(null) }
     var previousProjectionGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
+    var geometryRetryTick by remember(summaryId) { mutableLongStateOf(0L) }
+
+    // rememberCoroutineScope() survives a summary-key change. Dispose the
+    // previous summary's explicit jump/restore job before its list state is
+    // discarded, otherwise a late completion can move the next conversation.
+    DisposableEffect(summaryId) {
+        onDispose {
+            activeScrollJob?.cancel()
+        }
+    }
+
     val geometry = ViewportGeometry(
         dockHeightPx = with(density) { dockClearance.roundToPx() },
         bottomInsetPx = bottomOcclusion.getBottom(density),
+        bottomInsetsSettled = bottomInsetsSettled,
         safeTopInsetPx = safeTopInsetPx,
         safeLeftInsetPx = safeLeftInsetPx,
         safeRightInsetPx = safeRightInsetPx,
@@ -439,7 +471,7 @@ private fun ConversationViewport(
         }
     }
 
-    LaunchedEffect(itemCount, summaryId, geometry, projectionGeneration) {
+    LaunchedEffect(itemCount, summaryId, geometry, projectionGeneration, geometryRetryTick) {
         if (initialProjectionHandled || itemCount == 0) return@LaunchedEffect
         snapshotFlow {
             listState.layoutInfo.totalItemsCount == itemCount &&
@@ -450,6 +482,8 @@ private fun ConversationViewport(
                 )
         }.filter { it }.first()
         if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
+            delay(GEOMETRY_RETRY_DELAY_MS)
+            geometryRetryTick += 1
             return@LaunchedEffect
         }
         if (initialProjectionHandled) return@LaunchedEffect
@@ -510,7 +544,7 @@ private fun ConversationViewport(
         }
     }
 
-    LaunchedEffect(geometry, itemKeys, summaryId, projectionGeneration) {
+    LaunchedEffect(geometry, itemKeys, summaryId, projectionGeneration, geometryRetryTick) {
         val previous = previousGeometry
         val previousKeys = previousItemKeys
         val previousProjection = previousProjectionGeneration
@@ -520,9 +554,17 @@ private fun ConversationViewport(
         val geometryChanged = previous != null && previous != geometry
         val projectionChanged = previousKeys != null && previousKeys != itemKeys
         val generationChanged = previousProjection != null && previousProjection != projectionGeneration
-        if (!geometryChanged && !projectionChanged && !generationChanged) return@LaunchedEffect
+        val retryingPendingGeometry = transitionActive &&
+            !geometryChanged && !projectionChanged && !generationChanged
+        if (!geometryChanged && !projectionChanged && !generationChanged && !retryingPendingGeometry) {
+            return@LaunchedEffect
+        }
 
-        val generation = transitionGeneration + 1
+        val generation = if (retryingPendingGeometry) {
+            transitionGeneration
+        } else {
+            transitionGeneration + 1
+        }
         activeScrollJob?.cancel()
         activeScrollJob = null
         transitionGeneration = generation
@@ -539,11 +581,13 @@ private fun ConversationViewport(
             pendingAnchor = lastHistoryAnchor ?: captureAnchor()
         }
 
-        // Require two identical usable samples so a zero/stale inset or a
-        // cancelled animation is not treated as settled just because two
-        // frames elapsed.
+        // Keep this effect pending until two identical usable samples also
+        // report settled inset state. A zero/stale inset or cancelled IME
+        // animation must retry from a later sample, not clear the guard after
+        // a fixed frame budget and lose the pending restoration.
         if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
-            transitionActive = false
+            delay(GEOMETRY_RETRY_DELAY_MS)
+            if (generation == transitionGeneration) geometryRetryTick += 1
             return@LaunchedEffect
         }
         if (generation != transitionGeneration) return@LaunchedEffect
@@ -777,6 +821,7 @@ private data class TranscriptAnchor(
 private data class ViewportGeometry(
     val dockHeightPx: Int,
     val bottomInsetPx: Int,
+    val bottomInsetsSettled: Boolean,
     val safeTopInsetPx: Int,
     val safeLeftInsetPx: Int,
     val safeRightInsetPx: Int,
@@ -840,6 +885,7 @@ private suspend fun restoreTranscriptAnchor(
 private data class GeometrySample(
     val dockHeightPx: Int,
     val bottomInsetPx: Int,
+    val bottomInsetsSettled: Boolean,
     val totalItemsCount: Int,
     val viewportStartOffset: Int,
     val viewportEndOffset: Int,
@@ -860,6 +906,7 @@ private suspend fun awaitStableUsableGeometry(
         val sample = GeometrySample(
             dockHeightPx = geometry.dockHeightPx,
             bottomInsetPx = bottomOcclusion.getBottom(density),
+            bottomInsetsSettled = geometry.bottomInsetsSettled,
             totalItemsCount = layoutInfo.totalItemsCount,
             viewportStartOffset = layoutInfo.viewportStartOffset,
             viewportEndOffset = layoutInfo.viewportEndOffset,
@@ -871,16 +918,21 @@ private suspend fun awaitStableUsableGeometry(
             stableFrames = 1
         }
         if (sample.totalItemsCount == itemCount &&
-            hasUsableViewportGeometry(
+            hasSettledViewportGeometry(
                 dockHeightPx = sample.dockHeightPx,
                 viewportStartOffsetPx = sample.viewportStartOffset,
                 viewportEndOffsetPx = sample.viewportEndOffset,
+                bottomInsetsSettled = sample.bottomInsetsSettled,
             ) &&
             stableFrames >= 2
         ) {
             return true
         }
     }
+    // Do not convert an invalid but stable sample into a completed transition.
+    // The keyed caller schedules another frame window after a short yield so
+    // cancelled/incomplete IME animations and late inset dispatch can recover
+    // without keeping the recomposer permanently busy.
     return false
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -407,7 +407,7 @@ private fun ConversationViewport(
             ScrollPolicyInput(
                 followsLatest = followsLatest,
                 deliberateDragAway = true,
-                pendingGeneration = transitionGeneration,
+                pendingGeneration = programmaticScrollGeneration ?: transitionGeneration,
                 transitionGeneration = transitionGeneration,
                 hasItems = itemCount > 0,
             ),
@@ -420,7 +420,7 @@ private fun ConversationViewport(
             }
         }
         followsLatest = decision.followsLatest
-        transitionGeneration = decision.transitionGeneration + 1
+        transitionGeneration = decision.transitionGeneration
         transitionActive = false
         programmaticScrollGeneration = null
     }
@@ -430,7 +430,8 @@ private fun ConversationViewport(
         programmaticScrollGeneration = generation
         try {
             action()
-            return true
+            return generation == transitionGeneration &&
+                programmaticScrollGeneration == generation
         } finally {
             if (programmaticScrollGeneration == generation) {
                 programmaticScrollGeneration = null
@@ -471,32 +472,42 @@ private fun ConversationViewport(
         }
     }
 
-    LaunchedEffect(
-        listState,
-        summaryId,
-        followsLatest,
-        transitionGeneration,
-        transitionActive,
-        programmaticScrollGeneration,
-    ) {
+    LaunchedEffect(listState, summaryId, itemCount) {
         var previousPosition: ScrollPosition? = null
         snapshotFlow {
             ScrollPosition(
                 firstVisibleItemIndex = listState.firstVisibleItemIndex,
                 firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
                 isScrollInProgress = listState.isScrollInProgress,
+                programmaticScrollGeneration = programmaticScrollGeneration,
             )
         }.distinctUntilChanged().collect { position ->
             val movedTowardHistory = previousPosition?.let {
                 position.isEarlierThan(it)
             } == true
+            val positionChanged = previousPosition?.let {
+                position.firstVisibleItemIndex != it.firstVisibleItemIndex ||
+                    position.firstVisibleItemScrollOffset != it.firstVisibleItemScrollOffset
+            } == true
             val deliberateScrollBeforeInitialSettle = !initialProjectionHandled &&
                 previousPosition != null &&
-                position != previousPosition
-            if (position.isScrollInProgress &&
-                (movedTowardHistory || deliberateScrollBeforeInitialSettle) &&
-                programmaticScrollGeneration == null
+                positionChanged
+            val userMovedAwayFromLatest = movedTowardHistory || (
+                deliberateScrollBeforeInitialSettle &&
+                    programmaticScrollGeneration == null
+            )
+            val interruptedProgrammaticScroll =
+                (position.programmaticScrollGeneration != null ||
+                    previousPosition?.programmaticScrollGeneration != null) &&
+                    movedTowardHistory
+            if (interruptedProgrammaticScroll ||
+                (position.isScrollInProgress && userMovedAwayFromLatest)
             ) {
+                // An accessibility scroll-to-index and a drag can cancel an
+                // active animateScrollToItem between two snapshots. Treat the
+                // historyward movement as input even while that generation is
+                // still published, rather than allowing its completion to
+                // relatch latest.
                 markHistoryReading()
             } else if (!position.isScrollInProgress &&
                 previousPosition?.isScrollInProgress == true &&
@@ -910,6 +921,7 @@ private data class ScrollPosition(
     val firstVisibleItemIndex: Int,
     val firstVisibleItemScrollOffset: Int,
     val isScrollInProgress: Boolean,
+    val programmaticScrollGeneration: Long? = null,
 ) {
     fun isEarlierThan(other: ScrollPosition): Boolean =
         firstVisibleItemIndex < other.firstVisibleItemIndex ||

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemGestures
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -95,6 +97,12 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 @Composable
+internal fun conversationBottomOcclusionInsets(): WindowInsets =
+    WindowInsets.ime
+        .union(WindowInsets.navigationBars)
+        .union(WindowInsets.systemGestures)
+
+@Composable
 internal fun ConversationScreen(
     summary: StoredSession,
     messages: List<ConversationMessage>,
@@ -108,26 +116,36 @@ internal fun ConversationScreen(
     onInterrupt: () -> Unit,
     onReconnect: () -> Unit,
     onBack: () -> Unit,
+    projectionGeneration: Long = 0L,
+    bottomOcclusion: WindowInsets? = null,
+    safeDrawingInsets: WindowInsets? = null,
 ) {
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val configuration = LocalConfiguration.current
-    val safeDrawingInsets = WindowInsets.safeDrawing
-    val safeDrawingPadding = safeDrawingInsets.asPaddingValues()
+    val activeBottomOcclusion = bottomOcclusion ?: conversationBottomOcclusionInsets()
+    val activeSafeDrawingInsets = safeDrawingInsets ?: WindowInsets.safeDrawing
+    val safeDrawingPadding = activeSafeDrawingInsets.asPaddingValues()
     val safeTopPadding = safeDrawingPadding.calculateTopPadding()
     val headerTopPadding = maxOf(34.dp - safeTopPadding, 10.dp)
-    val bottomOcclusion = remember {
-        WindowInsets.ime.union(WindowInsets.navigationBars)
-    }
     val imeVisible = WindowInsets.ime.getBottom(density) > 0
     var composerFocused by remember(summary.id) { mutableStateOf(false) }
+    var previousImeVisible by remember(summary.id) { mutableStateOf(false) }
     var dockHeightPx by remember(summary.id) { mutableIntStateOf(0) }
 
-    // ConversationScreen owns the second Back. The first one is consumed here
-    // whenever the IME or the composer still owns focus, before route navigation.
-    BackHandler {
+    LaunchedEffect(summary.id, imeVisible, composerFocused) {
+        // Some Android versions let the IME consume Back without clearing the
+        // focused field. Clear that stale focus as soon as the IME actually
+        // reports hidden, so the next Back can leave the conversation.
+        if (previousImeVisible && !imeVisible && composerFocused) {
+            focusManager.clearFocus(force = true)
+        }
+        previousImeVisible = imeVisible
+    }
+
+    fun handleConversationBack() {
         if (imeVisible || composerFocused) {
             focusManager.clearFocus(force = true)
             keyboardController?.hide()
@@ -136,12 +154,16 @@ internal fun ConversationScreen(
         }
     }
 
+    // ConversationScreen owns the second Back. The first one is consumed here
+    // whenever the IME or the composer still owns focus, before route navigation.
+    BackHandler { handleConversationBack() }
+
     CelesteBackdrop(showOrnament = false) {
         Column(
             Modifier
                 .fillMaxSize()
-                .windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Horizontal))
-                .windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
+                .windowInsetsPadding(activeSafeDrawingInsets.only(WindowInsetsSides.Horizontal))
+                .windowInsetsPadding(activeSafeDrawingInsets.only(WindowInsetsSides.Top))
                 .padding(top = headerTopPadding),
         ) {
             Row(
@@ -149,7 +171,7 @@ internal fun ConversationScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(
-                    onClick = onBack,
+                    onClick = ::handleConversationBack,
                     contentPadding = PaddingValues(horizontal = 6.dp, vertical = 8.dp),
                 ) {
                     Text("←  Back", color = CelesteBlue, fontWeight = FontWeight.SemiBold)
@@ -207,10 +229,12 @@ internal fun ConversationScreen(
                     summaryId = summary.id,
                     messages = messages,
                     streamingText = streamingText,
+                    projectionGeneration = projectionGeneration,
+                    bottomOcclusion = activeBottomOcclusion,
                     dockClearance = with(density) { dockHeightPx.toDp() },
-                    safeTopInsetPx = safeDrawingInsets.getTop(density),
-                    safeLeftInsetPx = safeDrawingInsets.getLeft(density, layoutDirection),
-                    safeRightInsetPx = safeDrawingInsets.getRight(density, layoutDirection),
+                    safeTopInsetPx = activeSafeDrawingInsets.getTop(density),
+                    safeLeftInsetPx = activeSafeDrawingInsets.getLeft(density, layoutDirection),
+                    safeRightInsetPx = activeSafeDrawingInsets.getRight(density, layoutDirection),
                     configurationWidthDp = configuration.screenWidthDp,
                     configurationHeightDp = configuration.screenHeightDp,
                     configurationOrientation = configuration.orientation,
@@ -219,7 +243,7 @@ internal fun ConversationScreen(
                 )
                 ComposerDock(
                     modifier = Modifier.align(Alignment.BottomCenter),
-                    bottomOcclusion = bottomOcclusion,
+                    bottomOcclusion = activeBottomOcclusion,
                     draft = draft,
                     turnState = turnState,
                     onDraftChange = onDraftChange,
@@ -241,6 +265,8 @@ private fun ConversationViewport(
     summaryId: String,
     messages: List<ConversationMessage>,
     streamingText: String,
+    projectionGeneration: Long,
+    bottomOcclusion: WindowInsets,
     dockClearance: Dp,
     safeTopInsetPx: Int,
     safeLeftInsetPx: Int,
@@ -271,12 +297,11 @@ private fun ConversationViewport(
     var programmaticScrollGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
     var activeScrollJob by remember(summaryId) { mutableStateOf<Job?>(null) }
     var previousGeometry by remember(summaryId) { mutableStateOf<ViewportGeometry?>(null) }
+    var previousItemKeys by remember(summaryId) { mutableStateOf<List<String>?>(null) }
+    var previousProjectionGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
     val geometry = ViewportGeometry(
         dockHeightPx = with(density) { dockClearance.roundToPx() },
-        bottomInsetPx = activeBottomOcclusionPx(
-            imeBottomPx = WindowInsets.ime.getBottom(density),
-            navigationBottomPx = WindowInsets.navigationBars.getBottom(density),
-        ),
+        bottomInsetPx = bottomOcclusion.getBottom(density),
         safeTopInsetPx = safeTopInsetPx,
         safeLeftInsetPx = safeLeftInsetPx,
         safeRightInsetPx = safeRightInsetPx,
@@ -352,6 +377,7 @@ private fun ConversationViewport(
         activeScrollJob = scope.launch {
             scrollForGeneration(generation) {
                 listState.animateScrollToItem(itemCount - 1)
+                settleTerminalRow(listState, itemCount)
             }
         }
     }
@@ -413,12 +439,19 @@ private fun ConversationViewport(
         }
     }
 
-    LaunchedEffect(itemCount, summaryId) {
+    LaunchedEffect(itemCount, summaryId, geometry, projectionGeneration) {
         if (initialProjectionHandled || itemCount == 0) return@LaunchedEffect
         snapshotFlow {
             listState.layoutInfo.totalItemsCount == itemCount &&
-                listState.layoutInfo.viewportEndOffset > listState.layoutInfo.viewportStartOffset
+                hasUsableViewportGeometry(
+                    dockHeightPx = geometry.dockHeightPx,
+                    viewportStartOffsetPx = listState.layoutInfo.viewportStartOffset,
+                    viewportEndOffsetPx = listState.layoutInfo.viewportEndOffset,
+                )
         }.filter { it }.first()
+        if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
+            return@LaunchedEffect
+        }
         if (initialProjectionHandled) return@LaunchedEffect
         val decision = policy.decide(
             ScrollPolicyInput(
@@ -433,7 +466,7 @@ private fun ConversationViewport(
         if (decision.command == ScrollCommand.FollowLatest) {
             val generation = decision.transitionGeneration
             scrollForGeneration(generation) {
-                listState.scrollToItem(itemCount - 1)
+                settleTerminalRow(listState, itemCount)
             }
         }
     }
@@ -447,12 +480,19 @@ private fun ConversationViewport(
         followsLatest,
         transitionGeneration,
         transitionActive,
+        projectionGeneration,
     ) {
         if (!followsLatest || itemCount == 0) return@LaunchedEffect
         snapshotFlow {
             terminalLayoutSignature(listState.layoutInfo, itemCount)
         }.distinctUntilChanged().collectLatest {
             if (transitionActive) return@collectLatest
+            if (!hasUsableViewportGeometry(
+                    dockHeightPx = geometry.dockHeightPx,
+                    viewportStartOffsetPx = listState.layoutInfo.viewportStartOffset,
+                    viewportEndOffsetPx = listState.layoutInfo.viewportEndOffset,
+                )
+            ) return@collectLatest
             val decision = policy.decide(
                 ScrollPolicyInput(
                     followsLatest = followsLatest,
@@ -465,30 +505,47 @@ private fun ConversationViewport(
             withFrameNanos { }
             val generation = transitionGeneration
             scrollForGeneration(generation) {
-                listState.scrollToItem(itemCount - 1)
+                settleTerminalRow(listState, itemCount)
             }
         }
     }
 
-    LaunchedEffect(geometry, summaryId) {
+    LaunchedEffect(geometry, itemKeys, summaryId, projectionGeneration) {
         val previous = previousGeometry
+        val previousKeys = previousItemKeys
+        val previousProjection = previousProjectionGeneration
         previousGeometry = geometry
-        if (previous == null || previous == geometry) return@LaunchedEffect
+        previousItemKeys = itemKeys
+        previousProjectionGeneration = projectionGeneration
+        val geometryChanged = previous != null && previous != geometry
+        val projectionChanged = previousKeys != null && previousKeys != itemKeys
+        val generationChanged = previousProjection != null && previousProjection != projectionGeneration
+        if (!geometryChanged && !projectionChanged && !generationChanged) return@LaunchedEffect
 
         val generation = transitionGeneration + 1
         activeScrollJob?.cancel()
         activeScrollJob = null
         transitionGeneration = generation
         transitionActive = true
+        if (itemCount == 0) {
+            pendingAnchor = null
+            lastHistoryAnchor = null
+            recoveryNeeded = false
+            transitionActive = false
+            return@LaunchedEffect
+        }
         val shouldRestoreAnchor = !followsLatest
         if (shouldRestoreAnchor) {
             pendingAnchor = lastHistoryAnchor ?: captureAnchor()
         }
 
-        // Two settled frames let the dock, IME, and list report their new bounds
-        // before a follow or anchor command is issued.
-        withFrameNanos { }
-        withFrameNanos { }
+        // Require two identical usable samples so a zero/stale inset or a
+        // cancelled animation is not treated as settled just because two
+        // frames elapsed.
+        if (!awaitStableUsableGeometry(listState, itemCount, geometry, bottomOcclusion, density)) {
+            transitionActive = false
+            return@LaunchedEffect
+        }
         if (generation != transitionGeneration) return@LaunchedEffect
 
         val anchor = pendingAnchor
@@ -510,7 +567,7 @@ private fun ConversationViewport(
         when (decision.command) {
             ScrollCommand.FollowLatest -> {
                 scrollForGeneration(generation) {
-                    listState.scrollToItem(itemCount - 1)
+                    settleTerminalRow(listState, itemCount)
                 }
             }
 
@@ -522,7 +579,7 @@ private fun ConversationViewport(
                         anchor = anchor,
                     )
                     if (decision.fallbackToLatest || !restored) {
-                        listState.scrollToItem(itemCount - 1)
+                        settleTerminalRow(listState, itemCount)
                         recoveryNeeded = true
                     }
                 }
@@ -551,14 +608,30 @@ private fun ConversationViewport(
             itemsIndexed(
                 items = messages,
                 key = { index, _ -> transcriptKeys[index] },
-            ) { _, message ->
-                MessageBubble(message)
+            ) { index, message ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics {
+                            if (!hasStreamingRow && index == itemCount - 1) {
+                                contentDescription = "Terminal transcript row"
+                            }
+                        },
+                ) {
+                    MessageBubble(message)
+                }
             }
             if (hasStreamingRow) {
                 item(key = STREAMING_TRANSCRIPT_KEY) {
-                    MessageBubble(
-                        ConversationMessage(role = "assistant", text = streamingText, pending = true),
-                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { contentDescription = "Terminal transcript row" },
+                    ) {
+                        MessageBubble(
+                            ConversationMessage(role = "assistant", text = streamingText, pending = true),
+                        )
+                    }
                 }
             }
         }
@@ -661,7 +734,7 @@ private fun ComposerDock(
             when (turnState) {
                 TurnState.Running -> OutlinedButton(
                     onClick = onInterrupt,
-                    modifier = Modifier.height(46.dp),
+                    modifier = Modifier.defaultMinSize(minHeight = 46.dp),
                     shape = RoundedCornerShape(23.dp),
                     border = androidx.compose.foundation.BorderStroke(1.dp, CelesteCoral),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteCoral),
@@ -669,7 +742,7 @@ private fun ComposerDock(
 
                 TurnState.Reconnecting -> OutlinedButton(
                     onClick = onReconnect,
-                    modifier = Modifier.height(46.dp),
+                    modifier = Modifier.defaultMinSize(minHeight = 46.dp),
                     shape = RoundedCornerShape(23.dp),
                     border = androidx.compose.foundation.BorderStroke(1.dp, CelesteBlue),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteBlue),
@@ -681,7 +754,7 @@ private fun ComposerDock(
                         focusManager.clearFocus()
                     },
                     enabled = draft.isNotBlank() && turnState == TurnState.Idle,
-                    modifier = Modifier.height(46.dp),
+                    modifier = Modifier.defaultMinSize(minHeight = 46.dp),
                     shape = RoundedCornerShape(23.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = CelesteInk,
@@ -762,6 +835,73 @@ private suspend fun restoreTranscriptAnchor(
         listState.scrollBy((currentOffset - anchor.relativeOffsetPx).toFloat())
     }
     return true
+}
+
+private data class GeometrySample(
+    val dockHeightPx: Int,
+    val bottomInsetPx: Int,
+    val totalItemsCount: Int,
+    val viewportStartOffset: Int,
+    val viewportEndOffset: Int,
+)
+
+private suspend fun awaitStableUsableGeometry(
+    listState: LazyListState,
+    itemCount: Int,
+    geometry: ViewportGeometry,
+    bottomOcclusion: WindowInsets,
+    density: androidx.compose.ui.unit.Density,
+): Boolean {
+    var previous: GeometrySample? = null
+    var stableFrames = 0
+    repeat(12) {
+        withFrameNanos { }
+        val layoutInfo = listState.layoutInfo
+        val sample = GeometrySample(
+            dockHeightPx = geometry.dockHeightPx,
+            bottomInsetPx = bottomOcclusion.getBottom(density),
+            totalItemsCount = layoutInfo.totalItemsCount,
+            viewportStartOffset = layoutInfo.viewportStartOffset,
+            viewportEndOffset = layoutInfo.viewportEndOffset,
+        )
+        if (sample == previous) {
+            stableFrames += 1
+        } else {
+            previous = sample
+            stableFrames = 1
+        }
+        if (sample.totalItemsCount == itemCount &&
+            hasUsableViewportGeometry(
+                dockHeightPx = sample.dockHeightPx,
+                viewportStartOffsetPx = sample.viewportStartOffset,
+                viewportEndOffsetPx = sample.viewportEndOffset,
+            ) &&
+            stableFrames >= 2
+        ) {
+            return true
+        }
+    }
+    return false
+}
+
+private suspend fun settleTerminalRow(
+    listState: LazyListState,
+    itemCount: Int,
+) {
+    if (itemCount == 0) return
+    listState.scrollToItem(itemCount - 1)
+    withFrameNanos { }
+    val layoutInfo = listState.layoutInfo
+    val terminal = layoutInfo.visibleItemsInfo.firstOrNull { it.index == itemCount - 1 }
+        ?: return
+    val clearance = terminalBottomClearancePx(
+        terminalOffsetPx = terminal.offset,
+        terminalSizePx = terminal.size,
+        viewportEndOffsetPx = layoutInfo.viewportEndOffset,
+    )
+    if (clearance < 0) {
+        listState.scrollBy(-clearance.toFloat())
+    }
 }
 
 private fun terminalLayoutSignature(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -1,8 +1,11 @@
 package dev.hazydreams.hermesceleste.ui.conversation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,16 +16,18 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListLayoutInfo
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -37,14 +42,32 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.TurnState
@@ -60,8 +83,16 @@ import dev.hazydreams.hermesceleste.ui.CelesteInk
 import dev.hazydreams.hermesceleste.ui.CelesteMuted
 import dev.hazydreams.hermesceleste.ui.CelestePanel
 import dev.hazydreams.hermesceleste.ui.CelestePaper
-
 import dev.hazydreams.hermesceleste.ui.StatusMessage
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 @Composable
 internal fun ConversationScreen(
@@ -78,17 +109,31 @@ internal fun ConversationScreen(
     onReconnect: () -> Unit,
     onBack: () -> Unit,
 ) {
-    val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
-    val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
-    val visibleMessageCount = messages.size + if (streamingText.isNotBlank()) 1 else 0
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val configuration = LocalConfiguration.current
     val safeDrawingInsets = WindowInsets.safeDrawing
-    val headerTopPadding = maxOf(
-        34.dp,
-        safeDrawingInsets.asPaddingValues().calculateTopPadding() + 10.dp,
-    )
-    LaunchedEffect(visibleMessageCount, streamingText.length) {
-        if (visibleMessageCount > 0) listState.animateScrollToItem(visibleMessageCount - 1)
+    val safeDrawingPadding = safeDrawingInsets.asPaddingValues()
+    val safeTopPadding = safeDrawingPadding.calculateTopPadding()
+    val headerTopPadding = maxOf(34.dp - safeTopPadding, 10.dp)
+    val bottomOcclusion = remember {
+        WindowInsets.ime.union(WindowInsets.navigationBars)
+    }
+    val imeVisible = WindowInsets.ime.getBottom(density) > 0
+    var composerFocused by remember(summary.id) { mutableStateOf(false) }
+    var dockHeightPx by remember(summary.id) { mutableIntStateOf(0) }
+
+    // ConversationScreen owns the second Back. The first one is consumed here
+    // whenever the IME or the composer still owns focus, before route navigation.
+    BackHandler {
+        if (imeVisible || composerFocused) {
+            focusManager.clearFocus(force = true)
+            keyboardController?.hide()
+        } else {
+            onBack()
+        }
     }
 
     CelesteBackdrop(showOrnament = false) {
@@ -96,6 +141,7 @@ internal fun ConversationScreen(
             Modifier
                 .fillMaxSize()
                 .windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Horizontal))
+                .windowInsetsPadding(safeDrawingInsets.only(WindowInsetsSides.Top))
                 .padding(top = headerTopPadding),
         ) {
             Row(
@@ -127,7 +173,10 @@ internal fun ConversationScreen(
                 Spacer(Modifier.height(6.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     androidx.compose.foundation.layout.Box(
-                        Modifier.size(6.dp).background(turnStateColor(turnState), androidx.compose.foundation.shape.CircleShape),
+                        Modifier.size(6.dp).background(
+                            turnStateColor(turnState),
+                            androidx.compose.foundation.shape.CircleShape,
+                        ),
                     )
                     Spacer(Modifier.size(7.dp))
                     Text(
@@ -153,128 +202,592 @@ internal fun ConversationScreen(
                 }
             }
 
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.weight(1f).fillMaxWidth(),
-                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 26.dp),
-                verticalArrangement = Arrangement.spacedBy(25.dp),
-            ) {
-                itemsIndexed(
-                    items = messages,
-                    key = { index, _ -> transcriptKeys[index] },
-                ) { _, message ->
-                    MessageBubble(message)
-                }
-                if (streamingText.isNotBlank()) {
-                    item(key = STREAMING_TRANSCRIPT_KEY) {
-                        MessageBubble(
-                            ConversationMessage(role = "assistant", text = streamingText, pending = true),
-                        )
-                    }
-                }
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(CelestePanel)
-                    .border(1.dp, CelesteHairline)
-                    .navigationBarsPadding()
-                    .imePadding()
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
-            ) {
-                OutlinedTextField(
-                    value = draft,
-                    onValueChange = onDraftChange,
-                    enabled = turnState == TurnState.Idle || turnState == TurnState.Reconnecting,
-                    modifier = Modifier.fillMaxWidth(),
-                    placeholder = {
-                        Text(
-                            when (turnState) {
-                                TurnState.Idle -> "Message Hermes"
-                                TurnState.Running -> "Hermes is responding…"
-                                TurnState.Synchronizing -> "Synchronizing…"
-                                TurnState.Reconnecting -> "Keep drafting while Celeste reconnects…"
-                            },
-                            color = CelesteMuted,
-                        )
-                    },
-                    minLines = 1,
-                    maxLines = 5,
-                    shape = RoundedCornerShape(22.dp),
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                    keyboardActions = KeyboardActions(
-                        onSend = {
-                            if (draft.isNotBlank() && turnState == TurnState.Idle) {
-                                onSend()
-                                focusManager.clearFocus()
-                            }
-                        },
-                    ),
-                    textStyle = MaterialTheme.typography.bodyLarge,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = CelesteBlue,
-                        unfocusedBorderColor = CelesteHairline,
-                        focusedContainerColor = CelestePaper,
-                        unfocusedContainerColor = CelestePaper,
-                        disabledContainerColor = CelestePaper,
-                        cursorColor = CelesteBlue,
-                    ),
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                ConversationViewport(
+                    summaryId = summary.id,
+                    messages = messages,
+                    streamingText = streamingText,
+                    dockClearance = with(density) { dockHeightPx.toDp() },
+                    safeTopInsetPx = safeDrawingInsets.getTop(density),
+                    safeLeftInsetPx = safeDrawingInsets.getLeft(density, layoutDirection),
+                    safeRightInsetPx = safeDrawingInsets.getRight(density, layoutDirection),
+                    configurationWidthDp = configuration.screenWidthDp,
+                    configurationHeightDp = configuration.screenHeightDp,
+                    configurationOrientation = configuration.orientation,
+                    configurationFontScale = configuration.fontScale,
+                    modifier = Modifier.fillMaxSize(),
                 )
-                Spacer(Modifier.height(10.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = when (turnState) {
-                            TurnState.Idle -> ""
-                            TurnState.Running -> "Responding"
-                            TurnState.Synchronizing -> "Synchronizing"
-                            TurnState.Reconnecting -> "Draft saved here"
-                        },
-                        color = CelesteMuted,
-                        fontSize = 11.sp,
-                        modifier = Modifier.weight(1f),
-                    )
-                    when (turnState) {
-                        TurnState.Running -> OutlinedButton(
-                            onClick = onInterrupt,
-                            modifier = Modifier.height(46.dp),
-                            shape = RoundedCornerShape(23.dp),
-                            border = androidx.compose.foundation.BorderStroke(1.dp, CelesteCoral),
-                            colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteCoral),
-                        ) { Text("Stop", fontWeight = FontWeight.SemiBold) }
-
-                        TurnState.Reconnecting -> OutlinedButton(
-                            onClick = onReconnect,
-                            modifier = Modifier.height(46.dp),
-                            shape = RoundedCornerShape(23.dp),
-                            border = androidx.compose.foundation.BorderStroke(1.dp, CelesteBlue),
-                            colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteBlue),
-                        ) { Text("Retry", fontWeight = FontWeight.SemiBold) }
-
-                        else -> Button(
-                            onClick = {
-                                onSend()
-                                focusManager.clearFocus()
-                            },
-                            enabled = draft.isNotBlank() && turnState == TurnState.Idle,
-                            modifier = Modifier.height(46.dp),
-                            shape = RoundedCornerShape(23.dp),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = CelesteInk,
-                                contentColor = CelestePaper,
-                                disabledContainerColor = CelesteHairline,
-                                disabledContentColor = CelesteMuted,
-                            ),
-                        ) { Text("Send  →", fontWeight = FontWeight.Bold) }
-                    }
-                }
+                ComposerDock(
+                    modifier = Modifier.align(Alignment.BottomCenter),
+                    bottomOcclusion = bottomOcclusion,
+                    draft = draft,
+                    turnState = turnState,
+                    onDraftChange = onDraftChange,
+                    onSend = onSend,
+                    onInterrupt = onInterrupt,
+                    onReconnect = onReconnect,
+                    onFocusChanged = { composerFocused = it },
+                    onMeasured = { measuredHeight ->
+                        if (dockHeightPx != measuredHeight) dockHeightPx = measuredHeight
+                    },
+                )
             }
         }
     }
+}
+
+@Composable
+private fun ConversationViewport(
+    summaryId: String,
+    messages: List<ConversationMessage>,
+    streamingText: String,
+    dockClearance: Dp,
+    safeTopInsetPx: Int,
+    safeLeftInsetPx: Int,
+    safeRightInsetPx: Int,
+    configurationWidthDp: Int,
+    configurationHeightDp: Int,
+    configurationOrientation: Int,
+    configurationFontScale: Float,
+    modifier: Modifier,
+) {
+    val density = LocalDensity.current
+    val scope = rememberCoroutineScope()
+    val listState = remember(summaryId) { LazyListState() }
+    val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
+    val hasStreamingRow = streamingText.isNotBlank()
+    val itemCount = messages.size + if (hasStreamingRow) 1 else 0
+    val itemKeys = remember(transcriptKeys, hasStreamingRow) {
+        if (hasStreamingRow) transcriptKeys + STREAMING_TRANSCRIPT_KEY else transcriptKeys
+    }
+    val policy = remember(summaryId) { ConversationScrollPolicy() }
+    var followsLatest by remember(summaryId) { mutableStateOf(true) }
+    var transitionGeneration by remember(summaryId) { mutableLongStateOf(0L) }
+    var transitionActive by remember(summaryId) { mutableStateOf(false) }
+    var initialProjectionHandled by remember(summaryId) { mutableStateOf(false) }
+    var pendingAnchor by remember(summaryId) { mutableStateOf<TranscriptAnchor?>(null) }
+    var lastHistoryAnchor by remember(summaryId) { mutableStateOf<TranscriptAnchor?>(null) }
+    var recoveryNeeded by remember(summaryId) { mutableStateOf(false) }
+    var programmaticScrollGeneration by remember(summaryId) { mutableStateOf<Long?>(null) }
+    var activeScrollJob by remember(summaryId) { mutableStateOf<Job?>(null) }
+    var previousGeometry by remember(summaryId) { mutableStateOf<ViewportGeometry?>(null) }
+    val geometry = ViewportGeometry(
+        dockHeightPx = with(density) { dockClearance.roundToPx() },
+        bottomInsetPx = activeBottomOcclusionPx(
+            imeBottomPx = WindowInsets.ime.getBottom(density),
+            navigationBottomPx = WindowInsets.navigationBars.getBottom(density),
+        ),
+        safeTopInsetPx = safeTopInsetPx,
+        safeLeftInsetPx = safeLeftInsetPx,
+        safeRightInsetPx = safeRightInsetPx,
+        configurationWidthDp = configurationWidthDp,
+        configurationHeightDp = configurationHeightDp,
+        configurationOrientation = configurationOrientation,
+        configurationFontScale = configurationFontScale,
+    )
+    val terminalDistanceDp by remember(listState, itemCount, density) {
+        derivedStateOf {
+            terminalDistanceDp(listState.layoutInfo, itemCount, density)
+        }
+    }
+    val showJumpToLatest = itemCount > 0 && !followsLatest &&
+        (recoveryNeeded || !policy.isNearBottom(terminalDistanceDp))
+
+    fun captureAnchor(): TranscriptAnchor? = captureTranscriptAnchor(listState)
+
+    fun markHistoryReading() {
+        activeScrollJob?.cancel()
+        activeScrollJob = null
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = followsLatest,
+                deliberateDragAway = true,
+                pendingGeneration = transitionGeneration,
+                transitionGeneration = transitionGeneration,
+                hasItems = itemCount > 0,
+            ),
+        )
+        if (itemCount > 0) {
+            val anchor = captureAnchor()
+            if (anchor != null) {
+                lastHistoryAnchor = anchor
+                pendingAnchor = anchor
+            }
+        }
+        followsLatest = decision.followsLatest
+        transitionGeneration = decision.transitionGeneration + 1
+        transitionActive = false
+        programmaticScrollGeneration = null
+    }
+
+    suspend fun scrollForGeneration(generation: Long, action: suspend () -> Unit) {
+        if (generation != transitionGeneration) return
+        programmaticScrollGeneration = generation
+        try {
+            action()
+        } finally {
+            if (programmaticScrollGeneration == generation) {
+                programmaticScrollGeneration = null
+            }
+        }
+    }
+
+    fun jumpToLatest() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = followsLatest,
+                explicitJumpToLatest = true,
+                transitionGeneration = transitionGeneration,
+                hasItems = itemCount > 0,
+            ),
+        )
+        if (decision.command != ScrollCommand.JumpToLatest || itemCount == 0) return
+        followsLatest = decision.followsLatest
+        recoveryNeeded = false
+        pendingAnchor = null
+        transitionActive = false
+        transitionGeneration = decision.transitionGeneration + 1
+        val generation = transitionGeneration
+        activeScrollJob?.cancel()
+        activeScrollJob = scope.launch {
+            scrollForGeneration(generation) {
+                listState.animateScrollToItem(itemCount - 1)
+            }
+        }
+    }
+
+    LaunchedEffect(listState, summaryId, followsLatest) {
+        snapshotFlow { captureTranscriptAnchor(listState) }
+            .filterNotNull()
+            .distinctUntilChanged()
+            .collect { anchor ->
+                if (!followsLatest) lastHistoryAnchor = anchor
+            }
+    }
+
+    LaunchedEffect(
+        listState,
+        summaryId,
+        followsLatest,
+        transitionGeneration,
+        transitionActive,
+        programmaticScrollGeneration,
+    ) {
+        var previousPosition: ScrollPosition? = null
+        snapshotFlow {
+            ScrollPosition(
+                firstVisibleItemIndex = listState.firstVisibleItemIndex,
+                firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset,
+                isScrollInProgress = listState.isScrollInProgress,
+            )
+        }.distinctUntilChanged().collect { position ->
+            val movedTowardHistory = previousPosition?.let {
+                position.isEarlierThan(it)
+            } == true
+            if (position.isScrollInProgress &&
+                movedTowardHistory &&
+                programmaticScrollGeneration == null
+            ) {
+                markHistoryReading()
+            } else if (!position.isScrollInProgress &&
+                previousPosition?.isScrollInProgress == true &&
+                programmaticScrollGeneration == null
+            ) {
+                val decision = policy.decide(
+                    ScrollPolicyInput(
+                        followsLatest = followsLatest,
+                        nearBottomDistanceDp = terminalDistanceDp,
+                        imeOrInsetTransition = transitionActive,
+                        transitionSettled = !transitionActive,
+                        transitionGeneration = transitionGeneration,
+                        hasItems = itemCount > 0,
+                        allowRelatch = true,
+                    ),
+                )
+                if (decision.command == ScrollCommand.RelatchLatest) {
+                    followsLatest = decision.followsLatest
+                    transitionGeneration = decision.transitionGeneration + 1
+                }
+            }
+            previousPosition = position
+        }
+    }
+
+    LaunchedEffect(itemCount, summaryId) {
+        if (initialProjectionHandled || itemCount == 0) return@LaunchedEffect
+        snapshotFlow {
+            listState.layoutInfo.totalItemsCount == itemCount &&
+                listState.layoutInfo.viewportEndOffset > listState.layoutInfo.viewportStartOffset
+        }.filter { it }.first()
+        if (initialProjectionHandled) return@LaunchedEffect
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = followsLatest,
+                initialProjectionReady = true,
+                transitionGeneration = transitionGeneration,
+                hasItems = true,
+            ),
+        )
+        initialProjectionHandled = true
+        followsLatest = decision.followsLatest
+        if (decision.command == ScrollCommand.FollowLatest) {
+            val generation = decision.transitionGeneration
+            scrollForGeneration(generation) {
+                listState.scrollToItem(itemCount - 1)
+            }
+        }
+    }
+
+    // A single immediate settle handles append, streaming deltas, and terminal-row
+    // growth without animating once per token or touching a history reader.
+    LaunchedEffect(
+        listState,
+        summaryId,
+        itemCount,
+        followsLatest,
+        transitionGeneration,
+        transitionActive,
+    ) {
+        if (!followsLatest || itemCount == 0) return@LaunchedEffect
+        snapshotFlow {
+            terminalLayoutSignature(listState.layoutInfo, itemCount)
+        }.distinctUntilChanged().collectLatest {
+            if (transitionActive) return@collectLatest
+            val decision = policy.decide(
+                ScrollPolicyInput(
+                    followsLatest = followsLatest,
+                    contentChanged = true,
+                    transitionGeneration = transitionGeneration,
+                    hasItems = true,
+                ),
+            )
+            if (decision.command != ScrollCommand.FollowLatest) return@collectLatest
+            withFrameNanos { }
+            val generation = transitionGeneration
+            scrollForGeneration(generation) {
+                listState.scrollToItem(itemCount - 1)
+            }
+        }
+    }
+
+    LaunchedEffect(geometry, summaryId) {
+        val previous = previousGeometry
+        previousGeometry = geometry
+        if (previous == null || previous == geometry) return@LaunchedEffect
+
+        val generation = transitionGeneration + 1
+        activeScrollJob?.cancel()
+        activeScrollJob = null
+        transitionGeneration = generation
+        transitionActive = true
+        val shouldRestoreAnchor = !followsLatest
+        if (shouldRestoreAnchor) {
+            pendingAnchor = lastHistoryAnchor ?: captureAnchor()
+        }
+
+        // Two settled frames let the dock, IME, and list report their new bounds
+        // before a follow or anchor command is issued.
+        withFrameNanos { }
+        withFrameNanos { }
+        if (generation != transitionGeneration) return@LaunchedEffect
+
+        val anchor = pendingAnchor
+        val anchorCanBeRestored = anchor != null && (
+            itemKeys.contains(anchor.key) || anchor.index in itemKeys.indices
+        )
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = followsLatest,
+                imeOrInsetTransition = true,
+                restorationPending = shouldRestoreAnchor,
+                anchorAvailable = anchorCanBeRestored,
+                transitionSettled = true,
+                transitionGeneration = generation,
+                hasItems = itemCount > 0,
+            ),
+        )
+        transitionActive = false
+        when (decision.command) {
+            ScrollCommand.FollowLatest -> {
+                scrollForGeneration(generation) {
+                    listState.scrollToItem(itemCount - 1)
+                }
+            }
+
+            ScrollCommand.RestoreAnchor -> {
+                scrollForGeneration(generation) {
+                    val restored = restoreTranscriptAnchor(
+                        listState = listState,
+                        itemKeys = itemKeys,
+                        anchor = anchor,
+                    )
+                    if (decision.fallbackToLatest || !restored) {
+                        listState.scrollToItem(itemCount - 1)
+                        recoveryNeeded = true
+                    }
+                }
+                pendingAnchor = null
+            }
+
+            else -> Unit
+        }
+    }
+
+    Box(modifier) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .semantics {
+                    contentDescription = "Conversation transcript"
+                },
+            contentPadding = PaddingValues(
+                horizontal = 24.dp,
+                top = 26.dp,
+                bottom = dockClearance + 26.dp,
+            ),
+            verticalArrangement = Arrangement.spacedBy(25.dp),
+        ) {
+            itemsIndexed(
+                items = messages,
+                key = { index, _ -> transcriptKeys[index] },
+            ) { _, message ->
+                MessageBubble(message)
+            }
+            if (hasStreamingRow) {
+                item(key = STREAMING_TRANSCRIPT_KEY) {
+                    MessageBubble(
+                        ConversationMessage(role = "assistant", text = streamingText, pending = true),
+                    )
+                }
+            }
+        }
+
+        if (showJumpToLatest) {
+            TextButton(
+                onClick = ::jumpToLatest,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = dockClearance + 8.dp)
+                    .semantics { contentDescription = "Jump to latest" },
+            ) {
+                Text("Jump to latest", color = CelesteBlue, fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComposerDock(
+    modifier: Modifier,
+    bottomOcclusion: WindowInsets,
+    draft: String,
+    turnState: TurnState,
+    onDraftChange: (String) -> Unit,
+    onSend: () -> Unit,
+    onInterrupt: () -> Unit,
+    onReconnect: () -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
+    onMeasured: (Int) -> Unit,
+) {
+    val focusManager = LocalFocusManager.current
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(CelestePanel)
+            .border(1.dp, CelesteHairline)
+            .windowInsetsPadding(bottomOcclusion.only(WindowInsetsSides.Bottom))
+            .onGloballyPositioned { coordinates -> onMeasured(coordinates.size.height) }
+            .padding(horizontal = 16.dp, vertical = 14.dp)
+            .semantics { contentDescription = "Message composer" },
+    ) {
+        OutlinedTextField(
+            value = draft,
+            onValueChange = onDraftChange,
+            enabled = turnState == TurnState.Idle || turnState == TurnState.Reconnecting,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusChanged { onFocusChanged(it.isFocused) },
+            placeholder = {
+                Text(
+                    when (turnState) {
+                        TurnState.Idle -> "Message Hermes"
+                        TurnState.Running -> "Hermes is responding…"
+                        TurnState.Synchronizing -> "Synchronizing…"
+                        TurnState.Reconnecting -> "Keep drafting while Celeste reconnects…"
+                    },
+                    color = CelesteMuted,
+                )
+            },
+            minLines = 1,
+            maxLines = 5,
+            shape = RoundedCornerShape(22.dp),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+            keyboardActions = KeyboardActions(
+                onSend = {
+                    if (draft.isNotBlank() && turnState == TurnState.Idle) {
+                        onSend()
+                        focusManager.clearFocus()
+                    }
+                },
+            ),
+            textStyle = MaterialTheme.typography.bodyLarge,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = CelesteBlue,
+                unfocusedBorderColor = CelesteHairline,
+                focusedContainerColor = CelestePaper,
+                unfocusedContainerColor = CelestePaper,
+                disabledContainerColor = CelestePaper,
+                cursorColor = CelesteBlue,
+            ),
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = when (turnState) {
+                    TurnState.Idle -> ""
+                    TurnState.Running -> "Responding"
+                    TurnState.Synchronizing -> "Synchronizing"
+                    TurnState.Reconnecting -> "Draft saved here"
+                },
+                color = CelesteMuted,
+                fontSize = 11.sp,
+                modifier = Modifier.weight(1f),
+            )
+            when (turnState) {
+                TurnState.Running -> OutlinedButton(
+                    onClick = onInterrupt,
+                    modifier = Modifier.height(46.dp),
+                    shape = RoundedCornerShape(23.dp),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, CelesteCoral),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteCoral),
+                ) { Text("Stop", fontWeight = FontWeight.SemiBold) }
+
+                TurnState.Reconnecting -> OutlinedButton(
+                    onClick = onReconnect,
+                    modifier = Modifier.height(46.dp),
+                    shape = RoundedCornerShape(23.dp),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, CelesteBlue),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteBlue),
+                ) { Text("Retry", fontWeight = FontWeight.SemiBold) }
+
+                else -> Button(
+                    onClick = {
+                        onSend()
+                        focusManager.clearFocus()
+                    },
+                    enabled = draft.isNotBlank() && turnState == TurnState.Idle,
+                    modifier = Modifier.height(46.dp),
+                    shape = RoundedCornerShape(23.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = CelesteInk,
+                        contentColor = CelestePaper,
+                        disabledContainerColor = CelesteHairline,
+                        disabledContentColor = CelesteMuted,
+                    ),
+                ) { Text("Send  →", fontWeight = FontWeight.Bold) }
+            }
+        }
+    }
+}
+
+private data class TranscriptAnchor(
+    val key: String,
+    val index: Int,
+    val relativeOffsetPx: Int,
+)
+
+private data class ViewportGeometry(
+    val dockHeightPx: Int,
+    val bottomInsetPx: Int,
+    val safeTopInsetPx: Int,
+    val safeLeftInsetPx: Int,
+    val safeRightInsetPx: Int,
+    val configurationWidthDp: Int,
+    val configurationHeightDp: Int,
+    val configurationOrientation: Int,
+    val configurationFontScale: Float,
+)
+
+private data class ScrollPosition(
+    val firstVisibleItemIndex: Int,
+    val firstVisibleItemScrollOffset: Int,
+    val isScrollInProgress: Boolean,
+) {
+    fun isEarlierThan(other: ScrollPosition): Boolean =
+        firstVisibleItemIndex < other.firstVisibleItemIndex ||
+            (firstVisibleItemIndex == other.firstVisibleItemIndex &&
+                firstVisibleItemScrollOffset < other.firstVisibleItemScrollOffset)
+}
+
+private data class TerminalLayoutSignature(
+    val totalItemsCount: Int,
+    val terminalIndex: Int,
+    val terminalOffset: Int,
+    val terminalSize: Int,
+    val viewportEndOffset: Int,
+)
+
+private fun captureTranscriptAnchor(listState: LazyListState): TranscriptAnchor? {
+    val layoutInfo = listState.layoutInfo
+    val item = layoutInfo.visibleItemsInfo.firstOrNull() ?: return null
+    return TranscriptAnchor(
+        key = item.key.toString(),
+        index = item.index,
+        relativeOffsetPx = item.offset - layoutInfo.viewportStartOffset,
+    )
+}
+
+private suspend fun restoreTranscriptAnchor(
+    listState: LazyListState,
+    itemKeys: List<String>,
+    anchor: TranscriptAnchor?,
+): Boolean {
+    if (anchor == null || itemKeys.isEmpty()) return false
+    val exactIndex = itemKeys.indexOf(anchor.key)
+    val targetIndex = if (exactIndex >= 0) {
+        exactIndex
+    } else {
+        anchor.index.takeIf { it in itemKeys.indices } ?: return false
+    }
+    listState.scrollToItem(targetIndex)
+    val restoredItem = listState.layoutInfo.visibleItemsInfo
+        .firstOrNull { it.index == targetIndex }
+    if (restoredItem != null) {
+        val currentOffset = restoredItem.offset - listState.layoutInfo.viewportStartOffset
+        listState.scrollBy((currentOffset - anchor.relativeOffsetPx).toFloat())
+    }
+    return true
+}
+
+private fun terminalLayoutSignature(
+    layoutInfo: LazyListLayoutInfo,
+    itemCount: Int,
+): TerminalLayoutSignature {
+    val terminal = layoutInfo.visibleItemsInfo.firstOrNull { it.index == itemCount - 1 }
+    return TerminalLayoutSignature(
+        totalItemsCount = layoutInfo.totalItemsCount,
+        terminalIndex = terminal?.index ?: -1,
+        terminalOffset = terminal?.offset ?: 0,
+        terminalSize = terminal?.size ?: 0,
+        viewportEndOffset = layoutInfo.viewportEndOffset,
+    )
+}
+
+private fun terminalDistanceDp(
+    layoutInfo: LazyListLayoutInfo,
+    itemCount: Int,
+    density: androidx.compose.ui.unit.Density,
+): Float? {
+    if (itemCount == 0) return null
+    val terminal = layoutInfo.visibleItemsInfo.firstOrNull { it.index == itemCount - 1 }
+        ?: return null
+    val distancePx = abs(layoutInfo.viewportEndOffset - (terminal.offset + terminal.size))
+    return with(density) { distancePx.toDp().value }
 }
 
 private fun turnStateColor(turnState: TurnState): Color = when (turnState) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
@@ -71,10 +71,14 @@ internal class ConversationScrollPolicy(
         }
 
         if (input.deliberateDragAway) {
+            val invalidatedGeneration = maxOf(
+                input.transitionGeneration,
+                input.pendingGeneration ?: input.transitionGeneration,
+            ) + 1L
             return ScrollPolicyDecision(
                 followsLatest = false,
                 command = ScrollCommand.CancelPendingFollow,
-                transitionGeneration = input.transitionGeneration,
+                transitionGeneration = invalidatedGeneration,
             )
         }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
@@ -7,8 +7,27 @@ package dev.hazydreams.hermesceleste.ui.conversation
  * measured geometry and transition state, while the ViewModel remains authoritative
  * for the transcript itself.
  */
-internal fun activeBottomOcclusionPx(imeBottomPx: Int, navigationBottomPx: Int): Int =
-    maxOf(imeBottomPx, navigationBottomPx)
+internal fun activeBottomOcclusionPx(
+    imeBottomPx: Int,
+    navigationBottomPx: Int,
+    systemGesturesBottomPx: Int = 0,
+): Int = maxOf(imeBottomPx, navigationBottomPx, systemGesturesBottomPx)
+
+/**
+ * Positive values mean that the terminal row ends above the usable viewport
+ * boundary. Negative values mean that it is still occluded by the dock.
+ */
+internal fun terminalBottomClearancePx(
+    terminalOffsetPx: Int,
+    terminalSizePx: Int,
+    viewportEndOffsetPx: Int,
+): Int = viewportEndOffsetPx - (terminalOffsetPx + terminalSizePx)
+
+internal fun hasUsableViewportGeometry(
+    dockHeightPx: Int,
+    viewportStartOffsetPx: Int,
+    viewportEndOffsetPx: Int,
+): Boolean = dockHeightPx > 0 && viewportEndOffsetPx > viewportStartOffsetPx
 
 internal class ConversationScrollPolicy(
     private val nearBottomThresholdDp: Float = 40f,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
@@ -29,6 +29,23 @@ internal fun hasUsableViewportGeometry(
     viewportEndOffsetPx: Int,
 ): Boolean = dockHeightPx > 0 && viewportEndOffsetPx > viewportStartOffsetPx
 
+/**
+ * A stable-looking layout is not enough during an IME transition. Android can
+ * briefly report a zero or stale occlusion while the list has already produced
+ * usable bounds, so callers must keep the transition pending until the inset
+ * source reports a settled sample too.
+ */
+internal fun hasSettledViewportGeometry(
+    dockHeightPx: Int,
+    viewportStartOffsetPx: Int,
+    viewportEndOffsetPx: Int,
+    bottomInsetsSettled: Boolean,
+): Boolean = bottomInsetsSettled && hasUsableViewportGeometry(
+    dockHeightPx = dockHeightPx,
+    viewportStartOffsetPx = viewportStartOffsetPx,
+    viewportEndOffsetPx = viewportEndOffsetPx,
+)
+
 internal class ConversationScrollPolicy(
     private val nearBottomThresholdDp: Float = 40f,
 ) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
@@ -1,0 +1,141 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+/**
+ * The only policy that decides whether transcript mutations may move the viewport.
+ *
+ * This type deliberately has no Compose or ViewModel dependency. The UI supplies
+ * measured geometry and transition state, while the ViewModel remains authoritative
+ * for the transcript itself.
+ */
+internal fun activeBottomOcclusionPx(imeBottomPx: Int, navigationBottomPx: Int): Int =
+    maxOf(imeBottomPx, navigationBottomPx)
+
+internal class ConversationScrollPolicy(
+    private val nearBottomThresholdDp: Float = 40f,
+) {
+    fun isNearBottom(distanceDp: Float?): Boolean =
+        distanceDp != null && distanceDp.isFinite() && distanceDp <= nearBottomThresholdDp
+
+    fun decide(input: ScrollPolicyInput): ScrollPolicyDecision {
+        if (!input.hasItems) {
+            return input.hold()
+        }
+
+        if (input.deliberateDragAway) {
+            return ScrollPolicyDecision(
+                followsLatest = false,
+                command = ScrollCommand.CancelPendingFollow,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.pendingGeneration != null &&
+            input.pendingGeneration != input.transitionGeneration
+        ) {
+            return ScrollPolicyDecision(
+                followsLatest = input.followsLatest,
+                command = ScrollCommand.CancelPendingFollow,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.explicitJumpToLatest) {
+            return ScrollPolicyDecision(
+                followsLatest = true,
+                command = ScrollCommand.JumpToLatest,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.initialProjectionReady) {
+            return ScrollPolicyDecision(
+                followsLatest = true,
+                command = ScrollCommand.FollowLatest,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.restorationPending) {
+            if (!input.transitionSettled) return input.hold()
+            return ScrollPolicyDecision(
+                followsLatest = input.followsLatest,
+                command = ScrollCommand.RestoreAnchor,
+                fallbackToLatest = !input.anchorAvailable,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.imeOrInsetTransition && !input.transitionSettled) {
+            return input.hold()
+        }
+
+        if (input.imeOrInsetTransition && input.transitionSettled && input.followsLatest) {
+            return ScrollPolicyDecision(
+                followsLatest = true,
+                command = ScrollCommand.FollowLatest,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (!input.followsLatest &&
+            input.allowRelatch &&
+            isNearBottom(input.nearBottomDistanceDp)
+        ) {
+            return ScrollPolicyDecision(
+                followsLatest = true,
+                command = ScrollCommand.RelatchLatest,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.contentChanged && input.followsLatest) {
+            return ScrollPolicyDecision(
+                followsLatest = true,
+                command = ScrollCommand.FollowLatest,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        return input.hold()
+    }
+
+    private fun ScrollPolicyInput.hold(): ScrollPolicyDecision =
+        ScrollPolicyDecision(
+            followsLatest = followsLatest,
+            command = ScrollCommand.Hold,
+            transitionGeneration = transitionGeneration,
+        )
+}
+
+internal data class ScrollPolicyInput(
+    val followsLatest: Boolean,
+    val nearBottomDistanceDp: Float? = null,
+    val deliberateDragAway: Boolean = false,
+    val contentChanged: Boolean = false,
+    val imeOrInsetTransition: Boolean = false,
+    val restorationPending: Boolean = false,
+    val transitionGeneration: Long = 0L,
+    val pendingGeneration: Long? = null,
+    val transitionSettled: Boolean = true,
+    val initialProjectionReady: Boolean = false,
+    val explicitJumpToLatest: Boolean = false,
+    val hasItems: Boolean = true,
+    val anchorAvailable: Boolean = true,
+    val allowRelatch: Boolean = false,
+)
+
+internal data class ScrollPolicyDecision(
+    val followsLatest: Boolean,
+    val command: ScrollCommand,
+    val fallbackToLatest: Boolean = false,
+    val transitionGeneration: Long,
+)
+
+internal enum class ScrollCommand {
+    Hold,
+    FollowLatest,
+    RestoreAnchor,
+    RelatchLatest,
+    JumpToLatest,
+    CancelPendingFollow,
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
@@ -83,20 +83,20 @@ internal class ConversationScrollPolicy(
             )
         }
 
-        if (input.initialProjectionReady) {
-            return ScrollPolicyDecision(
-                followsLatest = true,
-                command = ScrollCommand.FollowLatest,
-                transitionGeneration = input.transitionGeneration,
-            )
-        }
-
         if (input.restorationPending) {
             if (!input.transitionSettled) return input.hold()
             return ScrollPolicyDecision(
                 followsLatest = input.followsLatest,
                 command = ScrollCommand.RestoreAnchor,
                 fallbackToLatest = !input.anchorAvailable,
+                transitionGeneration = input.transitionGeneration,
+            )
+        }
+
+        if (input.initialProjectionReady) {
+            return ScrollPolicyDecision(
+                followsLatest = true,
+                command = ScrollCommand.FollowLatest,
                 transitionGeneration = input.transitionGeneration,
             )
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScrollPolicy.kt
@@ -14,14 +14,27 @@ internal fun activeBottomOcclusionPx(
 ): Int = maxOf(imeBottomPx, navigationBottomPx, systemGesturesBottomPx)
 
 /**
- * Positive values mean that the terminal row ends above the usable viewport
- * boundary. Negative values mean that it is still occluded by the dock.
+ * Positive values mean that the terminal row ends above the usable dock boundary.
+ * Negative values mean that it is still occluded by the dock.
+ *
+ * `LazyListLayoutInfo.viewportEndOffset` includes the list's trailing content
+ * padding. The padding contains the measured dock plus a small visual gap, so
+ * derive the physical dock top from both values instead of treating the raw
+ * viewport end as the boundary.
  */
 internal fun terminalBottomClearancePx(
     terminalOffsetPx: Int,
     terminalSizePx: Int,
     viewportEndOffsetPx: Int,
-): Int = viewportEndOffsetPx - (terminalOffsetPx + terminalSizePx)
+    afterContentPaddingPx: Int = 0,
+    dockHeightPx: Int = 0,
+): Int {
+    val trailingPaddingPx = afterContentPaddingPx.coerceAtLeast(0)
+    val measuredDockHeightPx = dockHeightPx.coerceAtLeast(0)
+    val visualGapPx = (trailingPaddingPx - measuredDockHeightPx).coerceAtLeast(0)
+    val dockTopOffsetPx = viewportEndOffsetPx - trailingPaddingPx + visualGapPx
+    return dockTopOffsetPx - (terminalOffsetPx + terminalSizePx)
+}
 
 internal fun hasUsableViewportGeometry(
     dockHeightPx: Int,

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
@@ -148,10 +148,11 @@ class ConversationScrollPolicyTest {
     }
 
     @Test
-    fun newerTransitionGenerationCancelsStaleScrollWork() {
+    fun earlyHistoryScrollGenerationCancelsInitialLatestSettle() {
         val decision = policy.decide(
             ScrollPolicyInput(
                 followsLatest = true,
+                initialProjectionReady = true,
                 pendingGeneration = 3L,
                 transitionGeneration = 4L,
             ),
@@ -159,6 +160,22 @@ class ConversationScrollPolicyTest {
 
         assertEquals(ScrollCommand.CancelPendingFollow, decision.command)
         assertEquals(4L, decision.transitionGeneration)
+    }
+
+    @Test
+    fun savedHistoryModeTakesPrecedenceOverInitialLatestSettling() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = false,
+                restorationPending = true,
+                anchorAvailable = true,
+                initialProjectionReady = true,
+                transitionSettled = true,
+            ),
+        )
+
+        assertEquals(ScrollCommand.RestoreAnchor, decision.command)
+        assertFalse(decision.followsLatest)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
@@ -90,19 +90,21 @@ class ConversationScrollPolicyTest {
     }
 
     @Test
-    fun deliberateDragCancelsPendingFollowBeforeContentChanges() {
+    fun deliberateDragCancelsActiveProgrammaticFollowAndInvalidatesGeneration() {
+        val activeGeneration = 7L
         val decision = policy.decide(
             ScrollPolicyInput(
                 followsLatest = true,
                 deliberateDragAway = true,
                 contentChanged = true,
-                pendingGeneration = 7L,
-                transitionGeneration = 7L,
+                pendingGeneration = activeGeneration,
+                transitionGeneration = activeGeneration,
             ),
         )
 
         assertFalse(decision.followsLatest)
         assertEquals(ScrollCommand.CancelPendingFollow, decision.command)
+        assertEquals(activeGeneration + 1L, decision.transitionGeneration)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
@@ -1,0 +1,159 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.ui.conversation.ConversationScrollPolicy
+import dev.hazydreams.hermesceleste.ui.conversation.ScrollCommand
+import dev.hazydreams.hermesceleste.ui.conversation.activeBottomOcclusionPx
+import dev.hazydreams.hermesceleste.ui.conversation.ScrollPolicyInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConversationScrollPolicyTest {
+    private val policy = ConversationScrollPolicy()
+
+    @Test
+    fun initialProjectionClaimsLatestOnlyWhenTheListHasUsableContent() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = false,
+                hasItems = true,
+                initialProjectionReady = true,
+            ),
+        )
+
+        assertTrue(decision.followsLatest)
+        assertEquals(ScrollCommand.FollowLatest, decision.command)
+    }
+
+    @Test
+    fun bottomOcclusionUsesTheLargerInsetOnly() {
+        assertEquals(320, activeBottomOcclusionPx(320, 48))
+        assertEquals(48, activeBottomOcclusionPx(0, 48))
+    }
+
+    @Test
+    fun exactNearBottomBoundaryIsInclusive() {
+        assertTrue(policy.isNearBottom(40f))
+        assertFalse(policy.isNearBottom(40.01f))
+    }
+
+    @Test
+    fun deliberateDragCancelsPendingFollowBeforeContentChanges() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = true,
+                deliberateDragAway = true,
+                contentChanged = true,
+                pendingGeneration = 7L,
+                transitionGeneration = 7L,
+            ),
+        )
+
+        assertFalse(decision.followsLatest)
+        assertEquals(ScrollCommand.CancelPendingFollow, decision.command)
+    }
+
+    @Test
+    fun releaseNearBottomRelatchesOnlyAfterTheTransitionSettles() {
+        val waiting = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = false,
+                nearBottomDistanceDp = 40f,
+                allowRelatch = true,
+                imeOrInsetTransition = true,
+                transitionSettled = false,
+            ),
+        )
+        val settled = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = false,
+                nearBottomDistanceDp = 40f,
+                allowRelatch = true,
+                imeOrInsetTransition = true,
+                transitionSettled = true,
+            ),
+        )
+
+        assertEquals(ScrollCommand.Hold, waiting.command)
+        assertFalse(waiting.followsLatest)
+        assertEquals(ScrollCommand.RelatchLatest, settled.command)
+        assertTrue(settled.followsLatest)
+    }
+
+    @Test
+    fun settledInsetTransitionKeepsAFollowingReaderAtLatest() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = true,
+                imeOrInsetTransition = true,
+                transitionSettled = true,
+            ),
+        )
+
+        assertEquals(ScrollCommand.FollowLatest, decision.command)
+        assertTrue(decision.followsLatest)
+    }
+
+    @Test
+    fun contentChangesFollowLatestOnlyForAReaderWhoWasAlreadyFollowing() {
+        val following = policy.decide(
+            ScrollPolicyInput(followsLatest = true, contentChanged = true),
+        )
+        val readingHistory = policy.decide(
+            ScrollPolicyInput(followsLatest = false, contentChanged = true),
+        )
+
+        assertEquals(ScrollCommand.FollowLatest, following.command)
+        assertEquals(ScrollCommand.Hold, readingHistory.command)
+        assertTrue(following.followsLatest)
+        assertFalse(readingHistory.followsLatest)
+    }
+
+    @Test
+    fun newerTransitionGenerationCancelsStaleScrollWork() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = true,
+                pendingGeneration = 3L,
+                transitionGeneration = 4L,
+            ),
+        )
+
+        assertEquals(ScrollCommand.CancelPendingFollow, decision.command)
+        assertEquals(4L, decision.transitionGeneration)
+    }
+
+    @Test
+    fun missingAnchorUsesSafeLatestFallbackWithoutRelatchingFollow() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = false,
+                hasItems = true,
+                restorationPending = true,
+                anchorAvailable = false,
+                transitionSettled = true,
+            ),
+        )
+
+        assertEquals(ScrollCommand.RestoreAnchor, decision.command)
+        assertTrue(decision.fallbackToLatest)
+        assertFalse(decision.followsLatest)
+    }
+
+    @Test
+    fun emptyTranscriptDoesNotIssueScrollCommands() {
+        val decision = policy.decide(
+            ScrollPolicyInput(
+                followsLatest = true,
+                hasItems = false,
+                initialProjectionReady = true,
+                contentChanged = true,
+                explicitJumpToLatest = true,
+            ),
+        )
+
+        assertEquals(ScrollCommand.Hold, decision.command)
+        assertTrue(decision.followsLatest)
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
@@ -4,6 +4,7 @@ import dev.hazydreams.hermesceleste.ui.conversation.ConversationScrollPolicy
 import dev.hazydreams.hermesceleste.ui.conversation.ScrollCommand
 import dev.hazydreams.hermesceleste.ui.conversation.activeBottomOcclusionPx
 import dev.hazydreams.hermesceleste.ui.conversation.hasUsableViewportGeometry
+import dev.hazydreams.hermesceleste.ui.conversation.hasSettledViewportGeometry
 import dev.hazydreams.hermesceleste.ui.conversation.ScrollPolicyInput
 import dev.hazydreams.hermesceleste.ui.conversation.terminalBottomClearancePx
 import org.junit.Assert.assertEquals
@@ -46,6 +47,26 @@ class ConversationScrollPolicyTest {
         assertFalse(hasUsableViewportGeometry(0, 0, 400))
         assertFalse(hasUsableViewportGeometry(120, 400, 400))
         assertTrue(hasUsableViewportGeometry(120, 0, 400))
+    }
+
+    @Test
+    fun zeroOrStaleInsetKeepsOtherwiseUsableGeometryPending() {
+        assertFalse(
+            hasSettledViewportGeometry(
+                dockHeightPx = 120,
+                viewportStartOffsetPx = 0,
+                viewportEndOffsetPx = 400,
+                bottomInsetsSettled = false,
+            ),
+        )
+        assertTrue(
+            hasSettledViewportGeometry(
+                dockHeightPx = 120,
+                viewportStartOffsetPx = 0,
+                viewportEndOffsetPx = 400,
+                bottomInsetsSettled = true,
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
@@ -3,7 +3,9 @@ package dev.hazydreams.hermesceleste
 import dev.hazydreams.hermesceleste.ui.conversation.ConversationScrollPolicy
 import dev.hazydreams.hermesceleste.ui.conversation.ScrollCommand
 import dev.hazydreams.hermesceleste.ui.conversation.activeBottomOcclusionPx
+import dev.hazydreams.hermesceleste.ui.conversation.hasUsableViewportGeometry
 import dev.hazydreams.hermesceleste.ui.conversation.ScrollPolicyInput
+import dev.hazydreams.hermesceleste.ui.conversation.terminalBottomClearancePx
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -28,8 +30,22 @@ class ConversationScrollPolicyTest {
 
     @Test
     fun bottomOcclusionUsesTheLargerInsetOnly() {
-        assertEquals(320, activeBottomOcclusionPx(320, 48))
-        assertEquals(48, activeBottomOcclusionPx(0, 48))
+        assertEquals(320, activeBottomOcclusionPx(320, 48, 24))
+        assertEquals(48, activeBottomOcclusionPx(0, 48, 24))
+        assertEquals(56, activeBottomOcclusionPx(0, 24, 56))
+    }
+
+    @Test
+    fun terminalClearanceIsMeasuredAgainstTheUsableViewportEnd() {
+        assertEquals(12, terminalBottomClearancePx(100, 88, 200))
+        assertEquals(-8, terminalBottomClearancePx(100, 108, 200))
+    }
+
+    @Test
+    fun viewportGeometryIsPendingUntilTheDockAndListHaveUsableBounds() {
+        assertFalse(hasUsableViewportGeometry(0, 0, 400))
+        assertFalse(hasUsableViewportGeometry(120, 400, 400))
+        assertTrue(hasUsableViewportGeometry(120, 0, 400))
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationScrollPolicyTest.kt
@@ -43,6 +43,20 @@ class ConversationScrollPolicyTest {
     }
 
     @Test
+    fun terminalClearanceUsesMeasuredDockTopRatherThanTrailingPaddingEnd() {
+        assertEquals(
+            26,
+            terminalBottomClearancePx(
+                terminalOffsetPx = 780,
+                terminalSizePx = 74,
+                viewportEndOffsetPx = 1_000,
+                afterContentPaddingPx = 146,
+                dockHeightPx = 120,
+            ),
+        )
+    }
+
+    @Test
     fun viewportGeometryIsPendingUntilTheDockAndListHaveUsableBounds() {
         assertFalse(hasUsableViewportGeometry(0, 0, 400))
         assertFalse(hasUsableViewportGeometry(120, 400, 400))

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -83,7 +83,11 @@ scripts/celeste-env adb install -r /path/to/Hermes-Celeste-latest.apk
 
 Use a real device for Android-only behavior such as lifecycle transitions, IME/insets, system back, permissions, network changes, launcher assets, and performance. Record the flows and device conditions exercised rather than reporting “tested on device” without specifics.
 
-There is currently no `app/src/androidTest` suite. The configured instrumentation runner and connected-device tasks do not constitute device coverage; report Android runtime behavior as untested unless it was explicitly exercised.
+The DF-02 viewport scenarios live under `app/src/androidTest`. They are a device harness, not device evidence: the suite covers IME open/close and system Back, rotation, cutout-gated behavior, gesture and three-button navigation-gated behavior, large font scale, terminal-row clearance, and TalkBack semantics. Report Android runtime behavior as untested unless the scenarios were explicitly exercised on a device.
+
+### DF-02 physical device gate
+
+Before marking DF-02 accepted, record the actual device/API, keyboard and IME animation behavior, portrait/landscape configuration, cutout or waterfall configuration, navigation mode, default and large font scale, and TalkBack service/version. Exercise idle, composing, running, reconnecting, and error states with enough synthetic-length streaming text to grow the terminal row. Confirm the composer clears the measured IME/navigation/gesture occlusion without a double gap, history readers retain their anchor, following readers remain at latest, the first Back dismisses the IME, and the second Back leaves the conversation. This change records the gate only; no physical-device result is claimed here.
 
 Base-path-prefixed dashboard routing is supported in source but does not yet have a direct MockWebServer regression. Add one when route joining changes.
 


### PR DESCRIPTION
## Summary
- Implements the DF-02 conversation viewport scope: keep the composer above Android IME/navigation/gesture occlusion while preserving the largest readable transcript viewport.
- Adds one bottom-inset owner with measured dock clearance, conditional follow-latest behavior, history-anchor preservation, Jump to latest, IME-first Back, and transition/accessibility seams for rotation, cutouts, font scale, and TalkBack.
- DF-02 is layout/viewport behavior only; there are no Gateway, session, prompt-ordering, or protocol changes.

## Branch contents
- This branch also carries the paired DF-02 and CF-02 specifications plus the temporary first-device-pass tracker. These milestone artifacts are intentionally included for review and are not a claim that CF-02 is implemented.

## Luna review
- DF-02 specification: PASS
- Final Luna quality review: APPROVED through `3a669fae2454180ff69146f8bc2a298bf9f7b407`

## Validation status
The following gates are unrun on the constrained VPS:
- local Gradle/unit tests
- lint
- screenshot validation
- Android/instrumentation checks
- device validation
- APK build/verification

`git diff --check` passed locally. Physical IME/navigation/TalkBack acceptance remains pending. No merge is requested from this draft.