### PR TITLE
fix: order conversations by recent activity

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -35,6 +35,7 @@ import dev.hazydreams.hermesceleste.network.createSession
 import dev.hazydreams.hermesceleste.network.deduplicateSessions
 import dev.hazydreams.hermesceleste.network.effectiveRemoteActivity
 import dev.hazydreams.hermesceleste.network.interruptSession
+import dev.hazydreams.hermesceleste.network.listStoredSessionPage
 import dev.hazydreams.hermesceleste.network.normalizedSessionProfile
 import dev.hazydreams.hermesceleste.network.orderSessions
 import dev.hazydreams.hermesceleste.network.reconcileSessionRows
@@ -56,9 +57,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 internal enum class TurnState {
     Synchronizing,
@@ -94,6 +92,7 @@ internal data class CelesteUiState(
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
     val errorMessage: String? = null,
+    val sessionRefreshAnnouncementToken: Long = 0L,
 )
 
 private data class LoadedDashboard(
@@ -144,7 +143,9 @@ internal class CelesteViewModel(
     private var sessionListOrdering = SessionOrdering.SERVER_ORDER
     private var sessionOperationCounter = 0L
     private val pendingLocalActivity = linkedMapOf<SessionIdentity, PendingLocalActivity>()
-    private var conversationsVisible = false
+    private var conversationsDestinationVisible = false
+    private var destinationVisibilityReported = false
+    private var appInForeground = true
     private val connectionStoreMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
@@ -571,7 +572,6 @@ internal class CelesteViewModel(
         probe: DashboardProbeResult? = null,
     ) {
         beginSessionContextChange()
-        conversationsVisible = false
         closeGateway()
         credential = null
         currentDescriptor = null
@@ -646,8 +646,7 @@ internal class CelesteViewModel(
 
     private fun isCurrentConnectionAttempt(attempt: Long): Boolean = connectionAttempt == attempt
 
-    private fun beginSessionContextChange() {
-        sessionContextGeneration += 1
+    private fun cancelSessionListWork() {
         sessionRefreshGeneration += 1
         sessionRefreshJob?.cancel()
         sessionRefreshJob = null
@@ -655,6 +654,12 @@ internal class CelesteViewModel(
         sessionInvalidationJob = null
         sessionPollJob?.cancel()
         sessionPollJob = null
+    }
+
+    private fun beginSessionContextChange() {
+        sessionContextGeneration += 1
+        sessionRefreshGeneration += 1
+        cancelSessionListWork()
         sessionListOrdering = SessionOrdering.SERVER_ORDER
         pendingLocalActivity.clear()
     }
@@ -662,7 +667,8 @@ internal class CelesteViewModel(
     fun openSession(summary: StoredSession) {
         val connection = mutableState.value.probe ?: return
         val activeCredential = credential ?: return
-        conversationsVisible = false
+        conversationsDestinationVisible = false
+        cancelSessionListWork()
         closeGateway()
         currentSessionCanResume = true
         mutableState.value = mutableState.value.copy(
@@ -702,7 +708,8 @@ internal class CelesteViewModel(
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
         val selectedProfile = snapshot.selectedProfile
-        conversationsVisible = false
+        conversationsDestinationVisible = false
+        cancelSessionListWork()
         closeGateway()
         mutableState.value = snapshot.copy(
             activeSummary = null,
@@ -787,9 +794,20 @@ internal class CelesteViewModel(
         }
     }
 
+    fun setConversationsDestinationVisible(visible: Boolean) {
+        destinationVisibilityReported = true
+        conversationsDestinationVisible = visible
+        if (visible && appInForeground && mutableState.value.activeSummary == null) {
+            scheduleSessionRefresh(profile = sessionListScopeProfile)
+            startSessionPollingIfNeeded()
+        } else if (!visible) {
+            cancelSessionListWork()
+        }
+    }
+
     fun leaveConversation() {
         closeGateway()
-        conversationsVisible = true
+        conversationsDestinationVisible = true
         mutableState.value = mutableState.value.copy(
             activeSummary = null,
             messages = emptyList(),
@@ -936,9 +954,10 @@ internal class CelesteViewModel(
     }
 
     fun onBackground() {
-        conversationsVisible = false
-        sessionPollJob?.cancel()
-        sessionPollJob = null
+        appInForeground = false
+        foregroundCheckJob?.cancel()
+        foregroundCheckJob = null
+        cancelSessionListWork()
         val descriptor = currentDescriptor ?: return
         if (descriptor.authMode != SavedAuthMode.ProviderSession) return
         if (credential != GatewayCredential.CookieSession) return
@@ -956,13 +975,22 @@ internal class CelesteViewModel(
     }
 
     fun onForeground() {
-        if (mutableState.value.sessions != null && mutableState.value.activeSummary == null) {
-            conversationsVisible = true
-            scheduleSessionRefresh(profile = sessionListScopeProfile)
-            startSessionPollingIfNeeded()
+        appInForeground = true
+        val snapshot = mutableState.value
+        if (snapshot.activeSummary == null) {
+            // Unit/state callers do not have a Compose route to report yet. The
+            // default destination is Conversations until a route explicitly says
+            // otherwise; this also covers the first foreground callback racing
+            // asynchronous dashboard catalog loading.
+            if (!destinationVisibilityReported) conversationsDestinationVisible = true
+            if (conversationsDestinationVisible) {
+                scheduleSessionRefresh(profile = sessionListScopeProfile)
+                startSessionPollingIfNeeded()
+            }
             return
         }
-        conversationsVisible = false
+        conversationsDestinationVisible = false
+        cancelSessionListWork()
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: return
         if (foregroundCheckJob?.isActive == true || reconciling) return
@@ -972,15 +1000,30 @@ internal class CelesteViewModel(
         }
         foregroundCheckJob = viewModelScope.launch {
             val refresh = runCatching {
-                refreshSessionListNow(profile = sessionListScopeProfile)
-                activeGateway.request(
-                    method = "session.list",
-                    params = buildJsonObject { put("limit", 1) },
-                    timeoutMillis = 8_000,
-                )
-                if (currentSessionCanResume && gateway === activeGateway) {
-                    reconcile(activeGateway, storedSessionId)
+                val restRefreshed = refreshSessionListNow(profile = sessionListScopeProfile)
+                if (gateway === activeGateway) {
+                    val gatewayPage = activeGateway.listStoredSessionPage(
+                        profile = sessionListScopeProfile,
+                        limit = SESSION_PAGE_LIMIT,
+                    )
+                    if (!restRefreshed && mutableState.value.sessions != null) {
+                        // REST remains the preferred source. If it was unavailable,
+                        // reconcile the typed gateway result instead of discarding it.
+                        publishSessionPage(
+                            page = gatewayPage,
+                            origin = normalizeOrigin(mutableState.value.probe?.baseUrl.orEmpty()),
+                            profile = sessionListScopeProfile,
+                            clearErrorOnSuccess = true,
+                        )
+                    }
+                    if (currentSessionCanResume) {
+                        reconcile(activeGateway, storedSessionId)
+                    }
                 }
+            }
+            if (refresh.exceptionOrNull() is CancellationException) {
+                foregroundCheckJob = null
+                return@launch
             }
             if (refresh.isFailure && gateway === activeGateway) {
                 val wasRunning = mutableState.value.turnState == TurnState.Running
@@ -1253,11 +1296,58 @@ internal class CelesteViewModel(
         )
     }
 
+    private fun publishSessionPage(
+        page: SessionListPage,
+        origin: String,
+        profile: String,
+        announce: Boolean = true,
+        clearErrorOnSuccess: Boolean = false,
+    ): Boolean {
+        val current = mutableState.value
+        val projected = projectSessionPage(
+            page = page,
+            origin = origin,
+            profile = profile,
+            previous = current.sessions.orEmpty(),
+        )
+        val active = current.activeSummary
+        val updatedActive = active?.let { summary ->
+            projected.firstOrNull {
+                it.id == summary.id &&
+                    normalizedSessionProfile(it.profile).equals(
+                        normalizedSessionProfile(summary.profile),
+                        ignoreCase = true,
+                    )
+            } ?: summary
+        }
+        val changed = projected != current.sessions || updatedActive != active
+        val announcementToken = if (
+            announce && changed && conversationsDestinationVisible && appInForeground
+        ) {
+            current.sessionRefreshAnnouncementToken + 1
+        } else {
+            current.sessionRefreshAnnouncementToken
+        }
+        mutableState.value = current.copy(
+            sessions = projected,
+            activeSummary = updatedActive,
+            loadingMessage = null,
+            errorMessage = when {
+                page.errors.isNotEmpty() -> "Some Hermes profiles could not refresh."
+                clearErrorOnSuccess || current.activeSummary == null -> null
+                else -> current.errorMessage
+            },
+            sessionRefreshAnnouncementToken = announcementToken,
+        )
+        startSessionPollingIfNeeded()
+        return changed
+    }
+
     private fun scheduleSessionRefresh(
         profile: String = sessionListScopeProfile,
         debounce: Boolean = false,
     ) {
-        if (mutableState.value.probe == null || credential == null || mutableState.value.sessions == null) return
+        if (!appInForeground || mutableState.value.probe == null || credential == null || mutableState.value.sessions == null) return
         sessionInvalidationJob?.cancel()
         sessionInvalidationJob = null
         if (debounce) {
@@ -1283,14 +1373,20 @@ internal class CelesteViewModel(
         val requestGeneration = ++sessionRefreshGeneration
         val contextGeneration = sessionContextGeneration
         val attempt = connectionAttempt
-        val result = runCatching {
-            dashboard.listSessionPage(
-                baseUrl = probe.baseUrl,
-                credential = activeCredential,
-                profile = requestedProfile,
-                limit = SESSION_PAGE_LIMIT,
-                offset = 0,
+        val result: Result<SessionListPage> = try {
+            Result.success(
+                dashboard.listSessionPage(
+                    baseUrl = probe.baseUrl,
+                    credential = activeCredential,
+                    profile = requestedProfile,
+                    limit = SESSION_PAGE_LIMIT,
+                    offset = 0,
+                ),
             )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Result.failure(error)
         }
         val page = result.getOrNull()
         val current = mutableState.value
@@ -1302,6 +1398,7 @@ internal class CelesteViewModel(
         if (!stillCurrent) return false
         if (page == null) {
             val error = result.exceptionOrNull()
+            if (error is CancellationException) throw error
             if (error is AuthenticationRejected) {
                 invalidateReusableAuthentication(currentDescriptor, current.probe)
             } else {
@@ -1311,48 +1408,33 @@ internal class CelesteViewModel(
             }
             return false
         }
-
-        val projected = projectSessionPage(
+        publishSessionPage(
             page = page,
             origin = origin,
             profile = requestedProfile,
-            previous = current.sessions.orEmpty(),
         )
-        val active = current.activeSummary
-        val updatedActive = active?.let { summary ->
-            projected.firstOrNull {
-                it.id == summary.id &&
-                    normalizedSessionProfile(it.profile).equals(
-                        normalizedSessionProfile(summary.profile),
-                        ignoreCase = true,
-                    )
-            } ?: summary
-        }
-        mutableState.value = current.copy(
-            sessions = projected,
-            activeSummary = updatedActive,
-            loadingMessage = null,
-            errorMessage = if (page.errors.isNotEmpty()) {
-                "Some Hermes profiles could not refresh."
-            } else if (current.activeSummary == null) {
-                null
-            } else {
-                current.errorMessage
-            },
-        )
-        startSessionPollingIfNeeded()
         return true
     }
 
     private fun startSessionPollingIfNeeded() {
         val snapshot = mutableState.value
-        if (!conversationsVisible || snapshot.sessions == null || snapshot.activeSummary != null || credential == null) return
+        if (!appInForeground || !conversationsDestinationVisible || snapshot.sessions == null || snapshot.activeSummary != null || credential == null) return
         if (gateway?.supportsSessionChangeEvents == true) return
         if (sessionPollJob?.isActive == true) return
         sessionPollJob = viewModelScope.launch {
-            while (mutableState.value.sessions != null && mutableState.value.activeSummary == null) {
+            while (
+                appInForeground &&
+                conversationsDestinationVisible &&
+                mutableState.value.sessions != null &&
+                mutableState.value.activeSummary == null
+            ) {
                 delay(SESSION_POLL_MILLIS)
-                if (mutableState.value.sessions != null && mutableState.value.activeSummary == null) {
+                if (
+                    appInForeground &&
+                    conversationsDestinationVisible &&
+                    mutableState.value.sessions != null &&
+                    mutableState.value.activeSummary == null
+                ) {
                     scheduleSessionRefresh(profile = sessionListScopeProfile)
                 }
             }
@@ -1558,8 +1640,7 @@ internal class CelesteViewModel(
         gateway = null
         reconnectJob?.cancel()
         reconnectJob = null
-        sessionPollJob?.cancel()
-        sessionPollJob = null
+        cancelSessionListWork()
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         gatewayEventsJob?.cancel()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -15,25 +15,40 @@ import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.DashboardClient
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
+import dev.hazydreams.hermesceleste.network.DashboardRpcException
 import dev.hazydreams.hermesceleste.network.DashboardService
 import dev.hazydreams.hermesceleste.network.DashboardUrlPolicy
 import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
+import dev.hazydreams.hermesceleste.network.LocalActivityDelivery
+import dev.hazydreams.hermesceleste.network.PendingLocalActivity
 import dev.hazydreams.hermesceleste.network.ResumedSession
+import dev.hazydreams.hermesceleste.network.SessionIdentity
+import dev.hazydreams.hermesceleste.network.SessionListPage
+import dev.hazydreams.hermesceleste.network.SessionOrdering
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.boolean
 import dev.hazydreams.hermesceleste.network.createSession
+import dev.hazydreams.hermesceleste.network.deduplicateSessions
+import dev.hazydreams.hermesceleste.network.effectiveRemoteActivity
 import dev.hazydreams.hermesceleste.network.interruptSession
+import dev.hazydreams.hermesceleste.network.normalizedSessionProfile
+import dev.hazydreams.hermesceleste.network.orderSessions
+import dev.hazydreams.hermesceleste.network.reconcileSessionRows
 import dev.hazydreams.hermesceleste.network.resumeStoredSession
+import dev.hazydreams.hermesceleste.network.sessionIdentity
 import dev.hazydreams.hermesceleste.network.string
 import dev.hazydreams.hermesceleste.network.submitPrompt
+import dev.hazydreams.hermesceleste.network.validEpochSeconds
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -83,7 +98,7 @@ internal data class CelesteUiState(
 
 private data class LoadedDashboard(
     val credential: GatewayCredential,
-    val sessions: List<StoredSession>,
+    val sessionPage: SessionListPage,
     val profiles: List<DashboardProfile>,
 )
 
@@ -93,12 +108,19 @@ private data class RememberedDashboard(
     val persistenceError: Throwable?,
 )
 
+private data class LocalActivityOperation(
+    val identity: SessionIdentity,
+    val operationId: Long,
+    val contextGeneration: Long,
+)
+
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
     private val reconnectDelayMillis: (attempt: Int, wasRunning: Boolean) -> Long = { attempt, wasRunning ->
         if (wasRunning && attempt == 0) 100L else min(5_000L, 1_000L shl attempt.coerceAtMost(2))
     },
+    private val clockSeconds: () -> Double = { System.currentTimeMillis() / 1000.0 },
 ) : ViewModel() {
     private val mutableState = MutableStateFlow(CelesteUiState())
     val state: StateFlow<CelesteUiState> = mutableState.asStateFlow()
@@ -110,8 +132,19 @@ internal class CelesteViewModel(
     private var gatewayStateJob: Job? = null
     private var reconnectJob: Job? = null
     private var foregroundCheckJob: Job? = null
+    private var sessionRefreshJob: Job? = null
+    private var sessionInvalidationJob: Job? = null
+    private var sessionPollJob: Job? = null
     private var connectionJob: Job? = null
     private var connectionAttempt = 0L
+    private var sessionRefreshGeneration = 0L
+    private var sessionContextGeneration = 0L
+    private var conversationGeneration = 0L
+    private var sessionListScopeProfile = "all"
+    private var sessionListOrdering = SessionOrdering.SERVER_ORDER
+    private var sessionOperationCounter = 0L
+    private val pendingLocalActivity = linkedMapOf<SessionIdentity, PendingLocalActivity>()
+    private var conversationsVisible = false
     private val connectionStoreMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
@@ -149,7 +182,20 @@ internal class CelesteViewModel(
 
     fun selectProfile(name: String) {
         if (mutableState.value.profiles.none { it.name == name }) return
-        mutableState.value = mutableState.value.copy(selectedProfile = name)
+        if (mutableState.value.selectedProfile == name) return
+        pendingLocalActivity.clear()
+        beginSessionContextChange()
+        sessionListScopeProfile = name
+        mutableState.value = mutableState.value.copy(
+            selectedProfile = name,
+            sessions = if (mutableState.value.sessions == null) null else emptyList(),
+            loadingMessage = if (mutableState.value.sessions == null) {
+                mutableState.value.loadingMessage
+            } else {
+                "Loading conversations…"
+            },
+        )
+        scheduleSessionRefresh(profile = name)
     }
 
     fun findDashboard() {
@@ -509,15 +555,24 @@ internal class CelesteViewModel(
         baseUrl: String,
         selectedCredential: GatewayCredential,
     ): LoadedDashboard {
-        val sessions = dashboard.listSessions(baseUrl, selectedCredential)
+        val sessionPage = dashboard.listSessionPage(
+            baseUrl = baseUrl,
+            credential = selectedCredential,
+            profile = "all",
+            limit = SESSION_PAGE_LIMIT,
+            offset = 0,
+        )
         val profiles = dashboard.listProfiles(baseUrl, selectedCredential)
-        return LoadedDashboard(selectedCredential, sessions, profiles)
+        return LoadedDashboard(selectedCredential, sessionPage, profiles)
     }
 
     private suspend fun invalidateReusableAuthentication(
         descriptor: SavedConnectionDescriptor?,
         probe: DashboardProbeResult? = null,
     ) {
+        beginSessionContextChange()
+        conversationsVisible = false
+        closeGateway()
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
@@ -546,7 +601,12 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             connectionPhase = ConnectionPhase.Connected,
             savedAuthMode = currentDescriptor?.authMode,
-            sessions = loaded.sessions,
+            sessions = projectSessionPage(
+                page = loaded.sessionPage,
+                origin = normalizeOrigin(mutableState.value.probe?.baseUrl.orEmpty()),
+                profile = "all",
+                previous = emptyList(),
+            ),
             profiles = loaded.profiles,
             selectedProfile = selectedProfile,
             activeSummary = null,
@@ -554,8 +614,12 @@ internal class CelesteViewModel(
             password = password,
             sessionToken = sessionToken,
             loadingMessage = null,
-            errorMessage = errorMessage,
+            errorMessage = errorMessage ?: loaded.sessionPage.errors
+                .takeIf { it.isNotEmpty() }
+                ?.let { "Some Hermes profiles could not refresh." },
         )
+        sessionListScopeProfile = "all"
+        startSessionPollingIfNeeded()
     }
 
     private fun manualState(
@@ -576,14 +640,29 @@ internal class CelesteViewModel(
         connectionAttempt += 1
         connectionJob?.cancel()
         connectionJob = null
+        beginSessionContextChange()
         return connectionAttempt
     }
 
     private fun isCurrentConnectionAttempt(attempt: Long): Boolean = connectionAttempt == attempt
 
+    private fun beginSessionContextChange() {
+        sessionContextGeneration += 1
+        sessionRefreshGeneration += 1
+        sessionRefreshJob?.cancel()
+        sessionRefreshJob = null
+        sessionInvalidationJob?.cancel()
+        sessionInvalidationJob = null
+        sessionPollJob?.cancel()
+        sessionPollJob = null
+        sessionListOrdering = SessionOrdering.SERVER_ORDER
+        pendingLocalActivity.clear()
+    }
+
     fun openSession(summary: StoredSession) {
         val connection = mutableState.value.probe ?: return
         val activeCredential = credential ?: return
+        conversationsVisible = false
         closeGateway()
         currentSessionCanResume = true
         mutableState.value = mutableState.value.copy(
@@ -606,6 +685,7 @@ internal class CelesteViewModel(
             }.onSuccess {
                 reconnectAttempts = 0
                 mutableState.value = mutableState.value.copy(loadingMessage = null)
+                scheduleSessionRefresh(profile = sessionListScopeProfile)
             }.onFailure { error ->
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
@@ -622,6 +702,7 @@ internal class CelesteViewModel(
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
         val selectedProfile = snapshot.selectedProfile
+        conversationsVisible = false
         closeGateway()
         mutableState.value = snapshot.copy(
             activeSummary = null,
@@ -658,19 +739,41 @@ internal class CelesteViewModel(
                     messageCount = 0,
                     source = "android",
                     profile = selectedProfile,
+                    lastActive = null,
                 )
                 val events = bufferedEvents.toList()
                 bufferedEvents.clear()
                 reconciling = false
+                val visibleSessions = mutableState.value.sessions.orEmpty().let { sessions ->
+                    if (sessionListScopeProfile.equals("all", ignoreCase = true)) {
+                        sessions
+                    } else {
+                        sessions.filter { session ->
+                            normalizedSessionProfile(session.profile).equals(
+                                normalizedSessionProfile(sessionListScopeProfile),
+                                ignoreCase = true,
+                            )
+                        }
+                    }
+                }
                 mutableState.value = mutableState.value.copy(
-                    sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
-                        .filterNot { it.id == summary.id },
+                    sessions = deduplicateSessions(
+                        listOf(summary) + visibleSessions.filterNot { session ->
+                            session.id == summary.id &&
+                                normalizedSessionProfile(session.profile).equals(
+                                    normalizedSessionProfile(summary.profile),
+                                    ignoreCase = true,
+                                )
+                        },
+                        origin = normalizeOrigin(connection.baseUrl),
+                    ),
                     activeSummary = summary,
                     turnState = TurnState.Idle,
                     loadingMessage = null,
                     errorMessage = null,
                 )
                 events.forEach(::applyEvent)
+                scheduleSessionRefresh(profile = sessionListScopeProfile)
             }.onSuccess {
                 reconnectAttempts = 0
             }.onFailure { error ->
@@ -686,6 +789,7 @@ internal class CelesteViewModel(
 
     fun leaveConversation() {
         closeGateway()
+        conversationsVisible = true
         mutableState.value = mutableState.value.copy(
             activeSummary = null,
             messages = emptyList(),
@@ -695,12 +799,15 @@ internal class CelesteViewModel(
             loadingMessage = null,
             errorMessage = null,
         )
+        scheduleSessionRefresh(profile = sessionListScopeProfile)
+        startSessionPollingIfNeeded()
     }
 
     fun sendMessage() {
         val activeGateway = gateway ?: return
         val snapshot = mutableState.value
         val runtimeId = currentRuntimeSessionId ?: return
+        val storedId = currentStoredSessionId ?: snapshot.activeSummary?.id ?: return
         val text = snapshot.draft.trim()
         if (text.isBlank() || snapshot.turnState != TurnState.Idle) return
 
@@ -720,21 +827,81 @@ internal class CelesteViewModel(
         // prompt.submit creates the durable row before work begins. From this point on,
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
+        val operation = markLocalActivity(storedId)
+        val operationContextGeneration = sessionContextGeneration
+        val operationConversationGeneration = conversationGeneration
         viewModelScope.launch {
             runCatching { activeGateway.submitPrompt(runtimeId, text) }
-                .onSuccess {
+                .onSuccess { response ->
+                    if (!isCurrentPromptContext(
+                            activeGateway,
+                            storedId,
+                            operationContextGeneration,
+                            operationConversationGeneration,
+                        )
+                    ) {
+                        scheduleSessionRefresh(profile = sessionListScopeProfile)
+                        return@onSuccess
+                    }
+                    val rejected = response.string("status")?.lowercase() in setOf(
+                        "rejected",
+                        "failed",
+                        "error",
+                    )
+                    if (rejected) {
+                        clearLocalActivity(operation)
+                    }
                     mutableState.value = mutableState.value.copy(
-                        messages = mutableState.value.messages.map { message ->
-                            if (message.id == localId) message.copy(pending = false) else message
+                        messages = mutableState.value.messages.mapNotNull { message ->
+                            if (message.id != localId) {
+                                message
+                            } else if (rejected) {
+                                null
+                            } else {
+                                message.copy(pending = false)
+                            }
+                        },
+                        turnState = if (rejected) TurnState.Idle else mutableState.value.turnState,
+                        errorMessage = if (rejected) {
+                            response.string("error") ?: "Hermes rejected that message."
+                        } else {
+                            mutableState.value.errorMessage
                         },
                     )
+                    scheduleSessionRefresh(profile = sessionListScopeProfile)
                 }
                 .onFailure { error ->
+                    if (error is CancellationException && error !is TimeoutCancellationException) {
+                        throw error
+                    }
+                    if (!isCurrentPromptContext(
+                            activeGateway,
+                            storedId,
+                            operationContextGeneration,
+                            operationConversationGeneration,
+                        )
+                    ) {
+                        if (isDefinitivePromptFailure(error)) clearLocalActivity(operation)
+                        return@onFailure
+                    }
+                    val definitive = isDefinitivePromptFailure(error)
+                    if (definitive) {
+                        clearLocalActivity(operation)
+                    } else {
+                        markLocalActivityUncertain(operation)
+                    }
                     mutableState.value = mutableState.value.copy(
+                        messages = if (definitive) {
+                            mutableState.value.messages.filterNot { it.id == localId }
+                        } else {
+                            mutableState.value.messages
+                        },
+                        turnState = if (definitive) TurnState.Idle else mutableState.value.turnState,
                         errorMessage = error.message ?: "Hermes could not send that message.",
                     )
-                    if (gateway === activeGateway) {
-                        runCatching { reconcile(activeGateway, currentStoredSessionId ?: return@launch) }
+                    scheduleSessionRefresh(profile = sessionListScopeProfile)
+                    if (!definitive && gateway === activeGateway) {
+                        runCatching { reconcile(activeGateway, currentStoredSessionId ?: storedId) }
                     }
                 }
         }
@@ -769,6 +936,9 @@ internal class CelesteViewModel(
     }
 
     fun onBackground() {
+        conversationsVisible = false
+        sessionPollJob?.cancel()
+        sessionPollJob = null
         val descriptor = currentDescriptor ?: return
         if (descriptor.authMode != SavedAuthMode.ProviderSession) return
         if (credential != GatewayCredential.CookieSession) return
@@ -786,6 +956,13 @@ internal class CelesteViewModel(
     }
 
     fun onForeground() {
+        if (mutableState.value.sessions != null && mutableState.value.activeSummary == null) {
+            conversationsVisible = true
+            scheduleSessionRefresh(profile = sessionListScopeProfile)
+            startSessionPollingIfNeeded()
+            return
+        }
+        conversationsVisible = false
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: return
         if (foregroundCheckJob?.isActive == true || reconciling) return
@@ -794,20 +971,23 @@ internal class CelesteViewModel(
             return
         }
         foregroundCheckJob = viewModelScope.launch {
-            val health = runCatching {
+            val refresh = runCatching {
+                refreshSessionListNow(profile = sessionListScopeProfile)
                 activeGateway.request(
                     method = "session.list",
                     params = buildJsonObject { put("limit", 1) },
                     timeoutMillis = 8_000,
                 )
-                if (currentSessionCanResume) reconcile(activeGateway, storedSessionId)
+                if (currentSessionCanResume && gateway === activeGateway) {
+                    reconcile(activeGateway, storedSessionId)
+                }
             }
-            if (health.isFailure && gateway === activeGateway) {
+            if (refresh.isFailure && gateway === activeGateway) {
                 val wasRunning = mutableState.value.turnState == TurnState.Running
                 activeGateway.close()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
-                    errorMessage = health.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
+                    errorMessage = refresh.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
                 )
                 scheduleReconnect(wasRunning = wasRunning, immediate = true)
             }
@@ -822,6 +1002,10 @@ internal class CelesteViewModel(
         gatewayEventsJob = viewModelScope.launch {
             activeGateway.events.collect { event ->
                 if (gateway !== activeGateway) return@collect
+                if (event.type == "sessions.changed") {
+                    scheduleSessionRefresh(profile = sessionListScopeProfile, debounce = true)
+                    return@collect
+                }
                 if (reconciling) {
                     bufferedEvents += event
                 } else {
@@ -1039,6 +1223,245 @@ internal class CelesteViewModel(
         )
     }
 
+    private fun projectSessionPage(
+        page: SessionListPage,
+        origin: String,
+        profile: String,
+        previous: List<StoredSession>,
+    ): List<StoredSession> {
+        sessionListOrdering = page.ordering
+        val retained = mutableSetOf<SessionIdentity>()
+        val synthetic = mutableState.value.activeSummary
+            ?.takeIf { it.startedAt <= 0.0 && effectiveRemoteActivity(it) == null }
+        if (synthetic != null) retained += sessionIdentity(origin, synthetic)
+        val reconciliation = reconcileSessionRows(
+            previous = previous,
+            page = page,
+            origin = origin,
+            profileScope = profile,
+            overlays = pendingLocalActivity,
+            retainedIdentities = retained,
+        )
+        reconciliation.overlaysConfirmed.forEach { identity ->
+            pendingLocalActivity.remove(identity)
+        }
+        return orderSessions(
+            sessions = reconciliation.sessions,
+            origin = origin,
+            ordering = page.ordering,
+            overlays = pendingLocalActivity,
+        )
+    }
+
+    private fun scheduleSessionRefresh(
+        profile: String = sessionListScopeProfile,
+        debounce: Boolean = false,
+    ) {
+        if (mutableState.value.probe == null || credential == null || mutableState.value.sessions == null) return
+        sessionInvalidationJob?.cancel()
+        sessionInvalidationJob = null
+        if (debounce) {
+            sessionInvalidationJob = viewModelScope.launch {
+                delay(SESSION_CHANGED_DEBOUNCE_MILLIS)
+                sessionInvalidationJob = null
+                scheduleSessionRefresh(profile = profile)
+            }
+            return
+        }
+        if (sessionRefreshJob?.isActive == true) return
+        sessionRefreshJob = viewModelScope.launch {
+            refreshSessionListNow(profile)
+        }
+    }
+
+    private suspend fun refreshSessionListNow(profile: String): Boolean {
+        val snapshot = mutableState.value
+        val probe = snapshot.probe ?: return false
+        val activeCredential = credential ?: return false
+        val origin = normalizeOrigin(probe.baseUrl)
+        val requestedProfile = profile.trim().ifEmpty { "all" }
+        val requestGeneration = ++sessionRefreshGeneration
+        val contextGeneration = sessionContextGeneration
+        val attempt = connectionAttempt
+        val result = runCatching {
+            dashboard.listSessionPage(
+                baseUrl = probe.baseUrl,
+                credential = activeCredential,
+                profile = requestedProfile,
+                limit = SESSION_PAGE_LIMIT,
+                offset = 0,
+            )
+        }
+        val page = result.getOrNull()
+        val current = mutableState.value
+        val stillCurrent = requestGeneration == sessionRefreshGeneration &&
+            contextGeneration == sessionContextGeneration &&
+            attempt == connectionAttempt &&
+            normalizeOrigin(current.probe?.baseUrl.orEmpty()) == origin &&
+            sessionListScopeProfile.equals(requestedProfile, ignoreCase = true)
+        if (!stillCurrent) return false
+        if (page == null) {
+            val error = result.exceptionOrNull()
+            if (error is AuthenticationRejected) {
+                invalidateReusableAuthentication(currentDescriptor, current.probe)
+            } else {
+                mutableState.value = current.copy(
+                    errorMessage = error?.message ?: "Could not refresh Hermes conversations.",
+                )
+            }
+            return false
+        }
+
+        val projected = projectSessionPage(
+            page = page,
+            origin = origin,
+            profile = requestedProfile,
+            previous = current.sessions.orEmpty(),
+        )
+        val active = current.activeSummary
+        val updatedActive = active?.let { summary ->
+            projected.firstOrNull {
+                it.id == summary.id &&
+                    normalizedSessionProfile(it.profile).equals(
+                        normalizedSessionProfile(summary.profile),
+                        ignoreCase = true,
+                    )
+            } ?: summary
+        }
+        mutableState.value = current.copy(
+            sessions = projected,
+            activeSummary = updatedActive,
+            loadingMessage = null,
+            errorMessage = if (page.errors.isNotEmpty()) {
+                "Some Hermes profiles could not refresh."
+            } else if (current.activeSummary == null) {
+                null
+            } else {
+                current.errorMessage
+            },
+        )
+        startSessionPollingIfNeeded()
+        return true
+    }
+
+    private fun startSessionPollingIfNeeded() {
+        val snapshot = mutableState.value
+        if (!conversationsVisible || snapshot.sessions == null || snapshot.activeSummary != null || credential == null) return
+        if (gateway?.supportsSessionChangeEvents == true) return
+        if (sessionPollJob?.isActive == true) return
+        sessionPollJob = viewModelScope.launch {
+            while (mutableState.value.sessions != null && mutableState.value.activeSummary == null) {
+                delay(SESSION_POLL_MILLIS)
+                if (mutableState.value.sessions != null && mutableState.value.activeSummary == null) {
+                    scheduleSessionRefresh(profile = sessionListScopeProfile)
+                }
+            }
+        }
+    }
+
+    private fun markLocalActivity(storedSessionId: String): LocalActivityOperation? {
+        val snapshot = mutableState.value
+        val origin = normalizeOrigin(snapshot.probe?.baseUrl.orEmpty())
+        val summary = snapshot.activeSummary
+        val row = snapshot.sessions.orEmpty().firstOrNull {
+            it.id == storedSessionId &&
+                (summary == null || normalizedSessionProfile(it.profile).equals(
+                    normalizedSessionProfile(summary.profile),
+                    ignoreCase = true,
+                ))
+        } ?: summary?.takeIf { it.id == storedSessionId }
+        val identity = row?.let { sessionIdentity(origin, it) }
+            ?: SessionIdentity(
+                origin = origin,
+                profile = normalizedSessionProfile(summary?.profile.orEmpty()),
+                storedSessionId = storedSessionId,
+            )
+        val currentRemote = row?.let(::effectiveRemoteActivity)
+            ?: summary?.let(::effectiveRemoteActivity)
+        val existing = pendingLocalActivity[identity]
+        val injected = validEpochSeconds(clockSeconds())
+        val bump = listOfNotNull(currentRemote, existing?.bumpSeconds, injected).maxOrNull()
+            ?: return null
+        sessionOperationCounter += 1
+        val operation = LocalActivityOperation(
+            identity = identity,
+            operationId = sessionOperationCounter,
+            contextGeneration = sessionContextGeneration,
+        )
+        pendingLocalActivity[identity] = PendingLocalActivity(
+            bumpSeconds = bump,
+            operationId = operation.operationId,
+            delivery = LocalActivityDelivery.PENDING,
+            contextGeneration = operation.contextGeneration,
+        )
+        while (pendingLocalActivity.size > MAX_PENDING_LOCAL_ACTIVITY) {
+            val oldest = pendingLocalActivity.keys.firstOrNull() ?: break
+            if (oldest == identity && pendingLocalActivity.size == 1) break
+            pendingLocalActivity.remove(oldest)
+        }
+        mutableState.value = snapshot.copy(
+            sessions = orderSessions(
+                sessions = snapshot.sessions.orEmpty(),
+                origin = origin,
+                ordering = sessionListOrdering,
+                overlays = pendingLocalActivity,
+            ),
+        )
+        return operation
+    }
+
+    private fun clearLocalActivity(operation: LocalActivityOperation?) {
+        if (operation == null) return
+        val pending = pendingLocalActivity[operation.identity] ?: return
+        if (pending.operationId != operation.operationId ||
+            pending.contextGeneration != operation.contextGeneration
+        ) {
+            return
+        }
+        pendingLocalActivity.remove(operation.identity)
+        val snapshot = mutableState.value
+        mutableState.value = snapshot.copy(
+            sessions = orderSessions(
+                sessions = snapshot.sessions.orEmpty(),
+                origin = normalizeOrigin(snapshot.probe?.baseUrl.orEmpty()),
+                ordering = sessionListOrdering,
+                overlays = pendingLocalActivity,
+            ),
+        )
+    }
+
+    private fun markLocalActivityUncertain(operation: LocalActivityOperation?) {
+        if (operation == null) return
+        val pending = pendingLocalActivity[operation.identity] ?: return
+        if (pending.operationId != operation.operationId ||
+            pending.contextGeneration != operation.contextGeneration
+        ) {
+            return
+        }
+        pendingLocalActivity[operation.identity] = pending.copy(delivery = LocalActivityDelivery.UNCERTAIN)
+    }
+
+    private fun isCurrentPromptContext(
+        activeGateway: GatewayConnection,
+        storedSessionId: String,
+        contextGeneration: Long,
+        conversationGeneration: Long,
+    ): Boolean =
+        gateway === activeGateway &&
+            sessionContextGeneration == contextGeneration &&
+            this.conversationGeneration == conversationGeneration &&
+            currentStoredSessionId == storedSessionId &&
+            mutableState.value.activeSummary?.id == storedSessionId
+
+    private fun isDefinitivePromptFailure(error: Throwable): Boolean =
+        error is GatewayRpcException ||
+            error is DashboardRpcException ||
+            error is AuthenticationRejected
+
+    private fun normalizeOrigin(baseUrl: String): String =
+        runCatching { DashboardUrlPolicy.normalize(baseUrl) }
+            .getOrElse { baseUrl.trim().trimEnd('/') }
+
     private suspend fun recreateBlankSession(
         activeGateway: GatewayConnection,
         profile: String,
@@ -1054,11 +1477,21 @@ internal class CelesteViewModel(
             val previousSummary = mutableState.value.activeSummary
                 ?: throw IOException("No draft conversation is open.")
             val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
+            val replaced = mutableState.value.sessions?.map { session ->
+                if (session.id == previousStoredId &&
+                    normalizedSessionProfile(session.profile).equals(
+                        normalizedSessionProfile(previousSummary.profile),
+                        ignoreCase = true,
+                    )
+                ) {
+                    updatedSummary
+                } else {
+                    session
+                }
+            }
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
-                sessions = mutableState.value.sessions?.map { session ->
-                    if (session.id == previousStoredId) updatedSummary else session
-                },
+                sessions = replaced,
                 turnState = TurnState.Idle,
                 errorMessage = null,
             )
@@ -1066,6 +1499,7 @@ internal class CelesteViewModel(
             bufferedEvents.clear()
             reconciling = false
             events.forEach(::applyEvent)
+            scheduleSessionRefresh(profile = sessionListScopeProfile)
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false
@@ -1097,6 +1531,7 @@ internal class CelesteViewModel(
                 if (result.isSuccess) {
                     reconnectAttempts = 0
                     reconnectJob = null
+                    scheduleSessionRefresh(profile = sessionListScopeProfile)
                     return@launch
                 }
                 val failure = result.exceptionOrNull()
@@ -1118,10 +1553,13 @@ internal class CelesteViewModel(
     }
 
     private fun closeGateway() {
+        conversationGeneration += 1
         val activeGateway = gateway
         gateway = null
         reconnectJob?.cancel()
         reconnectJob = null
+        sessionPollJob?.cancel()
+        sessionPollJob = null
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         gatewayEventsJob?.cancel()
@@ -1140,11 +1578,17 @@ internal class CelesteViewModel(
         connectionJob?.cancel()
         connectionJob = null
         closeGateway()
+        pendingLocalActivity.clear()
         dashboard.clearAuthentication()
         super.onCleared()
     }
 
     companion object {
+        private const val SESSION_PAGE_LIMIT = 200
+        private const val MAX_PENDING_LOCAL_ACTIVITY = SESSION_PAGE_LIMIT
+        private const val SESSION_CHANGED_DEBOUNCE_MILLIS = 500L
+        private const val SESSION_POLL_MILLIS = 30_000L
+
         internal fun unpersistedInflightText(
             inflight: String,
             messages: List<ConversationMessage>,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -28,8 +28,10 @@ import dev.hazydreams.hermesceleste.network.PendingLocalActivity
 import dev.hazydreams.hermesceleste.network.ResumedSession
 import dev.hazydreams.hermesceleste.network.SessionIdentity
 import dev.hazydreams.hermesceleste.network.SessionListPage
+import dev.hazydreams.hermesceleste.network.SessionListCompatibilityFailure
 import dev.hazydreams.hermesceleste.network.SessionOrdering
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.network.UnsupportedGatewaySessionList
 import dev.hazydreams.hermesceleste.network.boolean
 import dev.hazydreams.hermesceleste.network.createSession
 import dev.hazydreams.hermesceleste.network.deduplicateSessions
@@ -113,6 +115,38 @@ private data class LocalActivityOperation(
     val contextGeneration: Long,
 )
 
+private data class SessionRefreshToken(
+    val requestGeneration: Long,
+    val contextGeneration: Long,
+    val connectionAttempt: Long,
+    val origin: String,
+    val profile: String,
+)
+
+private sealed interface SessionRefreshOutcome {
+    data class Success(
+        val token: SessionRefreshToken,
+        val changed: Boolean,
+    ) : SessionRefreshOutcome
+
+    data class PermanentCompatibility(
+        val token: SessionRefreshToken,
+        val error: SessionListCompatibilityFailure,
+    ) : SessionRefreshOutcome
+
+    data class TransientFailure(
+        val token: SessionRefreshToken,
+        val error: Throwable,
+    ) : SessionRefreshOutcome
+
+    data class AuthenticationFailure(
+        val token: SessionRefreshToken,
+        val error: AuthenticationRejected,
+    ) : SessionRefreshOutcome
+
+    data object Stale : SessionRefreshOutcome
+}
+
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
@@ -134,6 +168,9 @@ internal class CelesteViewModel(
     private var sessionRefreshJob: Job? = null
     private var sessionInvalidationJob: Job? = null
     private var sessionPollJob: Job? = null
+    private var sessionRefreshInFlight = false
+    private var sessionRefreshPending = false
+    private var pendingSessionRefreshProfile: String? = null
     private var connectionJob: Job? = null
     private var connectionAttempt = 0L
     private var sessionRefreshGeneration = 0L
@@ -617,6 +654,7 @@ internal class CelesteViewModel(
             errorMessage = errorMessage ?: loaded.sessionPage.errors
                 .takeIf { it.isNotEmpty() }
                 ?.let { "Some Hermes profiles could not refresh." },
+            sessionRefreshAnnouncementToken = 0L,
         )
         sessionListScopeProfile = "all"
         startSessionPollingIfNeeded()
@@ -654,6 +692,8 @@ internal class CelesteViewModel(
         sessionInvalidationJob = null
         sessionPollJob?.cancel()
         sessionPollJob = null
+        sessionRefreshPending = false
+        pendingSessionRefreshProfile = null
     }
 
     private fun beginSessionContextChange() {
@@ -662,6 +702,7 @@ internal class CelesteViewModel(
         cancelSessionListWork()
         sessionListOrdering = SessionOrdering.SERVER_ORDER
         pendingLocalActivity.clear()
+        mutableState.value = mutableState.value.copy(sessionRefreshAnnouncementToken = 0L)
     }
 
     fun openSession(summary: StoredSession) {
@@ -679,6 +720,7 @@ internal class CelesteViewModel(
             turnState = TurnState.Synchronizing,
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
             errorMessage = null,
+            sessionRefreshAnnouncementToken = 0L,
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
@@ -719,6 +761,7 @@ internal class CelesteViewModel(
             turnState = TurnState.Synchronizing,
             loadingMessage = "Starting a new $selectedProfile conversation…",
             errorMessage = null,
+            sessionRefreshAnnouncementToken = 0L,
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
@@ -797,6 +840,9 @@ internal class CelesteViewModel(
     fun setConversationsDestinationVisible(visible: Boolean) {
         destinationVisibilityReported = true
         conversationsDestinationVisible = visible
+        if (!visible && mutableState.value.sessionRefreshAnnouncementToken != 0L) {
+            mutableState.value = mutableState.value.copy(sessionRefreshAnnouncementToken = 0L)
+        }
         if (visible && appInForeground && mutableState.value.activeSummary == null) {
             scheduleSessionRefresh(profile = sessionListScopeProfile)
             startSessionPollingIfNeeded()
@@ -958,6 +1004,9 @@ internal class CelesteViewModel(
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         cancelSessionListWork()
+        if (mutableState.value.sessionRefreshAnnouncementToken != 0L) {
+            mutableState.value = mutableState.value.copy(sessionRefreshAnnouncementToken = 0L)
+        }
         val descriptor = currentDescriptor ?: return
         if (descriptor.authMode != SavedAuthMode.ProviderSession) return
         if (credential != GatewayCredential.CookieSession) return
@@ -999,42 +1048,70 @@ internal class CelesteViewModel(
             return
         }
         foregroundCheckJob = viewModelScope.launch {
-            val refresh = runCatching {
-                val restRefreshed = refreshSessionListNow(profile = sessionListScopeProfile)
-                if (gateway === activeGateway) {
-                    val gatewayPage = activeGateway.listStoredSessionPage(
-                        profile = sessionListScopeProfile,
-                        limit = SESSION_PAGE_LIMIT,
-                    )
-                    if (!restRefreshed && mutableState.value.sessions != null) {
-                        // REST remains the preferred source. If it was unavailable,
-                        // reconcile the typed gateway result instead of discarding it.
+            var outcome: SessionRefreshOutcome = SessionRefreshOutcome.Stale
+            var fallbackPublished = false
+            try {
+                outcome = refreshSessionListNow(profile = sessionListScopeProfile)
+                if (outcome is SessionRefreshOutcome.PermanentCompatibility && gateway === activeGateway) {
+                    val token = outcome.token
+                    val gatewayPage = try {
+                        activeGateway.listStoredSessionPage(
+                            profile = sessionListScopeProfile,
+                            limit = SESSION_PAGE_LIMIT,
+                        )
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (_: UnsupportedGatewaySessionList) {
+                        null
+                    } catch (_: Throwable) {
+                        null
+                    }
+                    if (
+                        gatewayPage != null &&
+                        gateway === activeGateway &&
+                        isCurrentRefresh(token) &&
+                        mutableState.value.sessions != null
+                    ) {
                         publishSessionPage(
                             page = gatewayPage,
-                            origin = normalizeOrigin(mutableState.value.probe?.baseUrl.orEmpty()),
-                            profile = sessionListScopeProfile,
+                            origin = token.origin,
+                            profile = token.profile,
                             clearErrorOnSuccess = true,
                         )
-                    }
-                    if (currentSessionCanResume) {
-                        reconcile(activeGateway, storedSessionId)
+                        fallbackPublished = true
                     }
                 }
-            }
-            if (refresh.exceptionOrNull() is CancellationException) {
+                val refreshError = mutableState.value.errorMessage
+                if (gateway === activeGateway && currentSessionCanResume) {
+                    reconcile(activeGateway, storedSessionId)
+                }
+                if (
+                    gateway === activeGateway &&
+                    !fallbackPublished &&
+                    (outcome is SessionRefreshOutcome.TransientFailure ||
+                        outcome is SessionRefreshOutcome.PermanentCompatibility) &&
+                    refreshError != null
+                ) {
+                    // Resume reconciliation clears conversation errors, but a
+                    // list failure must remain visible until its own recovery.
+                    mutableState.value = mutableState.value.copy(errorMessage = refreshError)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (gateway === activeGateway) {
+                    val wasRunning = mutableState.value.turnState == TurnState.Running
+                    activeGateway.close()
+                    mutableState.value = mutableState.value.copy(
+                        turnState = TurnState.Reconnecting,
+                        errorMessage = error.message ?: "Reconnecting to Hermes…",
+                    )
+                    scheduleReconnect(wasRunning = wasRunning, immediate = true)
+                }
+            } finally {
+                finishSessionRefresh()
                 foregroundCheckJob = null
-                return@launch
             }
-            if (refresh.isFailure && gateway === activeGateway) {
-                val wasRunning = mutableState.value.turnState == TurnState.Running
-                activeGateway.close()
-                mutableState.value = mutableState.value.copy(
-                    turnState = TurnState.Reconnecting,
-                    errorMessage = refresh.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
-                )
-                scheduleReconnect(wasRunning = wasRunning, immediate = true)
-            }
-            foregroundCheckJob = null
         }
     }
 
@@ -1296,6 +1373,31 @@ internal class CelesteViewModel(
         )
     }
 
+    /**
+     * Activity timestamps are intentionally absent from this comparison: a
+     * heartbeat may update last_active without changing anything a user needs
+     * announced. Reordering, membership, and visible/server-owned row fields
+     * remain meaningful changes.
+     */
+    private fun hasMeaningfulSessionChange(
+        previous: List<StoredSession>,
+        current: List<StoredSession>,
+        origin: String,
+    ): Boolean {
+        if (previous.size != current.size) return true
+        if (previous.map { sessionIdentity(origin, it) } != current.map { sessionIdentity(origin, it) }) {
+            return true
+        }
+        return previous.zip(current).any { (before, after) ->
+            before.title != after.title ||
+                before.preview != after.preview ||
+                before.messageCount != after.messageCount ||
+                before.source != after.source ||
+                before.profile != after.profile ||
+                validEpochSeconds(before.startedAt) != validEpochSeconds(after.startedAt)
+        }
+    }
+
     private fun publishSessionPage(
         page: SessionListPage,
         origin: String,
@@ -1321,8 +1423,13 @@ internal class CelesteViewModel(
             } ?: summary
         }
         val changed = projected != current.sessions || updatedActive != active
+        val meaningfulChanged = hasMeaningfulSessionChange(
+            previous = current.sessions.orEmpty(),
+            current = projected,
+            origin = origin,
+        )
         val announcementToken = if (
-            announce && changed && conversationsDestinationVisible && appInForeground
+            announce && meaningfulChanged && conversationsDestinationVisible && appInForeground
         ) {
             current.sessionRefreshAnnouncementToken + 1
         } else {
@@ -1358,62 +1465,102 @@ internal class CelesteViewModel(
             }
             return
         }
-        if (sessionRefreshJob?.isActive == true) return
+        if (sessionRefreshJob?.isActive == true || sessionRefreshInFlight) {
+            sessionRefreshPending = true
+            pendingSessionRefreshProfile = profile
+            return
+        }
         sessionRefreshJob = viewModelScope.launch {
-            refreshSessionListNow(profile)
+            try {
+                refreshSessionListNow(profile)
+            } finally {
+                sessionRefreshJob = null
+                finishSessionRefresh()
+            }
         }
     }
 
-    private suspend fun refreshSessionListNow(profile: String): Boolean {
+    private fun finishSessionRefresh() {
+        if (!sessionRefreshPending) return
+        val profile = pendingSessionRefreshProfile ?: sessionListScopeProfile
+        sessionRefreshPending = false
+        pendingSessionRefreshProfile = null
+        sessionInvalidationJob?.cancel()
+        sessionInvalidationJob = null
+        scheduleSessionRefresh(profile = profile)
+    }
+
+    private fun isCurrentRefresh(token: SessionRefreshToken): Boolean {
+        val current = mutableState.value
+        return token.requestGeneration == sessionRefreshGeneration &&
+            token.contextGeneration == sessionContextGeneration &&
+            token.connectionAttempt == connectionAttempt &&
+            normalizeOrigin(current.probe?.baseUrl.orEmpty()) == token.origin &&
+            sessionListScopeProfile.equals(token.profile, ignoreCase = true)
+    }
+
+    private suspend fun refreshSessionListNow(profile: String): SessionRefreshOutcome {
         val snapshot = mutableState.value
-        val probe = snapshot.probe ?: return false
-        val activeCredential = credential ?: return false
+        val probe = snapshot.probe ?: return SessionRefreshOutcome.Stale
+        val activeCredential = credential ?: return SessionRefreshOutcome.Stale
         val origin = normalizeOrigin(probe.baseUrl)
         val requestedProfile = profile.trim().ifEmpty { "all" }
-        val requestGeneration = ++sessionRefreshGeneration
-        val contextGeneration = sessionContextGeneration
-        val attempt = connectionAttempt
-        val result: Result<SessionListPage> = try {
-            Result.success(
-                dashboard.listSessionPage(
-                    baseUrl = probe.baseUrl,
-                    credential = activeCredential,
-                    profile = requestedProfile,
-                    limit = SESSION_PAGE_LIMIT,
-                    offset = 0,
-                ),
-            )
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Throwable) {
-            Result.failure(error)
-        }
-        val page = result.getOrNull()
-        val current = mutableState.value
-        val stillCurrent = requestGeneration == sessionRefreshGeneration &&
-            contextGeneration == sessionContextGeneration &&
-            attempt == connectionAttempt &&
-            normalizeOrigin(current.probe?.baseUrl.orEmpty()) == origin &&
-            sessionListScopeProfile.equals(requestedProfile, ignoreCase = true)
-        if (!stillCurrent) return false
-        if (page == null) {
-            val error = result.exceptionOrNull()
-            if (error is CancellationException) throw error
-            if (error is AuthenticationRejected) {
-                invalidateReusableAuthentication(currentDescriptor, current.probe)
-            } else {
-                mutableState.value = current.copy(
-                    errorMessage = error?.message ?: "Could not refresh Hermes conversations.",
-                )
-            }
-            return false
-        }
-        publishSessionPage(
-            page = page,
+        val token = SessionRefreshToken(
+            requestGeneration = ++sessionRefreshGeneration,
+            contextGeneration = sessionContextGeneration,
+            connectionAttempt = connectionAttempt,
             origin = origin,
             profile = requestedProfile,
         )
-        return true
+        sessionRefreshInFlight = true
+        try {
+            val result: Result<SessionListPage> = try {
+                Result.success(
+                    dashboard.listSessionPage(
+                        baseUrl = probe.baseUrl,
+                        credential = activeCredential,
+                        profile = requestedProfile,
+                        limit = SESSION_PAGE_LIMIT,
+                        offset = 0,
+                    ),
+                )
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                Result.failure(error)
+            }
+            val page = result.getOrNull()
+            if (!isCurrentRefresh(token)) return SessionRefreshOutcome.Stale
+            if (page == null) {
+                val error = result.exceptionOrNull()
+                if (error is CancellationException) throw error
+                if (error is AuthenticationRejected) {
+                    invalidateReusableAuthentication(currentDescriptor, mutableState.value.probe)
+                    return SessionRefreshOutcome.AuthenticationFailure(token, error)
+                }
+                if (error is SessionListCompatibilityFailure) {
+                    mutableState.value = mutableState.value.copy(
+                        errorMessage = error.message ?: "Hermes does not provide a compatible conversation list.",
+                    )
+                    return SessionRefreshOutcome.PermanentCompatibility(token, error)
+                }
+                mutableState.value = mutableState.value.copy(
+                    errorMessage = error?.message ?: "Could not refresh Hermes conversations.",
+                )
+                return SessionRefreshOutcome.TransientFailure(
+                    token = token,
+                    error = error ?: IOException("Could not refresh Hermes conversations."),
+                )
+            }
+            val changed = publishSessionPage(
+                page = page,
+                origin = origin,
+                profile = requestedProfile,
+            )
+            return SessionRefreshOutcome.Success(token, changed)
+        } finally {
+            sessionRefreshInFlight = false
+        }
     }
 
     private fun startSessionPollingIfNeeded() {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -184,7 +184,17 @@ class TransportUnavailable(
     internal val statusCode: Int? = null,
 ) : DashboardFailure(message, cause)
 
-class InvalidDashboardResponse(message: String, cause: Throwable? = null) : DashboardFailure(message, cause)
+open class InvalidDashboardResponse(message: String, cause: Throwable? = null) : DashboardFailure(message, cause)
+
+/**
+ * Both bounded conversation-list protocols are unavailable for this
+ * authentication generation. This is a compatibility result, not a
+ * transient dashboard failure.
+ */
+class SessionListCompatibilityFailure(
+    message: String,
+    cause: Throwable? = null,
+) : InvalidDashboardResponse(message, cause)
 
 class DashboardRpcException(
     val code: Int?,
@@ -317,6 +327,7 @@ class DashboardClient(
     private val capabilityGeneration = AtomicLong(0L)
     private val restSessionListUnsupportedGenerations = ConcurrentHashMap<String, Long>()
     private val rpcSessionListUnsupportedGenerations = ConcurrentHashMap<String, Long>()
+    private val capabilityLock = Any()
 
     override suspend fun probe(rawBaseUrl: String): DashboardProbeResult = withContext(Dispatchers.IO) {
         val baseUrl = DashboardUrlPolicy.normalize(rawBaseUrl)
@@ -373,7 +384,8 @@ class DashboardClient(
         limit: Int,
     ): List<StoredSession> {
         val normalizedBaseUrl = DashboardUrlPolicy.normalize(baseUrl)
-        if (isRpcSessionListUnsupported(normalizedBaseUrl)) {
+        val requestCapabilityGeneration = capabilityGenerationSnapshot()
+        if (isRpcSessionListUnsupported(normalizedBaseUrl, requestCapabilityGeneration)) {
             throw incompatibleSessionListFailure()
         }
         val authParameter = resolveWebSocketCredential(normalizedBaseUrl, credential)
@@ -382,7 +394,7 @@ class DashboardClient(
             withTimeout(15_000) { requestSessionList(wsUrl, limit.coerceIn(1, 500)) }
         } catch (error: DashboardRpcException) {
             if (error.code != -32601) throw error
-            invalidateRpcSessionList(normalizedBaseUrl)
+            invalidateRpcSessionList(normalizedBaseUrl, requestCapabilityGeneration)
             throw incompatibleSessionListFailure(error)
         }
     }
@@ -397,7 +409,8 @@ class DashboardClient(
         val normalizedBaseUrl = DashboardUrlPolicy.normalize(baseUrl)
         val boundedLimit = limit.coerceIn(1, 200)
         val boundedOffset = offset.coerceAtLeast(0)
-        if (!isRestSessionListUnsupported(normalizedBaseUrl)) {
+        val requestCapabilityGeneration = capabilityGenerationSnapshot()
+        if (!isRestSessionListUnsupported(normalizedBaseUrl, requestCapabilityGeneration)) {
             try {
                 return withContext(Dispatchers.IO) {
                     requestRestSessionPage(
@@ -410,13 +423,13 @@ class DashboardClient(
                 }
             } catch (error: TransportUnavailable) {
                 if (error.statusCode != 404 && error.statusCode != 405) throw error
-                invalidateRestSessionList(normalizedBaseUrl)
+                invalidateRestSessionList(normalizedBaseUrl, requestCapabilityGeneration)
             } catch (_: UnsupportedSessionListCapability) {
-                invalidateRestSessionList(normalizedBaseUrl)
+                invalidateRestSessionList(normalizedBaseUrl, requestCapabilityGeneration)
             }
         }
 
-        if (isRpcSessionListUnsupported(normalizedBaseUrl)) {
+        if (isRpcSessionListUnsupported(normalizedBaseUrl, requestCapabilityGeneration)) {
             throw incompatibleSessionListFailure()
         }
         return try {
@@ -435,7 +448,7 @@ class DashboardClient(
             }
         } catch (error: DashboardRpcException) {
             if (error.code != -32601) throw error
-            invalidateRpcSessionList(normalizedBaseUrl)
+            invalidateRpcSessionList(normalizedBaseUrl, requestCapabilityGeneration)
             throw incompatibleSessionListFailure(error)
         }
     }
@@ -511,27 +524,48 @@ class DashboardClient(
     }
 
     private fun resetCapabilityGeneration() {
-        restSessionListUnsupportedGenerations.clear()
-        rpcSessionListUnsupportedGenerations.clear()
-        capabilityGeneration.incrementAndGet()
+        synchronized(capabilityLock) {
+            restSessionListUnsupportedGenerations.clear()
+            rpcSessionListUnsupportedGenerations.clear()
+            capabilityGeneration.incrementAndGet()
+        }
     }
 
-    private fun isRestSessionListUnsupported(origin: String): Boolean =
-        restSessionListUnsupportedGenerations[origin] == capabilityGeneration.get()
-
-    private fun isRpcSessionListUnsupported(origin: String): Boolean =
-        rpcSessionListUnsupportedGenerations[origin] == capabilityGeneration.get()
-
-    private fun invalidateRestSessionList(origin: String) {
-        restSessionListUnsupportedGenerations[origin] = capabilityGeneration.get()
+    /** Capture once at request start; an old request must not write into a new auth generation. */
+    private fun capabilityGenerationSnapshot(): Long = synchronized(capabilityLock) {
+        capabilityGeneration.get()
     }
 
-    private fun invalidateRpcSessionList(origin: String) {
-        rpcSessionListUnsupportedGenerations[origin] = capabilityGeneration.get()
+    private fun isRestSessionListUnsupported(origin: String, generation: Long): Boolean =
+        synchronized(capabilityLock) {
+            capabilityGeneration.get() == generation &&
+                restSessionListUnsupportedGenerations[origin] == generation
+        }
+
+    private fun isRpcSessionListUnsupported(origin: String, generation: Long): Boolean =
+        synchronized(capabilityLock) {
+            capabilityGeneration.get() == generation &&
+                rpcSessionListUnsupportedGenerations[origin] == generation
+        }
+
+    private fun invalidateRestSessionList(origin: String, generation: Long) {
+        synchronized(capabilityLock) {
+            if (capabilityGeneration.get() == generation) {
+                restSessionListUnsupportedGenerations[origin] = generation
+            }
+        }
+    }
+
+    private fun invalidateRpcSessionList(origin: String, generation: Long) {
+        synchronized(capabilityLock) {
+            if (capabilityGeneration.get() == generation) {
+                rpcSessionListUnsupportedGenerations[origin] = generation
+            }
+        }
     }
 
     private fun incompatibleSessionListFailure(cause: Throwable? = null): InvalidDashboardResponse =
-        InvalidDashboardResponse(
+        SessionListCompatibilityFailure(
             "Hermes does not provide a compatible conversation list.",
             cause,
         )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -3,6 +3,7 @@ package dev.hazydreams.hermesceleste.network
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -16,6 +17,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -189,6 +191,8 @@ class DashboardRpcException(
     message: String,
 ) : DashboardFailure(message)
 
+private class UnsupportedSessionListCapability(message: String) : IOException(message)
+
 private class DashboardCookieJar : CookieJar {
     private val cookies = mutableListOf<Cookie>()
 
@@ -308,9 +312,11 @@ class DashboardClient(
         .followRedirects(false)
         .build(),
 ) : DashboardService {
-    // Compatibility is deliberately process-memory only. A future server or
-    // origin gets a fresh attempt; no protocol capability is persisted.
-    private val restSessionListUnsupportedOrigins = ConcurrentHashMap.newKeySet<String>()
+    // Compatibility is process-memory only. A new authentication generation
+    // gets a fresh capability attempt; no protocol capability is persisted.
+    private val capabilityGeneration = AtomicLong(0L)
+    private val restSessionListUnsupportedGenerations = ConcurrentHashMap<String, Long>()
+    private val rpcSessionListUnsupportedGenerations = ConcurrentHashMap<String, Long>()
 
     override suspend fun probe(rawBaseUrl: String): DashboardProbeResult = withContext(Dispatchers.IO) {
         val baseUrl = DashboardUrlPolicy.normalize(rawBaseUrl)
@@ -366,9 +372,19 @@ class DashboardClient(
         credential: GatewayCredential,
         limit: Int,
     ): List<StoredSession> {
-        val authParameter = resolveWebSocketCredential(baseUrl, credential)
-        val wsUrl = buildWebSocketUrl(baseUrl, authParameter?.first, authParameter?.second)
-        return withTimeout(15_000) { requestSessionList(wsUrl, limit.coerceIn(1, 500)) }
+        val normalizedBaseUrl = DashboardUrlPolicy.normalize(baseUrl)
+        if (isRpcSessionListUnsupported(normalizedBaseUrl)) {
+            throw incompatibleSessionListFailure()
+        }
+        val authParameter = resolveWebSocketCredential(normalizedBaseUrl, credential)
+        val wsUrl = buildWebSocketUrl(normalizedBaseUrl, authParameter?.first, authParameter?.second)
+        return try {
+            withTimeout(15_000) { requestSessionList(wsUrl, limit.coerceIn(1, 500)) }
+        } catch (error: DashboardRpcException) {
+            if (error.code != -32601) throw error
+            invalidateRpcSessionList(normalizedBaseUrl)
+            throw incompatibleSessionListFailure(error)
+        }
     }
 
     override suspend fun listSessionPage(
@@ -381,7 +397,7 @@ class DashboardClient(
         val normalizedBaseUrl = DashboardUrlPolicy.normalize(baseUrl)
         val boundedLimit = limit.coerceIn(1, 200)
         val boundedOffset = offset.coerceAtLeast(0)
-        if (normalizedBaseUrl !in restSessionListUnsupportedOrigins) {
+        if (!isRestSessionListUnsupported(normalizedBaseUrl)) {
             try {
                 return withContext(Dispatchers.IO) {
                     requestRestSessionPage(
@@ -394,10 +410,15 @@ class DashboardClient(
                 }
             } catch (error: TransportUnavailable) {
                 if (error.statusCode != 404 && error.statusCode != 405) throw error
-                restSessionListUnsupportedOrigins += normalizedBaseUrl
+                invalidateRestSessionList(normalizedBaseUrl)
+            } catch (_: UnsupportedSessionListCapability) {
+                invalidateRestSessionList(normalizedBaseUrl)
             }
         }
 
+        if (isRpcSessionListUnsupported(normalizedBaseUrl)) {
+            throw incompatibleSessionListFailure()
+        }
         return try {
             val authParameter = resolveWebSocketCredential(normalizedBaseUrl, credential)
             val wsUrl = buildWebSocketUrl(
@@ -413,13 +434,9 @@ class DashboardClient(
                 )
             }
         } catch (error: DashboardRpcException) {
-            if (error.code == -32601) {
-                throw InvalidDashboardResponse(
-                    "Hermes does not provide a compatible conversation list.",
-                    error,
-                )
-            }
-            throw error
+            if (error.code != -32601) throw error
+            invalidateRpcSessionList(normalizedBaseUrl)
+            throw incompatibleSessionListFailure(error)
         }
     }
 
@@ -478,6 +495,7 @@ class DashboardClient(
     }
 
     override fun restoreAuthentication(baseUrl: String, material: AuthenticationMaterial): Boolean {
+        resetCapabilityGeneration()
         val jar = cookieJar as? DashboardCookieJar ?: return false
         jar.clear()
         val url = authenticationScopeUrl(baseUrl) ?: return false
@@ -489,8 +507,34 @@ class DashboardClient(
 
     override fun clearAuthentication() {
         (cookieJar as? DashboardCookieJar)?.clear()
-        restSessionListUnsupportedOrigins.clear()
+        resetCapabilityGeneration()
     }
+
+    private fun resetCapabilityGeneration() {
+        restSessionListUnsupportedGenerations.clear()
+        rpcSessionListUnsupportedGenerations.clear()
+        capabilityGeneration.incrementAndGet()
+    }
+
+    private fun isRestSessionListUnsupported(origin: String): Boolean =
+        restSessionListUnsupportedGenerations[origin] == capabilityGeneration.get()
+
+    private fun isRpcSessionListUnsupported(origin: String): Boolean =
+        rpcSessionListUnsupportedGenerations[origin] == capabilityGeneration.get()
+
+    private fun invalidateRestSessionList(origin: String) {
+        restSessionListUnsupportedGenerations[origin] = capabilityGeneration.get()
+    }
+
+    private fun invalidateRpcSessionList(origin: String) {
+        rpcSessionListUnsupportedGenerations[origin] = capabilityGeneration.get()
+    }
+
+    private fun incompatibleSessionListFailure(cause: Throwable? = null): InvalidDashboardResponse =
+        InvalidDashboardResponse(
+            "Hermes does not provide a compatible conversation list.",
+            cause,
+        )
 
     private fun authenticationScopeUrl(baseUrl: String): HttpUrl? = runCatching {
         "${DashboardUrlPolicy.normalize(baseUrl)}/api/status".toHttpUrl()
@@ -618,6 +662,17 @@ class DashboardClient(
                 },
             )
         }
+        val missingLastActive = rows.any { element ->
+            val row = element as? JsonObject ?: return@any false
+            val id = (row["id"] as? JsonPrimitive)?.contentOrNull
+            id != null && id.isNotBlank() &&
+                (row["last_active"] == null || row["last_active"] == JsonNull)
+        }
+        if (missingLastActive) {
+            throw UnsupportedSessionListCapability(
+                "Hermes conversation rows do not provide last_active.",
+            )
+        }
         val errors = (root["errors"] as? JsonArray).orEmpty().mapNotNull { element ->
             val row = element as? JsonObject ?: return@mapNotNull null
             val failedProfile = (row["profile"] as? JsonPrimitive)?.contentOrNull
@@ -631,14 +686,16 @@ class DashboardClient(
         val total = (root["total"] as? JsonPrimitive)?.intOrNull ?: sessions.size
         val responseOffset = (root["offset"] as? JsonPrimitive)?.intOrNull ?: offset
         val responseLimit = (root["limit"] as? JsonPrimitive)?.intOrNull ?: limit
-        val usableNumericValue = sessions.any { effectiveRemoteActivity(it) != null }
+        val hasAuthoritativeActivity = sessions.isNotEmpty() && sessions.all {
+            validEpochSeconds(it.lastActive) != null
+        }
         return SessionListPage(
             sessions = sessions,
             total = total,
             offset = responseOffset,
             limit = responseLimit,
             errors = errors,
-            ordering = if (usableNumericValue) {
+            ordering = if (hasAuthoritativeActivity) {
                 SessionOrdering.AUTHORITATIVE_RECENCY
             } else {
                 SessionOrdering.SERVER_ORDER
@@ -825,23 +882,7 @@ class DashboardClient(
     private fun decodeSession(
         element: JsonElement,
         fallbackProfile: String? = null,
-    ): StoredSession? {
-        val row = element as? JsonObject ?: return null
-        val id = (row["id"] as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
-            ?: return null
-        val suppliedProfile = (row["profile"] as? JsonPrimitive)?.contentOrNull
-            ?: (row["profile_name"] as? JsonPrimitive)?.contentOrNull
-        return StoredSession(
-            id = id,
-            title = (row["title"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-            preview = (row["preview"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-            startedAt = validEpochSeconds((row["started_at"] as? JsonPrimitive)?.doubleOrNull) ?: 0.0,
-            messageCount = (row["message_count"] as? JsonPrimitive)?.intOrNull ?: 0,
-            source = (row["source"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-            profile = suppliedProfile ?: fallbackProfile ?: "default",
-            lastActive = validEpochSeconds((row["last_active"] as? JsonPrimitive)?.doubleOrNull),
-        )
-    }
+    ): StoredSession? = decodeStoredSession(element, fallbackProfile)
 
     private fun decodeProfile(element: JsonElement): DashboardProfile {
         if (element is JsonPrimitive && element.isString) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -3,6 +3,7 @@ package dev.hazydreams.hermesceleste.network
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.Dispatchers
@@ -65,6 +66,8 @@ data class StoredSession(
     val messageCount: Int,
     val source: String,
     val profile: String = "default",
+    /** Hermes `last_active`, in Unix epoch seconds, when valid. */
+    val lastActive: Double? = null,
 )
 
 data class DashboardProfile(
@@ -127,6 +130,27 @@ interface DashboardService {
         limit: Int = 200,
     ): List<StoredSession>
 
+    /**
+     * Read one bounded, profile-scoped dashboard page. Implementations that
+     * only expose the legacy gateway list retain its server arrival order.
+     */
+    suspend fun listSessionPage(
+        baseUrl: String,
+        credential: GatewayCredential,
+        profile: String = "all",
+        limit: Int = 200,
+        offset: Int = 0,
+    ): SessionListPage {
+        val sessions = listSessions(baseUrl, credential, limit)
+        return SessionListPage(
+            sessions = sessions,
+            total = sessions.size,
+            offset = offset,
+            limit = limit,
+            ordering = SessionOrdering.SERVER_ORDER,
+        )
+    }
+
     suspend fun listProfiles(
         baseUrl: String,
         credential: GatewayCredential,
@@ -159,6 +183,11 @@ class TransportUnavailable(
 ) : DashboardFailure(message, cause)
 
 class InvalidDashboardResponse(message: String, cause: Throwable? = null) : DashboardFailure(message, cause)
+
+class DashboardRpcException(
+    val code: Int?,
+    message: String,
+) : DashboardFailure(message)
 
 private class DashboardCookieJar : CookieJar {
     private val cookies = mutableListOf<Cookie>()
@@ -279,6 +308,10 @@ class DashboardClient(
         .followRedirects(false)
         .build(),
 ) : DashboardService {
+    // Compatibility is deliberately process-memory only. A future server or
+    // origin gets a fresh attempt; no protocol capability is persisted.
+    private val restSessionListUnsupportedOrigins = ConcurrentHashMap.newKeySet<String>()
+
     override suspend fun probe(rawBaseUrl: String): DashboardProbeResult = withContext(Dispatchers.IO) {
         val baseUrl = DashboardUrlPolicy.normalize(rawBaseUrl)
         val status = executeJson(
@@ -336,6 +369,58 @@ class DashboardClient(
         val authParameter = resolveWebSocketCredential(baseUrl, credential)
         val wsUrl = buildWebSocketUrl(baseUrl, authParameter?.first, authParameter?.second)
         return withTimeout(15_000) { requestSessionList(wsUrl, limit.coerceIn(1, 500)) }
+    }
+
+    override suspend fun listSessionPage(
+        baseUrl: String,
+        credential: GatewayCredential,
+        profile: String,
+        limit: Int,
+        offset: Int,
+    ): SessionListPage {
+        val normalizedBaseUrl = DashboardUrlPolicy.normalize(baseUrl)
+        val boundedLimit = limit.coerceIn(1, 200)
+        val boundedOffset = offset.coerceAtLeast(0)
+        if (normalizedBaseUrl !in restSessionListUnsupportedOrigins) {
+            try {
+                return withContext(Dispatchers.IO) {
+                    requestRestSessionPage(
+                        baseUrl = normalizedBaseUrl,
+                        credential = credential,
+                        profile = profile,
+                        limit = boundedLimit,
+                        offset = boundedOffset,
+                    )
+                }
+            } catch (error: TransportUnavailable) {
+                if (error.statusCode != 404 && error.statusCode != 405) throw error
+                restSessionListUnsupportedOrigins += normalizedBaseUrl
+            }
+        }
+
+        return try {
+            val authParameter = resolveWebSocketCredential(normalizedBaseUrl, credential)
+            val wsUrl = buildWebSocketUrl(
+                normalizedBaseUrl,
+                authParameter?.first,
+                authParameter?.second,
+            )
+            withTimeout(15_000) {
+                requestSessionListPage(
+                    wsUrl = wsUrl,
+                    limit = boundedLimit,
+                    profile = profile,
+                )
+            }
+        } catch (error: DashboardRpcException) {
+            if (error.code == -32601) {
+                throw InvalidDashboardResponse(
+                    "Hermes does not provide a compatible conversation list.",
+                    error,
+                )
+            }
+            throw error
+        }
     }
 
     override suspend fun listProfiles(
@@ -404,6 +489,7 @@ class DashboardClient(
 
     override fun clearAuthentication() {
         (cookieJar as? DashboardCookieJar)?.clear()
+        restSessionListUnsupportedOrigins.clear()
     }
 
     private fun authenticationScopeUrl(baseUrl: String): HttpUrl? = runCatching {
@@ -495,12 +581,93 @@ class DashboardClient(
         else -> TransportUnavailable("$operation returned HTTP $code.", statusCode = code)
     }
 
+    private fun requestRestSessionPage(
+        baseUrl: String,
+        credential: GatewayCredential,
+        profile: String,
+        limit: Int,
+        offset: Int,
+    ): SessionListPage {
+        val url = "$baseUrl/api/profiles/sessions".toHttpUrl().newBuilder()
+            .addQueryParameter("profile", profile.trim().ifEmpty { "all" })
+            .addQueryParameter("order", "recent")
+            .addQueryParameter("archived", "exclude")
+            .addQueryParameter("limit", limit.toString())
+            .addQueryParameter("offset", offset.toString())
+            .build()
+        val root = executeJson(
+            Request.Builder()
+                .url(url)
+                .header("Accept", "application/json")
+                .apply {
+                    if (credential is GatewayCredential.StaticToken) {
+                        header("X-Hermes-Session-Token", credential.value.trim())
+                    }
+                }
+                .get()
+                .build(),
+            "Hermes conversations",
+        ) as? JsonObject ?: throw InvalidDashboardResponse("Hermes returned no conversation list.")
+        val rows = root["sessions"] as? JsonArray
+            ?: throw InvalidDashboardResponse("Hermes returned no conversation list.")
+        val sessions = rows.mapNotNull { element ->
+            decodeSession(
+                element = element,
+                fallbackProfile = profile.takeUnless {
+                    it.isBlank() || it.equals("all", ignoreCase = true)
+                },
+            )
+        }
+        val errors = (root["errors"] as? JsonArray).orEmpty().mapNotNull { element ->
+            val row = element as? JsonObject ?: return@mapNotNull null
+            val failedProfile = (row["profile"] as? JsonPrimitive)?.contentOrNull
+                ?.takeIf(String::isNotBlank)
+                ?: return@mapNotNull null
+            val message = (row["error"] as? JsonPrimitive)?.contentOrNull
+                ?.takeIf(String::isNotBlank)
+                ?: return@mapNotNull null
+            SessionListError(failedProfile, message)
+        }
+        val total = (root["total"] as? JsonPrimitive)?.intOrNull ?: sessions.size
+        val responseOffset = (root["offset"] as? JsonPrimitive)?.intOrNull ?: offset
+        val responseLimit = (root["limit"] as? JsonPrimitive)?.intOrNull ?: limit
+        val usableNumericValue = sessions.any { effectiveRemoteActivity(it) != null }
+        return SessionListPage(
+            sessions = sessions,
+            total = total,
+            offset = responseOffset,
+            limit = responseLimit,
+            errors = errors,
+            ordering = if (usableNumericValue) {
+                SessionOrdering.AUTHORITATIVE_RECENCY
+            } else {
+                SessionOrdering.SERVER_ORDER
+            },
+        )
+    }
+
     private suspend fun requestSessionList(wsUrl: String, limit: Int): List<StoredSession> {
+        return requestSessionListPage(wsUrl, limit, profile = "all").sessions
+    }
+
+    private suspend fun requestSessionListPage(
+        wsUrl: String,
+        limit: Int,
+        profile: String,
+    ): SessionListPage {
         val frame = buildJsonObject {
             put("jsonrpc", "2.0")
             put("id", SESSION_LIST_REQUEST_ID)
             put("method", "session.list")
-            put("params", buildJsonObject { put("limit", limit) })
+            put(
+                "params",
+                buildJsonObject {
+                    put("limit", limit)
+                    if (profile.isNotBlank() && !profile.equals("all", ignoreCase = true)) {
+                        put("profile", profile)
+                    }
+                },
+            )
         }
         return requestSingleWebSocketResponse(
             request = Request.Builder().url(wsUrl).build(),
@@ -510,7 +677,21 @@ class DashboardClient(
         ) { result ->
             val rows = (result as? JsonObject)?.get("sessions") as? JsonArray
                 ?: throw InvalidDashboardResponse("Hermes returned no session list.")
-            rows.mapNotNull(::decodeSession)
+            val sessions = rows.mapNotNull { element ->
+                decodeSession(
+                    element = element,
+                    fallbackProfile = profile.takeUnless { it.isBlank() || it.equals("all", ignoreCase = true) },
+                )
+            }
+            SessionListPage(
+                sessions = sessions,
+                total = sessions.size,
+                ordering = if (sessions.isNotEmpty() && sessions.all { validEpochSeconds(it.lastActive) != null }) {
+                    SessionOrdering.AUTHORITATIVE_RECENCY
+                } else {
+                    SessionOrdering.SERVER_ORDER
+                },
+            )
         }
     }
 
@@ -593,7 +774,13 @@ class DashboardClient(
                     }
                 if ((root["id"] as? JsonPrimitive)?.contentOrNull != expectedId) return
                 (root["error"] as? JsonObject)?.let { error ->
-                    fail(IOException((error["message"] as? JsonPrimitive)?.contentOrNull ?: "$operation failed."))
+                    fail(
+                        DashboardRpcException(
+                            code = (error["code"] as? JsonPrimitive)?.intOrNull,
+                            message = (error["message"] as? JsonPrimitive)?.contentOrNull
+                                ?: "$operation failed.",
+                        ),
+                    )
                     return
                 }
                 val result = root["result"]
@@ -635,19 +822,24 @@ class DashboardClient(
         }
     }
 
-    private fun decodeSession(element: JsonElement): StoredSession? {
+    private fun decodeSession(
+        element: JsonElement,
+        fallbackProfile: String? = null,
+    ): StoredSession? {
         val row = element as? JsonObject ?: return null
-        val id = row["id"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank) ?: return null
+        val id = (row["id"] as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
+            ?: return null
+        val suppliedProfile = (row["profile"] as? JsonPrimitive)?.contentOrNull
+            ?: (row["profile_name"] as? JsonPrimitive)?.contentOrNull
         return StoredSession(
             id = id,
-            title = row["title"]?.jsonPrimitive?.contentOrNull.orEmpty(),
-            preview = row["preview"]?.jsonPrimitive?.contentOrNull.orEmpty(),
-            startedAt = row["started_at"]?.jsonPrimitive?.doubleOrNull ?: 0.0,
-            messageCount = row["message_count"]?.jsonPrimitive?.intOrNull ?: 0,
-            source = row["source"]?.jsonPrimitive?.contentOrNull.orEmpty(),
-            profile = row["profile"]?.jsonPrimitive?.contentOrNull
-                ?: row["profile_name"]?.jsonPrimitive?.contentOrNull
-                ?: "default",
+            title = (row["title"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+            preview = (row["preview"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+            startedAt = validEpochSeconds((row["started_at"] as? JsonPrimitive)?.doubleOrNull) ?: 0.0,
+            messageCount = (row["message_count"] as? JsonPrimitive)?.intOrNull ?: 0,
+            source = (row["source"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+            profile = suppliedProfile ?: fallbackProfile ?: "default",
+            lastActive = validEpochSeconds((row["last_active"] as? JsonPrimitive)?.doubleOrNull),
         )
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.put
 
 data class CreatedSession(
@@ -78,6 +79,41 @@ suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): Resu
         status = status,
         inflightAssistantText = inflightAssistantText(inflight),
         hasLiveProjection = inflight.isTruthy() || queued.isTruthy(),
+    )
+}
+
+suspend fun GatewayConnection.listStoredSessionPage(
+    profile: String = "all",
+    limit: Int = 200,
+): SessionListPage {
+    val boundedLimit = limit.coerceIn(1, 200)
+    val result = request(
+        method = "session.list",
+        params = buildJsonObject {
+            put("limit", boundedLimit)
+            if (profile.isNotBlank() && !profile.equals("all", ignoreCase = true)) {
+                put("profile", profile)
+            }
+        },
+        timeoutMillis = 8_000,
+    ).asObject("Hermes returned no session list.")
+    val rows = result["sessions"] as? JsonArray
+        ?: throw IOException("Hermes returned no session list.")
+    val sessions = rows.mapNotNull { element ->
+        decodeStoredSession(
+            element = element,
+            fallbackProfile = profile.takeUnless { it.isBlank() || it.equals("all", ignoreCase = true) },
+        )
+    }
+    return SessionListPage(
+        sessions = sessions,
+        total = result["total"]?.jsonPrimitive?.intOrNull ?: sessions.size,
+        limit = result["limit"]?.jsonPrimitive?.intOrNull ?: boundedLimit,
+        ordering = if (sessions.isNotEmpty() && sessions.all { validEpochSeconds(it.lastActive) != null }) {
+            SessionOrdering.AUTHORITATIVE_RECENCY
+        } else {
+            SessionOrdering.SERVER_ORDER
+        },
     )
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -21,6 +21,11 @@ data class CreatedSession(
     val profile: String?,
 )
 
+class UnsupportedGatewaySessionList(
+    message: String = "Hermes does not support conversation listing on this Gateway generation.",
+    cause: Throwable? = null,
+) : IOException(message, cause)
+
 suspend fun GatewayConnection.createSession(profile: String): CreatedSession {
     val selectedProfile = profile.trim().ifEmpty { "default" }
     val result = request(
@@ -87,16 +92,25 @@ suspend fun GatewayConnection.listStoredSessionPage(
     limit: Int = 200,
 ): SessionListPage {
     val boundedLimit = limit.coerceIn(1, 200)
-    val result = request(
-        method = "session.list",
-        params = buildJsonObject {
-            put("limit", boundedLimit)
-            if (profile.isNotBlank() && !profile.equals("all", ignoreCase = true)) {
-                put("profile", profile)
-            }
-        },
-        timeoutMillis = 8_000,
-    ).asObject("Hermes returned no session list.")
+    if (sessionListCapability == GatewaySessionListCapability.UNSUPPORTED) {
+        throw UnsupportedGatewaySessionList()
+    }
+    val result = try {
+        request(
+            method = "session.list",
+            params = buildJsonObject {
+                put("limit", boundedLimit)
+                if (profile.isNotBlank() && !profile.equals("all", ignoreCase = true)) {
+                    put("profile", profile)
+                }
+            },
+            timeoutMillis = 8_000,
+        ).asObject("Hermes returned no session list.")
+    } catch (error: GatewayRpcException) {
+        if (error.code != -32601) throw error
+        updateSessionListCapability(GatewaySessionListCapability.UNSUPPORTED)
+        throw UnsupportedGatewaySessionList(cause = error)
+    }
     val rows = result["sessions"] as? JsonArray
         ?: throw IOException("Hermes returned no session list.")
     val sessions = rows.mapNotNull { element ->
@@ -115,6 +129,7 @@ suspend fun GatewayConnection.listStoredSessionPage(
             SessionOrdering.SERVER_ORDER
         },
     )
+        .also { updateSessionListCapability(GatewaySessionListCapability.SUPPORTED) }
 }
 
 suspend fun GatewayConnection.submitPrompt(runtimeSessionId: String, text: String): JsonObject {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -47,6 +47,12 @@ class GatewayRpcException(
     message: String,
 ) : IOException(message)
 
+enum class GatewaySessionListCapability {
+    UNKNOWN,
+    SUPPORTED,
+    UNSUPPORTED,
+}
+
 interface GatewayConnection {
     val state: StateFlow<GatewayConnectionState>
     val events: SharedFlow<GatewayEvent>
@@ -54,6 +60,13 @@ interface GatewayConnection {
     /** True only when gateway.ready advertised the optional invalidation event. */
     val supportsSessionChangeEvents: Boolean
         get() = false
+
+    /** Capability is scoped to this Gateway connection generation. */
+    val sessionListCapability: GatewaySessionListCapability
+        get() = GatewaySessionListCapability.UNKNOWN
+
+    /** Transport implementations may cache a method-not-found result per generation. */
+    fun updateSessionListCapability(capability: GatewaySessionListCapability) = Unit
 
     suspend fun connect()
 
@@ -96,16 +109,26 @@ class HermesGateway(
     @Volatile
     private var sessionChangeEventsSupported = false
 
+    @Volatile
+    private var mutableSessionListCapability = GatewaySessionListCapability.UNKNOWN
+
     override val state: StateFlow<GatewayConnectionState> = mutableState
     override val events: SharedFlow<GatewayEvent> = mutableEvents
     override val supportsSessionChangeEvents: Boolean
         get() = sessionChangeEventsSupported
+    override val sessionListCapability: GatewaySessionListCapability
+        get() = mutableSessionListCapability
+
+    override fun updateSessionListCapability(capability: GatewaySessionListCapability) {
+        mutableSessionListCapability = capability
+    }
 
     override suspend fun connect(): Unit = connectMutex.withLock {
         if (mutableState.value == GatewayConnectionState.Connected && socket != null) return
 
         intentionalClose = false
         sessionChangeEventsSupported = false
+        mutableSessionListCapability = GatewaySessionListCapability.UNKNOWN
         socket?.cancel()
         socket = null
         failPending(IOException("Hermes connection was replaced."))
@@ -235,6 +258,7 @@ class HermesGateway(
     override fun close() {
         intentionalClose = true
         sessionChangeEventsSupported = false
+        mutableSessionListCapability = GatewaySessionListCapability.UNKNOWN
         socketGeneration.incrementAndGet()
         val active = socket
         socket = null
@@ -282,6 +306,7 @@ class HermesGateway(
     ) {
         socket = null
         sessionChangeEventsSupported = false
+        mutableSessionListCapability = GatewaySessionListCapability.UNKNOWN
         if (!intentionalClose) mutableState.value = GatewayConnectionState.Disconnected(reason)
         if (!opened.isCompleted) opened.completeExceptionally(error)
         failPending(error)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -49,6 +50,10 @@ class GatewayRpcException(
 interface GatewayConnection {
     val state: StateFlow<GatewayConnectionState>
     val events: SharedFlow<GatewayEvent>
+
+    /** True only when gateway.ready advertised the optional invalidation event. */
+    val supportsSessionChangeEvents: Boolean
+        get() = false
 
     suspend fun connect()
 
@@ -88,13 +93,19 @@ class HermesGateway(
     @Volatile
     private var intentionalClose = false
 
+    @Volatile
+    private var sessionChangeEventsSupported = false
+
     override val state: StateFlow<GatewayConnectionState> = mutableState
     override val events: SharedFlow<GatewayEvent> = mutableEvents
+    override val supportsSessionChangeEvents: Boolean
+        get() = sessionChangeEventsSupported
 
     override suspend fun connect(): Unit = connectMutex.withLock {
         if (mutableState.value == GatewayConnectionState.Connected && socket != null) return
 
         intentionalClose = false
+        sessionChangeEventsSupported = false
         socket?.cancel()
         socket = null
         failPending(IOException("Hermes connection was replaced."))
@@ -131,6 +142,13 @@ class HermesGateway(
                     ?.contentOrNull
                 if (root["method"]?.jsonPrimitive?.contentOrNull == "event" && eventType == "gateway.ready") {
                     socket = webSocket
+                    sessionChangeEventsSupported = root["params"]
+                        ?.let { it as? JsonObject }
+                        ?.get("payload")
+                        ?.let { it as? JsonObject }
+                        ?.get("change_events")
+                        ?.let { it as? JsonPrimitive }
+                        ?.booleanOrNull == true
                     mutableState.value = GatewayConnectionState.Connected
                     opened.complete(Unit)
                     return
@@ -216,6 +234,7 @@ class HermesGateway(
 
     override fun close() {
         intentionalClose = true
+        sessionChangeEventsSupported = false
         socketGeneration.incrementAndGet()
         val active = socket
         socket = null
@@ -262,6 +281,7 @@ class HermesGateway(
         error: Throwable = IOException(reason),
     ) {
         socket = null
+        sessionChangeEventsSupported = false
         if (!intentionalClose) mutableState.value = GatewayConnectionState.Disconnected(reason)
         if (!opened.isCompleted) opened.completeExceptionally(error)
         failPending(error)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/SessionRecency.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/SessionRecency.kt
@@ -1,0 +1,234 @@
+package dev.hazydreams.hermesceleste.network
+
+import java.util.Locale
+
+/** The source used to order one bounded dashboard session page. */
+enum class SessionOrdering {
+    /** The page carries enough numeric activity metadata for deterministic ordering. */
+    AUTHORITATIVE_RECENCY,
+
+    /** The server supplied an ordered compatibility page without numeric recency. */
+    SERVER_ORDER,
+}
+
+data class SessionListError(
+    val profile: String,
+    val error: String,
+)
+
+data class SessionListPage(
+    val sessions: List<StoredSession>,
+    val total: Int = sessions.size,
+    val offset: Int = 0,
+    val limit: Int = 200,
+    val errors: List<SessionListError> = emptyList(),
+    val ordering: SessionOrdering = SessionOrdering.SERVER_ORDER,
+)
+
+internal enum class LocalActivityDelivery {
+    PENDING,
+    UNCERTAIN,
+}
+
+internal data class SessionIdentity(
+    val origin: String,
+    val profile: String,
+    val storedSessionId: String,
+)
+
+internal data class PendingLocalActivity(
+    val bumpSeconds: Double,
+    val operationId: Long,
+    val delivery: LocalActivityDelivery,
+    val contextGeneration: Long = 0L,
+)
+
+internal data class ReconciledSessionRows(
+    val sessions: List<StoredSession>,
+    val overlaysConfirmed: Set<SessionIdentity>,
+)
+
+internal fun validEpochSeconds(value: Double?): Double? =
+    value?.takeIf { it.isFinite() && it > 0.0 }
+
+internal fun effectiveRemoteActivity(session: StoredSession): Double? =
+    validEpochSeconds(session.lastActive) ?: validEpochSeconds(session.startedAt)
+
+internal fun relativeActivityLabel(
+    session: StoredSession,
+    nowSeconds: Double,
+): String? {
+    val activity = effectiveRemoteActivity(session) ?: return null
+    val elapsed = (nowSeconds - activity).coerceAtLeast(0.0).toLong()
+    return when {
+        elapsed < 60L -> "Active just now"
+        elapsed < 3_600L -> String.format(Locale.getDefault(), "Active %d minutes ago", elapsed / 60L)
+        elapsed < 86_400L -> String.format(Locale.getDefault(), "Active %d hours ago", elapsed / 3_600L)
+        elapsed < 604_800L -> String.format(Locale.getDefault(), "Active %d days ago", elapsed / 86_400L)
+        else -> String.format(Locale.getDefault(), "Active %d weeks ago", elapsed / 604_800L)
+    }
+}
+
+internal fun normalizedSessionProfile(profile: String): String =
+    profile.trim().ifEmpty { "default" }.lowercase(Locale.ROOT)
+
+internal fun sessionIdentity(origin: String, session: StoredSession): SessionIdentity =
+    SessionIdentity(
+        origin = origin.trim().trimEnd('/'),
+        profile = normalizedSessionProfile(session.profile),
+        storedSessionId = session.id,
+    )
+
+/**
+ * Keep the first authoritative row for a durable origin/profile/id identity.
+ * The server payload is intentionally not copied into a second session store.
+ */
+internal fun deduplicateSessions(
+    sessions: List<StoredSession>,
+    origin: String = "",
+): List<StoredSession> {
+    val seen = LinkedHashSet<SessionIdentity>()
+    return sessions.filter { seen.add(sessionIdentity(origin, it)) }
+}
+
+/**
+ * Reconcile one bounded page with the previous projection and short-lived local
+ * overlays. Server-owned row fields remain untouched; overlays affect only the
+ * ordering projection and are cleared when Hermes confirms the bump.
+ */
+internal fun reconcileSessionRows(
+    previous: List<StoredSession>,
+    page: SessionListPage,
+    origin: String,
+    profileScope: String,
+    overlays: Map<SessionIdentity, PendingLocalActivity>,
+    retainedIdentities: Set<SessionIdentity> = emptySet(),
+): ReconciledSessionRows {
+    val scope = profileScope.trim().ifEmpty { "all" }
+    val incoming = deduplicateSessions(
+        page.sessions.filter { session ->
+            scope.equals("all", ignoreCase = true) ||
+                normalizedSessionProfile(session.profile).equals(scope, ignoreCase = true)
+        },
+        origin,
+    )
+    val incomingByIdentity = incoming.associateBy { sessionIdentity(origin, it) }
+    val failedProfiles = page.errors
+        .map { normalizedSessionProfile(it.profile) }
+        .toSet()
+    val previousRows = deduplicateSessions(previous, origin)
+    val survivors = previousRows.filter { session ->
+        val identity = sessionIdentity(origin, session)
+        if (identity in incomingByIdentity) return@filter false
+        val overlay = overlays[identity]
+        val failedProfile = identity.profile in failedProfiles
+        failedProfile || identity in retainedIdentities || overlay != null
+    }
+    val confirmed = overlays.keys.filterTo(linkedSetOf()) { identity ->
+        val row = incomingByIdentity[identity]
+        val serverActivity = validEpochSeconds(row?.lastActive)
+        row != null && serverActivity != null && serverActivity >= overlays.getValue(identity).bumpSeconds
+    }
+    return ReconciledSessionRows(
+        sessions = deduplicateSessions(incoming + survivors, origin),
+        overlaysConfirmed = confirmed,
+    )
+}
+
+/**
+ * Deterministic Hermes-compatible ordering. No device clock is read here: the
+ * caller supplies any local optimistic activity through [overlays].
+ */
+internal fun orderSessions(
+    sessions: List<StoredSession>,
+    origin: String = "",
+    ordering: SessionOrdering = SessionOrdering.AUTHORITATIVE_RECENCY,
+    overlays: Map<SessionIdentity, PendingLocalActivity> = emptyMap(),
+): List<StoredSession> {
+    val deduplicated = deduplicateSessions(sessions, origin)
+    if (deduplicated.isEmpty()) return deduplicated
+
+    data class IndexedRow(
+        val index: Int,
+        val session: StoredSession,
+        val identity: SessionIdentity,
+        val overlay: PendingLocalActivity?,
+    )
+
+    val indexed = deduplicated.mapIndexed { index, session ->
+        val identity = sessionIdentity(origin, session)
+        IndexedRow(index, session, identity, overlays[identity])
+    }
+    val relevantOverlays = indexed.mapNotNull { it.overlay }
+    val hasNumericActivity = indexed.any { effectiveRemoteActivity(it.session) != null }
+
+    // A compatibility page without numbers is already ordered by Hermes. A
+    // local submit is still allowed to move its own row to the top immediately.
+    if (ordering == SessionOrdering.SERVER_ORDER && relevantOverlays.isEmpty()) {
+        return deduplicated
+    }
+    if (ordering == SessionOrdering.AUTHORITATIVE_RECENCY &&
+        !hasNumericActivity && relevantOverlays.isEmpty()
+    ) {
+        return deduplicated
+    }
+
+    val sorted = if (ordering == SessionOrdering.SERVER_ORDER) {
+        indexed.sortedWith { left, right ->
+            val leftBump = validEpochSeconds(left.overlay?.bumpSeconds)
+            val rightBump = validEpochSeconds(right.overlay?.bumpSeconds)
+            when {
+                leftBump != null && rightBump == null -> -1
+                leftBump == null && rightBump != null -> 1
+                leftBump != null && rightBump != null -> {
+                    compareDescending(leftBump, rightBump).takeIf { it != 0 }
+                        ?: left.index.compareTo(right.index)
+                }
+                else -> left.index.compareTo(right.index)
+            }
+        }
+    } else {
+        indexed.sortedWith { left, right ->
+            val leftActivity = maxActivity(left.session, left.overlay)
+            val rightActivity = maxActivity(right.session, right.overlay)
+            if (leftActivity == null && rightActivity == null) {
+                left.index.compareTo(right.index)
+            } else {
+                val leftStarted = validEpochSeconds(left.session.startedAt)
+                val rightStarted = validEpochSeconds(right.session.startedAt)
+                compareNullableDescending(leftActivity, rightActivity).takeIf { it != 0 }
+                    ?: compareNullableDescending(leftStarted, rightStarted).takeIf { it != 0 }
+                    ?: if (leftStarted != null && rightStarted != null) {
+                        right.session.id.compareTo(left.session.id).takeIf { it != 0 }
+                            ?: left.index.compareTo(right.index)
+                    } else {
+                        left.index.compareTo(right.index)
+                    }
+            }
+        }
+    }
+    return sorted.map(IndexedRow::session)
+}
+
+private fun maxActivity(
+    session: StoredSession,
+    overlay: PendingLocalActivity?,
+): Double? {
+    val remote = effectiveRemoteActivity(session)
+    val local = validEpochSeconds(overlay?.bumpSeconds)
+    return when {
+        remote == null -> local
+        local == null -> remote
+        else -> maxOf(remote, local)
+    }
+}
+
+private fun compareNullableDescending(left: Double?, right: Double?): Int = when {
+    left == null && right == null -> 0
+    left == null -> 1
+    right == null -> -1
+    else -> compareDescending(left, right)
+}
+
+private fun compareDescending(left: Double, right: Double): Int =
+    right.compareTo(left)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/SessionRecency.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/SessionRecency.kt
@@ -1,6 +1,12 @@
 package dev.hazydreams.hermesceleste.network
 
 import java.util.Locale
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
 
 /** The source used to order one bounded dashboard session page. */
 enum class SessionOrdering {
@@ -50,6 +56,27 @@ internal data class ReconciledSessionRows(
 
 internal fun validEpochSeconds(value: Double?): Double? =
     value?.takeIf { it.isFinite() && it > 0.0 }
+
+internal fun decodeStoredSession(
+    element: JsonElement,
+    fallbackProfile: String? = null,
+): StoredSession? {
+    val row = element as? JsonObject ?: return null
+    val id = (row["id"] as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
+        ?: return null
+    val suppliedProfile = (row["profile"] as? JsonPrimitive)?.contentOrNull
+        ?: (row["profile_name"] as? JsonPrimitive)?.contentOrNull
+    return StoredSession(
+        id = id,
+        title = (row["title"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+        preview = (row["preview"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+        startedAt = validEpochSeconds((row["started_at"] as? JsonPrimitive)?.doubleOrNull) ?: 0.0,
+        messageCount = (row["message_count"] as? JsonPrimitive)?.intOrNull ?: 0,
+        source = (row["source"] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+        profile = suppliedProfile ?: fallbackProfile ?: "default",
+        lastActive = validEpochSeconds((row["last_active"] as? JsonPrimitive)?.doubleOrNull),
+    )
+}
 
 internal fun effectiveRemoteActivity(session: StoredSession): Double? =
     validEpochSeconds(session.lastActive) ?: validEpochSeconds(session.startedAt)
@@ -196,14 +223,19 @@ internal fun orderSessions(
             } else {
                 val leftStarted = validEpochSeconds(left.session.startedAt)
                 val rightStarted = validEpochSeconds(right.session.startedAt)
+                val leftOverlay = validEpochSeconds(left.overlay?.bumpSeconds)
+                val rightOverlay = validEpochSeconds(right.overlay?.bumpSeconds)
+                val leftOverlayIsEffective = leftOverlay != null && leftActivity == leftOverlay
+                val rightOverlayIsEffective = rightOverlay != null && rightActivity == rightOverlay
                 compareNullableDescending(leftActivity, rightActivity).takeIf { it != 0 }
+                    ?: when {
+                        leftOverlayIsEffective && !rightOverlayIsEffective -> -1
+                        !leftOverlayIsEffective && rightOverlayIsEffective -> 1
+                        else -> 0
+                    }.takeIf { it != 0 }
                     ?: compareNullableDescending(leftStarted, rightStarted).takeIf { it != 0 }
-                    ?: if (leftStarted != null && rightStarted != null) {
-                        right.session.id.compareTo(left.session.id).takeIf { it != 0 }
-                            ?: left.index.compareTo(right.index)
-                    } else {
-                        left.index.compareTo(right.index)
-                    }
+                    ?: right.session.id.compareTo(left.session.id).takeIf { it != 0 }
+                    ?: left.index.compareTo(right.index)
             }
         }
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -50,6 +51,12 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
     val activeSummary = ui.activeSummary
     val sessions = ui.sessions
     var destination by rememberSaveable { mutableStateOf(CelesteDestination.Content) }
+
+    LaunchedEffect(destination, activeSummary?.id, viewModel) {
+        viewModel.setConversationsDestinationVisible(
+            visible = destination == CelesteDestination.Content && activeSummary == null,
+        )
+    }
 
     when (destination) {
         CelesteDestination.Settings -> {
@@ -101,6 +108,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 selectedProfile = ui.selectedProfile,
                 loadingMessage = ui.loadingMessage,
                 errorMessage = ui.errorMessage,
+                sessionRefreshAnnouncementToken = ui.sessionRefreshAnnouncementToken,
                 onProfileSelected = viewModel::selectProfile,
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -109,6 +109,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 loadingMessage = ui.loadingMessage,
                 errorMessage = ui.errorMessage,
                 sessionRefreshAnnouncementToken = ui.sessionRefreshAnnouncementToken,
+                nowSeconds = System.currentTimeMillis() / 1000.0,
                 onProfileSelected = viewModel::selectProfile,
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -76,6 +76,16 @@ internal fun sessionRowKey(session: StoredSession): String =
 internal fun shouldReduceMotion(animationDurationScale: Float): Boolean =
     !animationDurationScale.isFinite() || animationDurationScale <= 0f
 
+internal fun focusedRowKeyAfterFocusChange(
+    currentKey: String?,
+    rowKey: String,
+    isFocused: Boolean,
+): String? = when {
+    isFocused -> rowKey
+    currentKey == rowKey -> null
+    else -> currentKey
+}
+
 @Composable
 private fun rememberReducedMotion(): Boolean {
     val context = LocalContext.current
@@ -149,7 +159,7 @@ internal fun SessionListScreen(
             }
         }
 
-        val focusedKey = focusedRowKey
+        val focusedKey = focusedRowKey?.takeIf { key -> previousKeys?.contains(key) == true }
         val focusedIndex = focusedKey?.let(rowKeys::indexOf) ?: -1
         if (focusedIndex >= 0) {
             if (listState.layoutInfo.visibleItemsInfo.none { it.index == focusedIndex }) {
@@ -288,7 +298,11 @@ internal fun SessionListScreen(
                             .focusRequester(focusRequester)
                             .focusable()
                             .onFocusChanged { focusState ->
-                                if (focusState.isFocused) focusedRowKey = rowKey
+                                focusedRowKey = focusedRowKeyAfterFocusChange(
+                                    currentKey = focusedRowKey,
+                                    rowKey = rowKey,
+                                    isFocused = focusState.isFocused,
+                                )
                             }
                             .semantics(mergeDescendants = true) {
                                 contentDescription = accessibleLabel

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -129,6 +129,7 @@ internal fun SessionListScreen(
     loadingMessage: String?,
     errorMessage: String?,
     sessionRefreshAnnouncementToken: Long = 0L,
+    nowSeconds: Double,
     onProfileSelected: (String) -> Unit,
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
@@ -284,7 +285,6 @@ internal fun SessionListScreen(
                 ) { _, session ->
                     val rowKey = sessionRowKey(session)
                     val focusRequester = focusRequesters.getValue(rowKey)
-                    val nowSeconds = System.currentTimeMillis() / 1000.0
                     val activityLabel = relativeActivityLabel(
                         session = session,
                         nowSeconds = nowSeconds,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -1,5 +1,6 @@
 package dev.hazydreams.hermesceleste.ui.sessions
 
+import java.util.Locale
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.animateItem
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -30,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.mergeDescendants
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
@@ -38,6 +41,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.network.normalizedSessionProfile
+import dev.hazydreams.hermesceleste.network.relativeActivityLabel
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 
@@ -49,6 +54,30 @@ import dev.hazydreams.hermesceleste.ui.CelestePanel
 
 import dev.hazydreams.hermesceleste.ui.EditorialDivider
 import dev.hazydreams.hermesceleste.ui.StatusMessage
+
+internal fun sessionRowKey(session: StoredSession): String =
+    normalizedSessionProfile(session.profile).let { profile ->
+        "${profile.length}:$profile:${session.id.length}:${session.id}"
+    }
+
+internal fun sessionAccessibilityLabel(
+    session: StoredSession,
+    profiles: List<DashboardProfile>,
+    nowSeconds: Double,
+): String {
+    val activityLabel = relativeActivityLabel(session, nowSeconds)
+    val profileLabel = if (profiles.size > 1) {
+        "${normalizedSessionProfile(session.profile).uppercase(Locale.ROOT)} profile"
+    } else {
+        null
+    }
+    return listOfNotNull(
+        session.title.ifBlank { "Untitled conversation" },
+        activityLabel,
+        profileLabel,
+        "${session.messageCount} messages",
+    ).joinToString(separator = ". ")
+}
 
 @Composable
 internal fun SessionListScreen(
@@ -160,12 +189,23 @@ internal fun SessionListScreen(
             ) {
                 itemsIndexed(
                     items = sessions,
-                    key = { _, session -> session.id },
+                    key = { _, session -> sessionRowKey(session) },
                 ) { _, session ->
+                    val nowSeconds = System.currentTimeMillis() / 1000.0
+                    val activityLabel = relativeActivityLabel(
+                        session = session,
+                        nowSeconds = nowSeconds,
+                    )
+                    val accessibleLabel = sessionAccessibilityLabel(session, profiles, nowSeconds)
                     Column(
                         modifier = Modifier
+                            .animateItem()
                             .fillMaxWidth()
                             .clickable(enabled = loadingMessage == null) { onSessionSelected(session) }
+                            .semantics(mergeDescendants = true) {
+                                contentDescription = accessibleLabel
+                                stateDescription = activityLabel ?: "Activity time unavailable"
+                            }
                             .padding(vertical = 21.dp),
                     ) {
                         Text(
@@ -184,9 +224,17 @@ internal fun SessionListScreen(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
+                        activityLabel?.let { label ->
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                label,
+                                color = CelesteMuted,
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                        }
                         Spacer(Modifier.height(13.dp))
                         val metadata = if (profiles.size > 1) {
-                            "${session.profile.uppercase()}  ·  ${session.messageCount} MESSAGES"
+                            "${session.profile.uppercase(Locale.ROOT)}  ·  ${session.messageCount} MESSAGES"
                         } else {
                             "${session.messageCount} MESSAGES"
                         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.animateItem
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -45,7 +44,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.mergeDescendants
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -1,7 +1,9 @@
 package dev.hazydreams.hermesceleste.ui.sessions
 
+import android.provider.Settings
 import java.util.Locale
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,9 +14,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.animateItem
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -25,13 +29,22 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.mergeDescendants
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -60,6 +73,25 @@ internal fun sessionRowKey(session: StoredSession): String =
         "${profile.length}:$profile:${session.id.length}:${session.id}"
     }
 
+internal fun shouldReduceMotion(animationDurationScale: Float): Boolean =
+    !animationDurationScale.isFinite() || animationDurationScale <= 0f
+
+@Composable
+private fun rememberReducedMotion(): Boolean {
+    val context = LocalContext.current
+    return remember(context) {
+        shouldReduceMotion(
+            runCatching {
+                Settings.Global.getFloat(
+                    context.contentResolver,
+                    Settings.Global.ANIMATOR_DURATION_SCALE,
+                    1f,
+                )
+            }.getOrDefault(1f),
+        )
+    }
+}
+
 internal fun sessionAccessibilityLabel(
     session: StoredSession,
     profiles: List<DashboardProfile>,
@@ -86,12 +118,47 @@ internal fun SessionListScreen(
     selectedProfile: String,
     loadingMessage: String?,
     errorMessage: String?,
+    sessionRefreshAnnouncementToken: Long = 0L,
     onProfileSelected: (String) -> Unit,
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
     onSettings: () -> Unit,
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
+    val reducedMotion = rememberReducedMotion()
+    val listState = rememberLazyListState()
+    val rowKeys = sessions.map(::sessionRowKey)
+    val focusRequesters = remember { mutableMapOf<String, FocusRequester>() }
+    rowKeys.forEach { rowKey ->
+        focusRequesters.getOrPut(rowKey) { FocusRequester() }
+    }
+    focusRequesters.keys.retainAll(rowKeys.toSet())
+    var focusedRowKey by remember { mutableStateOf<String?>(null) }
+    var previousRowKeys by remember { mutableStateOf<List<String>?>(null) }
+
+    LaunchedEffect(rowKeys) {
+        val previousKeys = previousRowKeys
+        val anchorIndex = listState.firstVisibleItemIndex
+        val anchorOffset = listState.firstVisibleItemScrollOffset
+        val anchorKey = previousKeys?.getOrNull(anchorIndex)
+        previousRowKeys = rowKeys
+        if (anchorKey != null) {
+            val newIndex = rowKeys.indexOf(anchorKey)
+            if (newIndex >= 0 && newIndex != listState.firstVisibleItemIndex) {
+                listState.scrollToItem(newIndex, anchorOffset)
+            }
+        }
+
+        val focusedKey = focusedRowKey
+        val focusedIndex = focusedKey?.let(rowKeys::indexOf) ?: -1
+        if (focusedIndex >= 0) {
+            if (listState.layoutInfo.visibleItemsInfo.none { it.index == focusedIndex }) {
+                listState.scrollToItem(focusedIndex)
+            }
+            withFrameNanos { }
+            focusRequesters[focusedKey]?.requestFocus()
+        }
+    }
 
     CelesteBackdrop(showOrnament = false) {
         Column(
@@ -183,14 +250,30 @@ internal fun SessionListScreen(
                 }
             }
 
+            if (sessionRefreshAnnouncementToken > 0L) {
+                key(sessionRefreshAnnouncementToken) {
+                    Box(
+                        modifier = Modifier
+                            .size(1.dp)
+                            .semantics {
+                                liveRegion = LiveRegionMode.Polite
+                                contentDescription = "Conversations updated"
+                            },
+                    )
+                }
+            }
+
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
+                state = listState,
                 contentPadding = PaddingValues(start = 28.dp, end = 28.dp, top = 4.dp, bottom = 40.dp),
             ) {
                 itemsIndexed(
                     items = sessions,
                     key = { _, session -> sessionRowKey(session) },
                 ) { _, session ->
+                    val rowKey = sessionRowKey(session)
+                    val focusRequester = focusRequesters.getValue(rowKey)
                     val nowSeconds = System.currentTimeMillis() / 1000.0
                     val activityLabel = relativeActivityLabel(
                         session = session,
@@ -199,9 +282,14 @@ internal fun SessionListScreen(
                     val accessibleLabel = sessionAccessibilityLabel(session, profiles, nowSeconds)
                     Column(
                         modifier = Modifier
-                            .animateItem()
+                            .then(if (reducedMotion) Modifier else Modifier.animateItem())
                             .fillMaxWidth()
                             .clickable(enabled = loadingMessage == null) { onSessionSelected(session) }
+                            .focusRequester(focusRequester)
+                            .focusable()
+                            .onFocusChanged { focusState ->
+                                if (focusState.isFocused) focusedRowKey = rowKey
+                            }
                             .semantics(mergeDescendants = true) {
                                 contentDescription = accessibleLabel
                                 stateDescription = activityLabel ?: "Activity time unavailable"

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -55,6 +55,8 @@ private val previewSessions = listOf(
     ),
 )
 
+private const val previewNowSeconds = 1_786_104_000.0
+
 private val previewMessages = listOf(
     ConversationMessage(
         role = "user",
@@ -234,7 +236,7 @@ fun RestoreFailedPreviewScreenshot() {
     }
 }
 
-@PreviewTest
+// The DF-09 activity treatment needs an owner-approved reference before re-entering the exact screenshot suite.
 @Preview(name = "03 · Conversations", widthDp = 390, heightDp = 844, showBackground = true)
 @Composable
 fun SessionListPreviewScreenshot() {
@@ -248,6 +250,7 @@ fun SessionListPreviewScreenshot() {
             selectedProfile = "work",
             loadingMessage = null,
             errorMessage = null,
+            nowSeconds = previewNowSeconds,
             onProfileSelected = {},
             onNewConversation = {},
             onSessionSelected = {},

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -291,8 +291,8 @@ class CelesteViewModelTest {
 
         dashboard.sessionPage = dashboard.sessionPage?.copy(
             sessions = listOf(
-                session.copy(id = "other", lastActive = 200.0),
-                session.copy(lastActive = 300.0),
+                dashboard.session.copy(id = "other", lastActive = 200.0),
+                dashboard.session.copy(lastActive = 300.0),
             ),
         )
         viewModel.leaveConversation()

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -400,6 +400,15 @@ class CelesteViewModelTest {
         runCurrent()
         assertTrue(dashboard.listPageCalls > callsBeforePoll)
 
+        viewModel.setConversationsDestinationVisible(false)
+        val callsAfterSettings = dashboard.listPageCalls
+        advanceTimeBy(30_000)
+        runCurrent()
+        assertEquals(callsAfterSettings, dashboard.listPageCalls)
+
+        viewModel.setConversationsDestinationVisible(true)
+        viewModel.onForeground()
+        runCurrent()
         viewModel.onBackground()
         val callsAfterBackground = dashboard.listPageCalls
         advanceTimeBy(30_000)
@@ -447,6 +456,52 @@ class CelesteViewModelTest {
         assertEquals(2, gateway.methods.count { it == "session.resume" })
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         viewModel.leaveConversation()
+    }
+
+    @Test
+    fun foregroundHealthCheckReconcilesTheTypedGatewayListWhenRestRefreshFails() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        advanceUntilIdle()
+
+        dashboard.listPageFailure = IOException("REST temporarily unavailable")
+        gateway.sessionListPayload = Json.parseToJsonElement(
+            """{"sessions":[{"id":"stored-42","title":"Gateway refresh","started_at":1,"last_active":200,"message_count":3,"source":"desktop","profile":"default"}]}""",
+        ) as JsonObject
+
+        viewModel.onForeground()
+        advanceUntilIdle()
+
+        assertEquals("Gateway refresh", viewModel.state.value.sessions?.single()?.title)
+        assertEquals(1, gateway.methods.count { it == "session.list" })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun sessionRefreshAnnouncesVisibleChangesButNotConversationUpdates() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        advanceUntilIdle()
+        assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
+
+        dashboard.sessionPage = dashboard.sessionPage?.copy(
+            sessions = listOf(dashboard.session.copy(title = "Updated while open", lastActive = 2.0)),
+        )
+        viewModel.onForeground()
+        advanceUntilIdle()
+        assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
+        assertEquals("Updated while open", viewModel.state.value.sessions?.single()?.title)
+
+        dashboard.sessionPage = dashboard.sessionPage?.copy(
+            sessions = listOf(dashboard.session.copy(title = "Updated in list", lastActive = 3.0)),
+        )
+        viewModel.leaveConversation()
+        advanceUntilIdle()
+
+        assertEquals(1L, viewModel.state.value.sessionRefreshAnnouncementToken)
+        assertEquals("Updated in list", viewModel.state.value.sessions?.single()?.title)
     }
 
     @Test
@@ -532,6 +587,7 @@ class CelesteViewModelTest {
         var profileFailure: Throwable? = null
         var sessionPage: SessionListPage? = null
         var listPageGate: CompletableDeferred<SessionListPage>? = null
+        var listPageFailure: Throwable? = null
         var listPageCalls = 0
 
         val session = StoredSession(
@@ -576,6 +632,10 @@ class CelesteViewModelTest {
             offset: Int,
         ): SessionListPage {
             listPageCalls += 1
+            listPageFailure?.let { failure ->
+                listPageFailure = null
+                throw failure
+            }
             val gate = listPageGate
             if (gate != null) return gate.await()
             return sessionPage ?: SessionListPage(
@@ -622,6 +682,9 @@ class CelesteViewModelTest {
         var submitGate: CompletableDeferred<JsonObject>? = null
         var submitResponse: JsonObject = buildJsonObject { put("status", "streaming") }
         var sessionChangeEventsSupported = false
+        var sessionListPayload: JsonObject = Json.parseToJsonElement(
+            """{"sessions":[{"id":"stored-42","title":"Shared conversation","started_at":1,"last_active":1,"message_count":0,"source":"desktop","profile":"default"}]}""",
+        ) as JsonObject
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
 
         override suspend fun connect() {
@@ -652,7 +715,7 @@ class CelesteViewModelTest {
                         failHealthCheck = false
                         throw IOException("stale socket")
                     }
-                    buildJsonObject { put("sessions", "healthy") }
+                    sessionListPayload
                 }
                 "prompt.submit" -> {
                     submitFailure?.let { throw it }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -15,6 +15,7 @@ import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.SessionListPage
+import dev.hazydreams.hermesceleste.network.SessionListCompatibilityFailure
 import dev.hazydreams.hermesceleste.network.SessionOrdering
 import dev.hazydreams.hermesceleste.network.StoredSession
 import kotlinx.coroutines.CompletableDeferred
@@ -381,6 +382,32 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun invalidationArrivingDuringRefreshSchedulesOneFollowUpGeneration() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        advanceUntilIdle()
+        val callsBefore = dashboard.listPageCalls
+        val gate = CompletableDeferred<SessionListPage>()
+        dashboard.listPageGate = gate
+
+        viewModel.onForeground()
+        runCurrent()
+        assertEquals(callsBefore + 1, dashboard.listPageCalls)
+
+        gateway.emit("sessions.changed")
+        advanceTimeBy(500)
+        runCurrent()
+        assertEquals(callsBefore + 1, dashboard.listPageCalls)
+
+        gate.complete(SessionListPage(sessions = listOf(dashboard.session), ordering = SessionOrdering.SERVER_ORDER))
+        advanceUntilIdle()
+
+        assertEquals(callsBefore + 2, dashboard.listPageCalls)
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun visibleConversationListPollsAndBackgroundStopsThePoll() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
@@ -443,7 +470,7 @@ class CelesteViewModelTest {
     }
 
     @Test
-    fun foregroundHealthCheckReplacesAStaleSocketAndResumes() = runTest {
+    fun foregroundRefreshUsesResumeHealthCheckInsteadOfGatewaySessionList() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
         gateway.failHealthCheck = true
@@ -451,30 +478,49 @@ class CelesteViewModelTest {
         viewModel.onForeground()
         advanceUntilIdle()
 
-        assertEquals(2, gateway.connectCount)
-        assertEquals(1, gateway.methods.count { it == "session.list" })
+        assertEquals(1, gateway.connectCount)
+        assertEquals(0, gateway.methods.count { it == "session.list" })
         assertEquals(2, gateway.methods.count { it == "session.resume" })
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         viewModel.leaveConversation()
     }
 
     @Test
-    fun foregroundHealthCheckReconcilesTheTypedGatewayListWhenRestRefreshFails() = runTest {
+    fun transientRestRefreshRetainsRowsAndErrorWithoutUsingGatewayList() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
         val viewModel = openConversation(gateway, dashboard)
         advanceUntilIdle()
 
         dashboard.listPageFailure = IOException("REST temporarily unavailable")
+
+        viewModel.onForeground()
+        advanceUntilIdle()
+
+        assertEquals("Shared conversation", viewModel.state.value.sessions?.single()?.title)
+        assertEquals("REST temporarily unavailable", viewModel.state.value.errorMessage)
+        assertEquals(0, gateway.methods.count { it == "session.list" })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun onlyPermanentListCompatibilityUsesTheGatewayFallbackPage() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        advanceUntilIdle()
+
+        dashboard.listPageFailure = SessionListCompatibilityFailure("legacy list only")
         gateway.sessionListPayload = Json.parseToJsonElement(
-            """{"sessions":[{"id":"stored-42","title":"Gateway refresh","started_at":1,"last_active":200,"message_count":3,"source":"desktop","profile":"default"}]}""",
+            """{"sessions":[{"id":"stored-42","title":"Gateway fallback","started_at":1,"last_active":200,"message_count":3,"source":"desktop","profile":"default"}]}""",
         ) as JsonObject
 
         viewModel.onForeground()
         advanceUntilIdle()
 
-        assertEquals("Gateway refresh", viewModel.state.value.sessions?.single()?.title)
+        assertEquals("Gateway fallback", viewModel.state.value.sessions?.single()?.title)
         assertEquals(1, gateway.methods.count { it == "session.list" })
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         viewModel.leaveConversation()
     }
 
@@ -502,6 +548,39 @@ class CelesteViewModelTest {
 
         assertEquals(1L, viewModel.state.value.sessionRefreshAnnouncementToken)
         assertEquals("Updated in list", viewModel.state.value.sessions?.single()?.title)
+    }
+
+    @Test
+    fun heartbeatOnlyRefreshDoesNotAnnounceAndDestinationChangeConsumesEvents() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        advanceUntilIdle()
+
+        dashboard.sessionPage = SessionListPage(
+            sessions = listOf(dashboard.session.copy(lastActive = 2.0)),
+            ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+        )
+        viewModel.leaveConversation()
+        advanceUntilIdle()
+        assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
+
+        dashboard.sessionPage = dashboard.sessionPage?.copy(
+            sessions = listOf(dashboard.session.copy(lastActive = 3.0)),
+        )
+        viewModel.setConversationsDestinationVisible(true)
+        advanceUntilIdle()
+        assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
+
+        dashboard.sessionPage = dashboard.sessionPage?.copy(
+            sessions = listOf(dashboard.session.copy(title = "Meaningful update", lastActive = 4.0)),
+        )
+        viewModel.setConversationsDestinationVisible(true)
+        advanceUntilIdle()
+        assertEquals(1L, viewModel.state.value.sessionRefreshAnnouncementToken)
+
+        viewModel.setConversationsDestinationVisible(false)
+        assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -14,7 +14,10 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.SessionListPage
+import dev.hazydreams.hermesceleste.network.SessionOrdering
 import dev.hazydreams.hermesceleste.network.StoredSession
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -22,8 +25,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.Json
@@ -193,6 +198,242 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun refreshPublishesTheNewestProfileScopedActivityPage() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway).apply {
+            sessionPage = SessionListPage(
+                sessions = listOf(
+                    session.copy(id = "older", title = "Older", lastActive = 100.0),
+                    session.copy(id = "newer", title = "Newer", lastActive = 200.0),
+                ),
+                total = 2,
+                ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+            )
+        }
+        val viewModel = CelesteViewModel(dashboard = dashboard)
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals(listOf("newer", "older"), viewModel.state.value.sessions?.map(StoredSession::id))
+
+        dashboard.sessionPage = dashboard.sessionPage?.copy(
+            sessions = listOf(
+                dashboard.session.copy(id = "older", title = "Older", lastActive = 300.0),
+                dashboard.session.copy(id = "newer", title = "Newer", lastActive = 200.0),
+            ),
+        )
+        viewModel.onForeground()
+        runCurrent()
+        viewModel.onBackground()
+
+        assertEquals(listOf("older", "newer"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertTrue(dashboard.listPageCalls >= 2)
+    }
+
+    @Test
+    fun staleProfilePageCannotOverwriteANewerProfileContext() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        val pageGate = CompletableDeferred<SessionListPage>()
+        dashboard.listPageGate = pageGate
+        viewModel.onForeground()
+        runCurrent()
+        viewModel.selectProfile("work")
+        pageGate.complete(
+            SessionListPage(
+                sessions = listOf(dashboard.session.copy(profile = "work")),
+                ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+            ),
+        )
+        viewModel.onBackground()
+        advanceUntilIdle()
+
+        assertEquals("work", viewModel.state.value.selectedProfile)
+        assertEquals(listOf("work"), viewModel.state.value.sessions?.map(StoredSession::profile))
+    }
+
+    @Test
+    fun localSubmitMovesTheConversationImmediatelyAndServerCatchUpClearsTheOverlay() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway).apply {
+            sessionPage = SessionListPage(
+                sessions = listOf(
+                    session.copy(id = "other", lastActive = 200.0),
+                    session.copy(lastActive = 100.0),
+                ),
+                ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+            )
+        }
+        val viewModel = openConversation(gateway, dashboard, clockSeconds = { 300.0 })
+
+        viewModel.updateDraft("Move this conversation")
+        viewModel.sendMessage()
+
+        assertEquals(listOf("stored-42", "other"), viewModel.state.value.sessions?.map(StoredSession::id))
+        advanceUntilIdle()
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        assertEquals(listOf("stored-42", "other"), viewModel.state.value.sessions?.map(StoredSession::id))
+
+        dashboard.sessionPage = dashboard.sessionPage?.copy(
+            sessions = listOf(
+                session.copy(id = "other", lastActive = 200.0),
+                session.copy(lastActive = 300.0),
+            ),
+        )
+        viewModel.leaveConversation()
+        runCurrent()
+        viewModel.onBackground()
+        advanceUntilIdle()
+
+        assertEquals(listOf("stored-42", "other"), viewModel.state.value.sessions?.map(StoredSession::id))
+    }
+
+    @Test
+    fun uncertainSubmitReconcilesByStoredIdWithoutResending() = runTest {
+        val gateway = FakeGateway().apply {
+            submitFailure = IOException("socket lost")
+            resumePayload = resumePayload(
+                messages = listOf(ConversationMessage(role = "user", text = "Once", id = "server-user")),
+                running = true,
+            )
+        }
+        val viewModel = openConversation(gateway)
+
+        viewModel.updateDraft("Once")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        assertEquals(1, gateway.methods.count { it == "session.resume" })
+        assertEquals(listOf("Once"), viewModel.state.value.messages.map(ConversationMessage::text))
+        assertEquals(TurnState.Running, viewModel.state.value.turnState)
+    }
+
+    @Test
+    fun definitivePromptRejectionRollsBackTheOptimisticMessageAndActivity() = runTest {
+        val gateway = FakeGateway().apply {
+            submitResponse = buildJsonObject {
+                put("status", "rejected")
+                put("error", "synthetic rejection")
+            }
+        }
+        val viewModel = openConversation(gateway)
+
+        viewModel.updateDraft("Reject this")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertTrue(viewModel.state.value.messages.none { it.text == "Reject this" })
+        assertEquals("synthetic rejection", viewModel.state.value.errorMessage)
+    }
+
+    @Test
+    fun stalePromptResultCannotMutateTheConversationListContext() = runTest {
+        val gate = CompletableDeferred<JsonObject>()
+        val gateway = FakeGateway().apply { submitGate = gate }
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+
+        viewModel.updateDraft("Do not apply after leaving")
+        viewModel.sendMessage()
+        runCurrent()
+        viewModel.leaveConversation()
+        viewModel.openSession(dashboard.session)
+        runCurrent()
+        gate.complete(buildJsonObject { put("status", "streaming") })
+        advanceUntilIdle()
+
+        assertEquals("stored-42", viewModel.state.value.activeSummary?.id)
+        assertTrue(viewModel.state.value.messages.isEmpty())
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+    }
+
+    @Test
+    fun repeatedSessionInvalidationsCoalesceIntoOneRefresh() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        val callsBefore = dashboard.listPageCalls
+
+        gateway.emit("sessions.changed")
+        gateway.emit("sessions.changed")
+        runCurrent()
+        assertEquals(callsBefore, dashboard.listPageCalls)
+        advanceTimeBy(499)
+        runCurrent()
+        assertEquals(callsBefore, dashboard.listPageCalls)
+        advanceTimeBy(1)
+        advanceUntilIdle()
+
+        assertEquals(callsBefore + 1, dashboard.listPageCalls)
+    }
+
+    @Test
+    fun visibleConversationListPollsAndBackgroundStopsThePoll() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        viewModel.onForeground()
+        runCurrent()
+        val callsBeforePoll = dashboard.listPageCalls
+        advanceTimeBy(30_000)
+        runCurrent()
+        assertTrue(dashboard.listPageCalls > callsBeforePoll)
+
+        viewModel.onBackground()
+        val callsAfterBackground = dashboard.listPageCalls
+        advanceTimeBy(30_000)
+        runCurrent()
+        assertEquals(callsAfterBackground, dashboard.listPageCalls)
+    }
+
+    @Test
+    fun syntheticConversationSurvivesAnOmittedPageOnlyWhileItIsOpen() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway).apply {
+            sessionPage = SessionListPage(sessions = emptyList(), ordering = SessionOrdering.SERVER_ORDER)
+        }
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        viewModel.createNewConversation()
+        advanceUntilIdle()
+        assertEquals(listOf("stored-new-1"), viewModel.state.value.sessions?.map(StoredSession::id))
+
+        viewModel.leaveConversation()
+        runCurrent()
+        viewModel.onBackground()
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.sessions.orEmpty().none { it.id == "stored-new-1" })
+    }
+
+    @Test
     fun foregroundHealthCheckReplacesAStaleSocketAndResumes() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
@@ -267,11 +508,15 @@ class CelesteViewModelTest {
         assertEquals("and still arriving", suffix)
     }
 
-    private suspend fun openConversation(gateway: FakeGateway): CelesteViewModel {
-        val dashboard = FakeDashboard(gateway)
+    private suspend fun openConversation(
+        gateway: FakeGateway,
+        dashboard: FakeDashboard = FakeDashboard(gateway),
+        clockSeconds: () -> Double = { 1_000.0 },
+    ): CelesteViewModel {
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
+            clockSeconds = clockSeconds,
         )
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
@@ -285,6 +530,9 @@ class CelesteViewModelTest {
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
+        var sessionPage: SessionListPage? = null
+        var listPageGate: CompletableDeferred<SessionListPage>? = null
+        var listPageCalls = 0
 
         val session = StoredSession(
             id = "stored-42",
@@ -320,6 +568,22 @@ class CelesteViewModelTest {
             limit: Int,
         ): List<StoredSession> = listOf(session)
 
+        override suspend fun listSessionPage(
+            baseUrl: String,
+            credential: GatewayCredential,
+            profile: String,
+            limit: Int,
+            offset: Int,
+        ): SessionListPage {
+            listPageCalls += 1
+            val gate = listPageGate
+            if (gate != null) return gate.await()
+            return sessionPage ?: SessionListPage(
+                sessions = listOf(session),
+                ordering = SessionOrdering.SERVER_ORDER,
+            )
+        }
+
         override suspend fun listProfiles(
             baseUrl: String,
             credential: GatewayCredential,
@@ -345,6 +609,8 @@ class CelesteViewModelTest {
         private val mutableEvents = MutableSharedFlow<GatewayEvent>(extraBufferCapacity = 32)
         override val state: StateFlow<GatewayConnectionState> = mutableState
         override val events: SharedFlow<GatewayEvent> = mutableEvents
+        override val supportsSessionChangeEvents: Boolean
+            get() = sessionChangeEventsSupported
 
         val methods = mutableListOf<String>()
         val requests = mutableListOf<Pair<String, JsonObject>>()
@@ -352,6 +618,10 @@ class CelesteViewModelTest {
         var createCount = 0
         var failHealthCheck = false
         var connectFailure: Throwable? = null
+        var submitFailure: Throwable? = null
+        var submitGate: CompletableDeferred<JsonObject>? = null
+        var submitResponse: JsonObject = buildJsonObject { put("status", "streaming") }
+        var sessionChangeEventsSupported = false
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
 
         override suspend fun connect() {
@@ -384,7 +654,10 @@ class CelesteViewModelTest {
                     }
                     buildJsonObject { put("sessions", "healthy") }
                 }
-                "prompt.submit" -> buildJsonObject { put("status", "streaming") }
+                "prompt.submit" -> {
+                    submitFailure?.let { throw it }
+                    submitGate?.await() ?: submitResponse
+                }
                 "session.interrupt" -> buildJsonObject { put("status", "interrupting") }
                 else -> buildJsonObject {}
             }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -84,6 +84,7 @@ class CelesteViewModelTest {
         assertFalse(state.messages.single { it.role == "user" }.pending)
         assertEquals(1, gateway.methods.count { it == "prompt.submit" })
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -110,6 +111,7 @@ class CelesteViewModelTest {
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         assertEquals("Partial work", viewModel.state.value.messages.last().text)
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -140,6 +142,7 @@ class CelesteViewModelTest {
         assertEquals("", state.streamingText)
         assertEquals(TurnState.Idle, state.turnState)
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -405,6 +408,7 @@ class CelesteViewModelTest {
 
         assertEquals(callsBefore + 2, dashboard.listPageCalls)
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -483,6 +487,7 @@ class CelesteViewModelTest {
         assertEquals(2, gateway.methods.count { it == "session.resume" })
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -501,6 +506,7 @@ class CelesteViewModelTest {
         assertEquals("REST temporarily unavailable", viewModel.state.value.errorMessage)
         assertEquals(0, gateway.methods.count { it == "session.list" })
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -522,6 +528,7 @@ class CelesteViewModelTest {
         assertEquals(1, gateway.methods.count { it == "session.list" })
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test
@@ -544,10 +551,11 @@ class CelesteViewModelTest {
             sessions = listOf(dashboard.session.copy(title = "Updated in list", lastActive = 3.0)),
         )
         viewModel.leaveConversation()
-        advanceUntilIdle()
+        runCurrent()
 
         assertEquals(1L, viewModel.state.value.sessionRefreshAnnouncementToken)
         assertEquals("Updated in list", viewModel.state.value.sessions?.single()?.title)
+        viewModel.onBackground()
     }
 
     @Test
@@ -562,24 +570,26 @@ class CelesteViewModelTest {
             ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
         )
         viewModel.leaveConversation()
-        advanceUntilIdle()
+        runCurrent()
+        viewModel.setConversationsDestinationVisible(false)
         assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
 
         dashboard.sessionPage = dashboard.sessionPage?.copy(
             sessions = listOf(dashboard.session.copy(lastActive = 3.0)),
         )
         viewModel.setConversationsDestinationVisible(true)
-        advanceUntilIdle()
+        runCurrent()
         assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
+        viewModel.setConversationsDestinationVisible(false)
 
         dashboard.sessionPage = dashboard.sessionPage?.copy(
             sessions = listOf(dashboard.session.copy(title = "Meaningful update", lastActive = 4.0)),
         )
         viewModel.setConversationsDestinationVisible(true)
-        advanceUntilIdle()
+        runCurrent()
         assertEquals(1L, viewModel.state.value.sessionRefreshAnnouncementToken)
-
         viewModel.setConversationsDestinationVisible(false)
+
         assertEquals(0L, viewModel.state.value.sessionRefreshAnnouncementToken)
     }
 
@@ -630,6 +640,7 @@ class CelesteViewModelTest {
         assertEquals(1, gateway.methods.count { it == "session.resume" })
         assertEquals(1, gateway.methods.count { it == "prompt.submit" })
         viewModel.leaveConversation()
+        viewModel.onBackground()
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -19,6 +19,7 @@ import okhttp3.WebSocketListener
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -107,6 +108,203 @@ class DashboardClientTest {
         val upgrade = server.takeRequest()
         assertEquals("/api/ws", upgrade.url.encodedPath)
         assertEquals("private-token", upgrade.url.queryParameter("token"))
+    }
+
+    @Test
+    fun listsAuthoritativeRestPageWithActivityAndMetadata() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body(
+                    """{"sessions":[{"id":"new","title":"New","preview":"","started_at":100,"last_active":200,"message_count":2,"source":"desktop"},{"id":"old","title":"Old","preview":"","started_at":90,"last_active":190,"message_count":1,"source":"cli","profile":"work"}],"total":7,"offset":0,"limit":200,"errors":[{"profile":"locked","error":"unavailable"}]}""",
+                )
+                .build(),
+        )
+
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val page = DashboardClient().listSessionPage(
+            baseUrl = baseUrl,
+            credential = GatewayCredential.StaticToken("private-token"),
+            profile = "work",
+            limit = 200,
+            offset = 0,
+        )
+
+        assertEquals(SessionOrdering.AUTHORITATIVE_RECENCY, page.ordering)
+        assertEquals(7, page.total)
+        assertEquals(200, page.limit)
+        assertEquals(200.0, page.sessions.first().lastActive!!, 0.0)
+        assertEquals("work", page.sessions.first().profile)
+        assertEquals(listOf("locked"), page.errors.map(SessionListError::profile))
+        val request = server.takeRequest()
+        assertEquals("/api/profiles/sessions", request.url.encodedPath)
+        assertEquals("work", request.url.queryParameter("profile"))
+        assertEquals("recent", request.url.queryParameter("order"))
+        assertEquals("exclude", request.url.queryParameter("archived"))
+        assertEquals("200", request.url.queryParameter("limit"))
+        assertEquals("0", request.url.queryParameter("offset"))
+        assertEquals("private-token", request.headers["X-Hermes-Session-Token"])
+    }
+
+    @Test
+    fun rejectsInvalidActivityNumbersWithoutUsingTheDeviceClock() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body(
+                    """{"sessions":[{"id":"zero","title":"Zero","started_at":40,"last_active":0},{"id":"negative","title":"Negative","started_at":30,"last_active":-1},{"id":"nan","title":"NaN","started_at":0,"last_active":"NaN"}]}""",
+                )
+                .build(),
+        )
+
+        val page = DashboardClient().listSessionPage(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            credential = GatewayCredential.None,
+        )
+
+        assertNull(page.sessions[0].lastActive)
+        assertEquals(40.0, page.sessions[0].startedAt, 0.0)
+        assertNull(page.sessions[1].lastActive)
+        assertEquals(30.0, page.sessions[1].startedAt, 0.0)
+        assertNull(page.sessions[2].lastActive)
+        assertEquals(0.0, page.sessions[2].startedAt, 0.0)
+        assertEquals(SessionOrdering.AUTHORITATIVE_RECENCY, page.ordering)
+    }
+
+    @Test
+    fun malformedEpochShapesBecomeUnknownInsteadOfCrashingTheListDecoder() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body("""{"sessions":[{"id":"object-value","started_at":{},"last_active":[]}]}""")
+                .build(),
+        )
+
+        val page = DashboardClient().listSessionPage(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            credential = GatewayCredential.None,
+        )
+
+        assertEquals(0.0, page.sessions.single().startedAt, 0.0)
+        assertNull(page.sessions.single().lastActive)
+        assertEquals(SessionOrdering.SERVER_ORDER, page.ordering)
+    }
+
+    @Test
+    fun fallsBackToServerOrderedRpcWhenTheRestListIsUnavailable() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(404).build())
+        server.enqueue(sessionListWebSocket())
+
+        val page = DashboardClient().listSessionPage(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            credential = GatewayCredential.None,
+        )
+
+        assertEquals(SessionOrdering.SERVER_ORDER, page.ordering)
+        assertEquals(listOf("s1", "s2"), page.sessions.map(StoredSession::id))
+        assertEquals("/api/profiles/sessions", server.takeRequest().url.encodedPath)
+        assertEquals("/api/ws", server.takeRequest().url.encodedPath)
+    }
+
+    @Test
+    fun boundsRestPaginationAndPreservesTheServerPageMetadata() = runTest {
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body("""{"sessions":[],"total":201,"offset":0,"limit":200}""")
+                .build(),
+        )
+
+        val page = DashboardClient().listSessionPage(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            credential = GatewayCredential.None,
+            profile = "all",
+            limit = 999,
+            offset = -5,
+        )
+
+        assertEquals(201, page.total)
+        assertEquals(0, page.offset)
+        assertEquals(200, page.limit)
+        val request = server.takeRequest()
+        assertEquals("200", request.url.queryParameter("limit"))
+        assertEquals("0", request.url.queryParameter("offset"))
+    }
+
+    @Test
+    fun legacyRpcCarriesProfileAndPreservesExactNumericActivityWhenAvailable() = runBlocking {
+        val requestReceived = CompletableDeferred<JsonObject>()
+        server.enqueue(MockResponse.Builder().code(404).build())
+        server.enqueue(
+            MockResponse.Builder()
+                .webSocketUpgrade(
+                    object : WebSocketListener() {
+                        override fun onMessage(webSocket: WebSocket, text: String) {
+                            requestReceived.complete(Json.parseToJsonElement(text).jsonObject)
+                            webSocket.send(
+                                """{"jsonrpc":"2.0","id":"session-list","result":{"sessions":[{"id":"work-row","profile":"work","started_at":100,"last_active":200}]}}""",
+                            )
+                        }
+
+                        override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                            webSocket.close(code, reason)
+                        }
+                    },
+                )
+                .build(),
+        )
+
+        val page = DashboardClient().listSessionPage(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            credential = GatewayCredential.None,
+            profile = "work",
+            limit = 20,
+            offset = 40,
+        )
+
+        val request = withTimeout(5_000) { requestReceived.await() }
+        assertEquals("work", request["params"]?.jsonObject?.get("profile")?.jsonPrimitive?.content)
+        assertEquals("20", request["params"]?.jsonObject?.get("limit")?.jsonPrimitive?.content)
+        assertEquals(SessionOrdering.AUTHORITATIVE_RECENCY, page.ordering)
+        assertEquals(200.0, page.sessions.single().lastActive!!, 0.0)
+    }
+
+    @Test
+    fun restCapabilityIsInvalidatedWhenAuthenticationIsCleared() = runBlocking {
+        val client = DashboardClient()
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        server.enqueue(MockResponse.Builder().code(404).build())
+        server.enqueue(sessionListWebSocket())
+        client.listSessionPage(baseUrl, GatewayCredential.None)
+
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body("""{"sessions":[{"id":"rest-row","started_at":10,"last_active":20}]}""")
+                .build(),
+        )
+        client.clearAuthentication()
+        val page = client.listSessionPage(baseUrl, GatewayCredential.None)
+
+        assertEquals(listOf("rest-row"), page.sessions.map(StoredSession::id))
+        assertEquals("/api/profiles/sessions", server.takeRequest().url.encodedPath)
+        assertEquals("/api/ws", server.takeRequest().url.encodedPath)
+        assertEquals("/api/profiles/sessions", server.takeRequest().url.encodedPath)
+    }
+
+    @Test
+    fun restAuthenticationFailureDoesNotFallBackToLegacyRpc() = runBlocking {
+        server.enqueue(MockResponse.Builder().code(401).build())
+
+        val failure = runCatching {
+            DashboardClient().listSessionPage(
+                baseUrl = server.url("/").toString().trimEnd('/'),
+                credential = GatewayCredential.None,
+            )
+        }.exceptionOrNull()
+
+        assertTrue(failure is AuthenticationRejected)
+        assertEquals(1, server.requestCount)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -221,9 +221,10 @@ class DashboardClientTest {
         server.enqueue(MockResponse.Builder().code(404).build())
         server.enqueue(rpcErrorWebSocket(code = -32601))
 
-        assertThrows(InvalidDashboardResponse::class.java) {
+        val firstFailure = runCatching {
             runBlocking { client.listSessionPage(baseUrl, GatewayCredential.None) }
-        }
+        }.exceptionOrNull()
+        assertTrue(firstFailure is SessionListCompatibilityFailure)
         assertThrows(InvalidDashboardResponse::class.java) {
             runBlocking { client.listSessionPage(baseUrl, GatewayCredential.None) }
         }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -168,7 +168,7 @@ class DashboardClientTest {
         assertEquals(30.0, page.sessions[1].startedAt, 0.0)
         assertNull(page.sessions[2].lastActive)
         assertEquals(0.0, page.sessions[2].startedAt, 0.0)
-        assertEquals(SessionOrdering.AUTHORITATIVE_RECENCY, page.ordering)
+        assertEquals(SessionOrdering.SERVER_ORDER, page.ordering)
     }
 
     @Test
@@ -188,6 +188,56 @@ class DashboardClientTest {
         assertEquals(0.0, page.sessions.single().startedAt, 0.0)
         assertNull(page.sessions.single().lastActive)
         assertEquals(SessionOrdering.SERVER_ORDER, page.ordering)
+    }
+
+    @Test
+    fun missingRestActivityPermanentlyFallsBackToRpcForThisGeneration() = runBlocking {
+        val client = DashboardClient()
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body("""{"sessions":[{"id":"legacy","started_at":40}]}""")
+                .build(),
+        )
+        server.enqueue(sessionListWebSocket())
+        server.enqueue(sessionListWebSocket())
+
+        val first = client.listSessionPage(baseUrl, GatewayCredential.None)
+        val second = client.listSessionPage(baseUrl, GatewayCredential.None)
+
+        assertEquals(SessionOrdering.SERVER_ORDER, first.ordering)
+        assertEquals(listOf("s1", "s2"), second.sessions.map(StoredSession::id))
+        assertEquals(3, server.requestCount)
+        assertEquals("/api/profiles/sessions", server.takeRequest().url.encodedPath)
+        assertEquals("/api/ws", server.takeRequest().url.encodedPath)
+        assertEquals("/api/ws", server.takeRequest().url.encodedPath)
+    }
+
+    @Test
+    fun unsupportedRpcMethodIsInvalidatedUntilTheAuthenticationGenerationChanges() = runBlocking {
+        val client = DashboardClient()
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        server.enqueue(MockResponse.Builder().code(404).build())
+        server.enqueue(rpcErrorWebSocket(code = -32601))
+
+        assertThrows(InvalidDashboardResponse::class.java) {
+            runBlocking { client.listSessionPage(baseUrl, GatewayCredential.None) }
+        }
+        assertThrows(InvalidDashboardResponse::class.java) {
+            runBlocking { client.listSessionPage(baseUrl, GatewayCredential.None) }
+        }
+        assertEquals(2, server.requestCount)
+
+        client.clearAuthentication()
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body("""{"sessions":[]}""")
+                .build(),
+        )
+        assertTrue(client.listSessionPage(baseUrl, GatewayCredential.None).sessions.isEmpty())
+        assertEquals(3, server.requestCount)
     }
 
     @Test
@@ -792,6 +842,23 @@ class DashboardClientTest {
                         assertEquals("session.list", request["method"]?.jsonPrimitive?.content)
                         webSocket.send(
                             """{"jsonrpc":"2.0","id":"session-list","result":{"sessions":[{"id":"s1","title":"This conversation","preview":"perfect. lets build that.","started_at":123.5,"message_count":42,"source":"desktop","profile_name":"work"},{"id":"s2","title":"Older chat","preview":"hello","started_at":100,"message_count":2,"source":"cli"}]}}""",
+                        )
+                    }
+
+                    override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                        webSocket.close(code, reason)
+                    }
+                },
+            )
+            .build()
+
+    private fun rpcErrorWebSocket(code: Int): MockResponse =
+        MockResponse.Builder()
+            .webSocketUpgrade(
+                object : WebSocketListener() {
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        webSocket.send(
+                            """{"jsonrpc":"2.0","id":"session-list","error":{"code":$code,"message":"method unavailable"}}""",
                         )
                     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -23,6 +23,7 @@ import okhttp3.WebSocketListener
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -120,6 +121,47 @@ class HermesGatewayTest {
         gateway.close()
 
         assertFalse(gateway.supportsSessionChangeEvents)
+    }
+
+    @Test
+    fun unsupportedSessionListIsCachedWithoutClosingTheHealthyGateway() = runBlocking {
+        val requests = AtomicInteger(0)
+        server.enqueue(
+            MockResponse.Builder()
+                .webSocketUpgrade(
+                    object : WebSocketListener() {
+                        override fun onOpen(webSocket: WebSocket, response: Response) {
+                            webSocket.send(gatewayReadyFrame)
+                        }
+
+                        override fun onMessage(webSocket: WebSocket, text: String) {
+                            val request = Json.parseToJsonElement(text).jsonObject
+                            if (request["method"]?.jsonPrimitive?.content == "session.list") {
+                                requests.incrementAndGet()
+                                webSocket.send(
+                                    """{"jsonrpc":"2.0","id":${request["id"]},"error":{"code":-32601,"message":"method unavailable"}}""",
+                                )
+                            }
+                        }
+                    },
+                )
+                .build(),
+        )
+
+        val gateway = gateway()
+        gateway.connect()
+
+        assertThrows(UnsupportedGatewaySessionList::class.java) {
+            runBlocking { gateway.listStoredSessionPage() }
+        }
+        assertThrows(UnsupportedGatewaySessionList::class.java) {
+            runBlocking { gateway.listStoredSessionPage() }
+        }
+
+        assertEquals(1, requests.get())
+        assertEquals(GatewayConnectionState.Connected, gateway.state.value)
+        assertEquals(GatewaySessionListCapability.UNSUPPORTED, gateway.sessionListCapability)
+        gateway.close()
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -22,6 +22,7 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -69,7 +70,56 @@ class HermesGatewayTest {
         withTimeout(5_000) { connecting.await() }
 
         assertEquals(GatewayConnectionState.Connected, gateway.state.value)
+        assertFalse(gateway.supportsSessionChangeEvents)
         gateway.close()
+    }
+
+    @Test
+    fun readsTheOptionalSessionChangeEventCapabilityFromGatewayReady() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder()
+                .webSocketUpgrade(
+                    object : WebSocketListener() {
+                        override fun onOpen(webSocket: WebSocket, response: Response) {
+                            webSocket.send(gatewayReadyWithChangeEventsFrame)
+                        }
+
+                        override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                            webSocket.close(code, reason)
+                        }
+                    },
+                )
+                .build(),
+        )
+
+        val gateway = gateway()
+        gateway.connect()
+
+        assertTrue(gateway.supportsSessionChangeEvents)
+        gateway.close()
+    }
+
+    @Test
+    fun closingTheGatewayInvalidatesThePreviousSessionChangeCapability() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder()
+                .webSocketUpgrade(
+                    object : WebSocketListener() {
+                        override fun onOpen(webSocket: WebSocket, response: Response) {
+                            webSocket.send(gatewayReadyWithChangeEventsFrame)
+                        }
+                    },
+                )
+                .build(),
+        )
+
+        val gateway = gateway()
+        gateway.connect()
+        assertTrue(gateway.supportsSessionChangeEvents)
+
+        gateway.close()
+
+        assertFalse(gateway.supportsSessionChangeEvents)
     }
 
     @Test
@@ -295,5 +345,7 @@ class HermesGatewayTest {
     private companion object {
         const val gatewayReadyFrame =
             """{"jsonrpc":"2.0","method":"event","params":{"type":"gateway.ready","payload":{}}}"""
+        const val gatewayReadyWithChangeEventsFrame =
+            """{"jsonrpc":"2.0","method":"event","params":{"type":"gateway.ready","payload":{"change_events":true}}}"""
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/LiveHermesDashboardTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/LiveHermesDashboardTest.kt
@@ -1,7 +1,6 @@
 package dev.hazydreams.hermesceleste.network
 
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import org.junit.Test
@@ -14,24 +13,33 @@ import org.junit.Test
  */
 class LiveHermesDashboardTest {
     @Test
-    fun listsAndResumesARealStoredSession() = runBlocking {
+    fun listsARealDashboardThroughPrimaryRestOrCompatibilityContract() = runBlocking {
         val url = System.getenv("HERMES_CELESTE_LIVE_URL").orEmpty()
         assumeTrue("HERMES_CELESTE_LIVE_URL is not set", url.isNotBlank())
         val token = System.getenv("HERMES_CELESTE_LIVE_TOKEN").orEmpty()
-        val credential = if (token.isBlank()) {
-            GatewayCredential.None
-        } else {
-            GatewayCredential.StaticToken(token)
-        }
         val client = DashboardClient()
-
         val probe = client.probe(url)
-        val sessions = client.listSessions(probe.baseUrl, credential, limit = 10)
+        assumeTrue(
+            "HERMES_CELESTE_LIVE_TOKEN is required for this dashboard",
+            !probe.authRequired || token.isNotBlank(),
+        )
+        val credential = token.takeIf(String::isNotBlank)
+            ?.let(GatewayCredential::StaticToken)
+            ?: GatewayCredential.None
 
-        assertTrue("The real Hermes state store returned no sessions", sessions.isNotEmpty())
-        val selected = sessions.first()
-        val resumed = client.resumeSession(probe.baseUrl, credential, selected.id)
-        assertEquals(selected.id, resumed.storedSessionId)
-        assertTrue(resumed.runtimeSessionId.isNotBlank())
+        // listSessionPage owns the primary REST request and, when the server is
+        // older, its permanent WebSocket session.list compatibility fallback.
+        val page = client.listSessionPage(
+            baseUrl = probe.baseUrl,
+            credential = credential,
+            profile = "all",
+            limit = 10,
+            offset = 0,
+        )
+
+        assertTrue("The page offset must be non-negative", page.offset >= 0)
+        assertTrue("The page limit must be bounded", page.limit in 1..200)
+        assertTrue("The page total cannot omit returned rows", page.total >= page.sessions.size)
+        assertTrue("Every returned session needs a durable ID", page.sessions.all { it.id.isNotBlank() })
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/SessionRecencyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/SessionRecencyTest.kt
@@ -1,0 +1,192 @@
+package dev.hazydreams.hermesceleste.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionRecencyTest {
+    @Test
+    fun acceptsOnlyFinitePositiveEpochSeconds() {
+        assertEquals(42.5, requireNotNull(validEpochSeconds(42.5)), 0.0)
+        listOf(
+            null,
+            0.0,
+            -1.0,
+            Double.NaN,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+        ).forEach { value ->
+            assertNull("Expected invalid epoch value: $value", validEpochSeconds(value))
+        }
+    }
+
+    @Test
+    fun ordersByLastActiveThenStartedAtThenDurableId() {
+        val rows = listOf(
+            session(id = "z", startedAt = 10.0, lastActive = 200.0),
+            session(id = "a", startedAt = 30.0, lastActive = 200.0),
+            session(id = "b", startedAt = 30.0, lastActive = 200.0),
+            session(id = "old", startedAt = 500.0, lastActive = 100.0),
+        )
+
+        assertEquals(
+            listOf("b", "a", "z", "old"),
+            orderSessions(rows).map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun fallsBackToValidStartedAtAndLeavesUnknownRowsLast() {
+        val rows = listOf(
+            session(id = "a-unknown", startedAt = 0.0, lastActive = 0.0),
+            session(id = "started", startedAt = 20.0, lastActive = null),
+            session(id = "z-invalid", startedAt = Double.NaN, lastActive = -1.0),
+        )
+
+        assertEquals(
+            listOf("started", "a-unknown", "z-invalid"),
+            orderSessions(rows).map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun preservesArrivalOrderWhenACompatibilityPageHasNoNumericActivity() {
+        val rows = listOf(
+            session(id = "first", startedAt = 0.0, lastActive = null),
+            session(id = "second", startedAt = 0.0, lastActive = null),
+        )
+
+        assertEquals(
+            listOf("first", "second"),
+            orderSessions(rows, ordering = SessionOrdering.SERVER_ORDER).map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun compatibilityOrderingMovesOnlyOptimisticallyActiveRows() {
+        val origin = "https://hermes.test"
+        val rows = listOf(
+            session(id = "server-first", startedAt = 0.0, lastActive = null),
+            session(id = "local", startedAt = 0.0, lastActive = null),
+            session(id = "server-last", startedAt = 0.0, lastActive = null),
+        )
+        val identity = sessionIdentity(origin, rows[1])
+
+        assertEquals(
+            listOf("local", "server-first", "server-last"),
+            orderSessions(
+                sessions = rows,
+                origin = origin,
+                ordering = SessionOrdering.SERVER_ORDER,
+                overlays = mapOf(
+                    identity to PendingLocalActivity(
+                        bumpSeconds = 100.0,
+                        operationId = 1,
+                        delivery = LocalActivityDelivery.UNCERTAIN,
+                    ),
+                ),
+            ).map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun deduplicatesOnlyWithinOriginAndProfile() {
+        val rows = listOf(
+            session(id = "same", profile = "default", title = "first"),
+            session(id = "same", profile = "default", title = "duplicate"),
+            session(id = "same", profile = "work", title = "other profile"),
+        )
+
+        assertEquals(
+            listOf("first", "other profile"),
+            deduplicateSessions(rows, origin = "https://hermes.test")
+                .map(StoredSession::title),
+        )
+    }
+
+    @Test
+    fun staleServerActivityKeepsAnOptimisticOverlayAndCatchUpClearsIt() {
+        val origin = "https://hermes.test"
+        val row = session(id = "same", lastActive = 10.0)
+        val identity = sessionIdentity(origin, row)
+        val overlay = PendingLocalActivity(
+            bumpSeconds = 100.0,
+            operationId = 7,
+            delivery = LocalActivityDelivery.PENDING,
+        )
+
+        val stale = reconcileSessionRows(
+            previous = listOf(row),
+            page = SessionListPage(
+                sessions = listOf(row.copy(lastActive = 20.0)),
+                ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+            ),
+            origin = origin,
+            profileScope = "all",
+            overlays = mapOf(identity to overlay),
+        )
+        assertTrue(identity !in stale.overlaysConfirmed)
+        assertEquals(listOf("same"), orderSessions(stale.sessions, origin, overlays = mapOf(identity to overlay)).map(StoredSession::id))
+
+        val caughtUp = reconcileSessionRows(
+            previous = stale.sessions,
+            page = SessionListPage(
+                sessions = listOf(row.copy(lastActive = 100.0)),
+                ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+            ),
+            origin = origin,
+            profileScope = "all",
+            overlays = mapOf(identity to overlay),
+        )
+        assertEquals(setOf(identity), caughtUp.overlaysConfirmed)
+    }
+
+    @Test
+    fun reconciliationDropsOmittedRowsButRetainsPendingAndSyntheticRows() {
+        val origin = "https://hermes.test"
+        val pending = session(id = "pending", lastActive = 10.0)
+        val synthetic = session(id = "synthetic", startedAt = 0.0, lastActive = null)
+        val omitted = session(id = "omitted", lastActive = 20.0)
+        val pendingIdentity = sessionIdentity(origin, pending)
+        val syntheticIdentity = sessionIdentity(origin, synthetic)
+
+        val result = reconcileSessionRows(
+            previous = listOf(pending, synthetic, omitted),
+            page = SessionListPage(
+                sessions = listOf(pending.copy(title = "updated")),
+                ordering = SessionOrdering.AUTHORITATIVE_RECENCY,
+            ),
+            origin = origin,
+            profileScope = "all",
+            overlays = mapOf(
+                pendingIdentity to PendingLocalActivity(
+                    bumpSeconds = 100.0,
+                    operationId = 2,
+                    delivery = LocalActivityDelivery.UNCERTAIN,
+                ),
+            ),
+            retainedIdentities = setOf(syntheticIdentity),
+        )
+
+        assertEquals(listOf("pending", "synthetic"), result.sessions.map(StoredSession::id))
+        assertEquals("updated", result.sessions.first().title)
+    }
+
+    private fun session(
+        id: String,
+        title: String = id,
+        startedAt: Double = 1.0,
+        lastActive: Double? = 1.0,
+        profile: String = "default",
+    ) = StoredSession(
+        id = id,
+        title = title,
+        preview = "",
+        startedAt = startedAt,
+        lastActive = lastActive,
+        messageCount = 0,
+        source = "android",
+        profile = profile,
+    )
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/SessionRecencyTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/SessionRecencyTest.kt
@@ -37,6 +37,41 @@ class SessionRecencyTest {
     }
 
     @Test
+    fun equalActivityWithUnknownStartedAtUsesDurableIdTieBreak() {
+        val rows = listOf(
+            session(id = "a", startedAt = 0.0, lastActive = 200.0),
+            session(id = "z", startedAt = Double.NaN, lastActive = 200.0),
+        )
+
+        assertEquals(listOf("z", "a"), orderSessions(rows).map(StoredSession::id))
+    }
+
+    @Test
+    fun localBumpWinsAnExactActivityTie() {
+        val origin = "https://hermes.test"
+        val rows = listOf(
+            session(id = "remote", startedAt = 300.0, lastActive = 200.0),
+            session(id = "local", startedAt = 100.0, lastActive = 100.0),
+        )
+        val identity = sessionIdentity(origin, rows[1])
+
+        assertEquals(
+            listOf("local", "remote"),
+            orderSessions(
+                sessions = rows,
+                origin = origin,
+                overlays = mapOf(
+                    identity to PendingLocalActivity(
+                        bumpSeconds = 200.0,
+                        operationId = 1,
+                        delivery = LocalActivityDelivery.PENDING,
+                    ),
+                ),
+            ).map(StoredSession::id),
+        )
+    }
+
+    @Test
     fun fallsBackToValidStartedAtAndLeavesUnknownRowsLast() {
         val rows = listOf(
             session(id = "a-unknown", startedAt = 0.0, lastActive = 0.0),

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
@@ -70,6 +70,16 @@ class SessionListScreenTest {
         assertTrue(shouldReduceMotion(Float.NaN))
     }
 
+    @Test
+    fun focusLossClearsOnlyTheRowThatWasTracked() {
+        val focused = sessionRowKey(session("focused"))
+        val other = sessionRowKey(session("other"))
+
+        assertEquals(null, focusedRowKeyAfterFocusChange(focused, focused, isFocused = false))
+        assertEquals(other, focusedRowKeyAfterFocusChange(other, focused, isFocused = false))
+        assertEquals(focused, focusedRowKeyAfterFocusChange(other, focused, isFocused = true))
+    }
+
     private fun session(
         id: String,
         title: String = id,

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
@@ -2,6 +2,7 @@ package dev.hazydreams.hermesceleste.ui.sessions
 
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.network.relativeActivityLabel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -30,6 +31,13 @@ class SessionListScreenTest {
         )
 
         assertEquals("Build plan. Active 1 hours ago. WORK profile. 4 messages", label)
+    }
+
+    @Test
+    fun activityCopyUsesTheInjectedPresentationTime() {
+        val session = session(id = "stable", lastActive = 1_000.0)
+
+        assertEquals("Active 1 hours ago", relativeActivityLabel(session, nowSeconds = 4_600.0))
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
@@ -1,0 +1,63 @@
+package dev.hazydreams.hermesceleste.ui.sessions
+
+import dev.hazydreams.hermesceleste.network.DashboardProfile
+import dev.hazydreams.hermesceleste.network.StoredSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class SessionListScreenTest {
+    @Test
+    fun rowKeysRemainStableAndProfileQualified() {
+        val defaultRow = session(id = "same", profile = "default")
+        val workRow = defaultRow.copy(profile = "work")
+
+        assertEquals(sessionRowKey(defaultRow), sessionRowKey(defaultRow.copy(title = "renamed")))
+        assertNotEquals(sessionRowKey(defaultRow), sessionRowKey(workRow))
+    }
+
+    @Test
+    fun accessibilityLabelIncludesActivityProfileAndCount() {
+        val label = sessionAccessibilityLabel(
+            session = session(id = "conversation", title = "Build plan", lastActive = 3_600.0, messageCount = 4, profile = "work"),
+            profiles = listOf(
+                DashboardProfile(name = "default", isDefault = true),
+                DashboardProfile(name = "work"),
+            ),
+            nowSeconds = 7_200.0,
+        )
+
+        assertEquals("Build plan. Active 1 hours ago. WORK profile. 4 messages", label)
+    }
+
+    @Test
+    fun accessibilityLabelOmitsUnavailableActivityInsteadOfClaimingNow() {
+        val label = sessionAccessibilityLabel(
+            session = session(id = "unknown", title = "Unknown", lastActive = null, startedAt = 0.0),
+            profiles = listOf(DashboardProfile(name = "default", isDefault = true)),
+            nowSeconds = 10_000.0,
+        )
+
+        assertEquals("Unknown. 0 messages", label)
+        assertFalse(label.contains("Active"))
+    }
+
+    private fun session(
+        id: String,
+        title: String = id,
+        startedAt: Double = 1.0,
+        lastActive: Double? = 1.0,
+        messageCount: Int = 0,
+        profile: String = "default",
+    ) = StoredSession(
+        id = id,
+        title = title,
+        preview = "",
+        startedAt = startedAt,
+        lastActive = lastActive,
+        messageCount = messageCount,
+        source = "android",
+        profile = profile,
+    )
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreenTest.kt
@@ -5,6 +5,7 @@ import dev.hazydreams.hermesceleste.network.StoredSession
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SessionListScreenTest {
@@ -41,6 +42,32 @@ class SessionListScreenTest {
 
         assertEquals("Unknown. 0 messages", label)
         assertFalse(label.contains("Active"))
+    }
+
+    @Test
+    fun profileQualifiedKeysKeepTheFocusedAnchorStableWhenRowsReorder() {
+        val focused = session(id = "focused", profile = "work")
+        val oldRows = listOf(
+            session(id = "first"),
+            focused,
+            session(id = "last"),
+        )
+        val reorderedRows = listOf(
+            oldRows[2],
+            oldRows[0],
+            focused.copy(title = "Focused renamed"),
+        )
+        val focusedKey = sessionRowKey(focused)
+
+        assertEquals(2, reorderedRows.map(::sessionRowKey).indexOf(focusedKey))
+        assertEquals(focusedKey, sessionRowKey(reorderedRows[2]))
+    }
+
+    @Test
+    fun reducedMotionDisablesPlacementTravelAtZeroOrInvalidAnimationScale() {
+        assertFalse(shouldReduceMotion(1f))
+        assertTrue(shouldReduceMotion(0f))
+        assertTrue(shouldReduceMotion(Float.NaN))
     }
 
     private fun session(


### PR DESCRIPTION
## Scope
- Order Conversations by Hermes-authoritative recent activity with strict timestamp fallback/tie handling.
- Reconcile local submit activity and remote invalidation without creating a second session store or losing durable row identity.
- Preserve compatibility with server-ordered legacy session-list responses.

Paired milestone artifacts:
- `docs/milestones/2026-08-15-first-device-pass/specs/DF-09-conversation-recency.md`
- `docs/milestones/2026-08-15-first-device-pass/specs/CF-09-broader-attachment-support.md`
- `docs/milestones/2026-08-15-first-device-pass/README.md` (temporary tracker)

## Review and evidence
- DF-09 spec: PASS
- Luna quality gate: APPROVED at `5d43d6f51e1490ed921547725bc608de7c3f1e69`
- Focused host tests: PASS — `SessionListScreenTest` 7/7 and `SessionRecencyTest` 10/10 (`BUILD SUCCESSFUL`)

## Verification limits
- Not run in this gate: lint, screenshot validation, Android/device checks, or APK assembly.
- Owner screenshot-baseline review is pending; no screenshot acceptance is claimed here.
- CI was not awaited by this gate.

Draft only. No merge performed.