### PR TITLE
fix: sanitize cancellation and operation failures

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -21,6 +21,7 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
 import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
 import dev.hazydreams.hermesceleste.network.ResumedSession
 import dev.hazydreams.hermesceleste.network.StoredSession
@@ -159,8 +160,12 @@ internal class CelesteViewModel(
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
     private var reconciling = false
+    private var reconciliationEpoch = 0L
+    private var activeReconciliationEpoch: Long? = null
     private var currentSessionCanResume = true
     private var interruptionRequested = false
+    private var turnGeneration = 0L
+    private var stoppedTurnGeneration: Long? = null
     private val bufferedEvents = mutableListOf<GatewayEvent>()
 
     init {
@@ -230,6 +235,39 @@ internal class CelesteViewModel(
         contextGeneration += 1
         cancelOwnedOperations()
     }
+
+    private fun detachGatewayObservers() {
+        gatewayEventsJob?.cancel()
+        gatewayStateJob?.cancel()
+        gatewayEventsJob = null
+        gatewayStateJob = null
+        ownedJobs.remove(CelesteOperation.GatewayObserver)?.cancel()
+        activeOperations.remove(CelesteOperation.GatewayObserver)
+    }
+
+    private fun beginReconciliation(): Long {
+        val epoch = ++reconciliationEpoch
+        activeReconciliationEpoch = epoch
+        reconciling = true
+        bufferedEvents.clear()
+        return epoch
+    }
+
+    private fun finishReconciliation(epoch: Long) {
+        if (activeReconciliationEpoch != epoch) return
+        activeReconciliationEpoch = null
+        reconciling = false
+        bufferedEvents.clear()
+    }
+
+    private fun invalidateReconciliation() {
+        reconciliationEpoch += 1
+        activeReconciliationEpoch = null
+        reconciling = false
+        bufferedEvents.clear()
+    }
+
+    private fun stoppedTurnIsActive(): Boolean = stoppedTurnGeneration == turnGeneration
 
     private fun cancelGatewayOperations() {
         listOf(
@@ -306,6 +344,11 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(notice = projectUiNotice(error, scope))
     }
 
+    private fun isAuthenticationFailure(error: Throwable): Boolean {
+        val code = (error as? GatewayRpcException)?.code
+        return error is AuthenticationRejected || code == 401 || code == 403
+    }
+
     fun updateDashboardUrl(value: String) {
         mutableState.value = mutableState.value.copy(
             dashboardUrl = value,
@@ -333,12 +376,53 @@ internal class CelesteViewModel(
     fun selectProfile(name: String) {
         if (mutableState.value.profiles.none { it.name == name }) return
         if (normalizedProfile(mutableState.value.selectedProfile) == normalizedProfile(name)) return
-        invalidateContext()
-        if (mutableState.value.activeSummary != null) closeGateway()
-        mutableState.value = mutableState.value.copy(
+
+        val snapshot = mutableState.value
+        val connection = snapshot.probe
+        val activeCredential = credential
+        beginConnectionAttempt()
+        closeGateway()
+        mutableState.value = snapshot.copy(
             selectedProfile = name,
+            sessions = null,
+            activeSummary = null,
+            messages = emptyList(),
+            streamingText = "",
+            draft = "",
+            turnState = TurnState.Synchronizing,
+            loadingMessage = if (connection != null && activeCredential != null) {
+                "Loading your conversations…"
+            } else {
+                null
+            },
             notice = null,
         )
+
+        if (connection == null || activeCredential == null) return
+        currentOrigin = normalizedOrigin(connection.baseUrl)
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+            profile = name,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            try {
+                val loaded = loadDashboard(connection.baseUrl, activeCredential, token)
+                if (!isCurrent(token)) return@launchOwned
+                publishConnectedDashboard(loaded)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "select_profile", UiNoticeScope.Connection)
+                mutableState.value = mutableState.value.copy(
+                    loadingMessage = null,
+                    turnState = TurnState.Idle,
+                )
+            }
+        }
     }
 
     fun findDashboard() {
@@ -396,9 +480,18 @@ internal class CelesteViewModel(
         currentOrigin = normalizedOrigin(connection.baseUrl)
         currentAuthMode = null
         val attempt = beginConnectionAttempt()
+        closeGateway()
+        credential = null
+        currentDescriptor = null
         dashboard.clearAuthentication()
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
+            sessions = null,
+            activeSummary = null,
+            messages = emptyList(),
+            streamingText = "",
+            draft = "",
+            turnState = TurnState.Idle,
             loadingMessage = "Loading your conversations…",
             notice = null,
         )
@@ -669,6 +762,7 @@ internal class CelesteViewModel(
         val attempt = beginConnectionAttempt()
         closeGateway()
         credential = null
+        currentDescriptor = null
         currentOrigin = null
         currentAuthMode = null
         mutableState.value = CelesteUiState(
@@ -956,32 +1050,42 @@ internal class CelesteViewModel(
             runtimeSessionId = null,
         )
         launchOwned(CelesteOperation.OpenSession, token) {
+            val reconciliationEpoch = beginReconciliation()
             try {
                 awaitCurrent(token) { newGateway.connect() }
-                reconcile(newGateway, summary.id, token)
+                reconcile(
+                    activeGateway = newGateway,
+                    storedSessionId = summary.id,
+                    token = token,
+                    reconciliationEpoch = reconciliationEpoch,
+                )
                 if (!isCurrent(token)) return@launchOwned
                 reconnectAttempts = 0
                 mutableState.value = mutableState.value.copy(loadingMessage = null)
             } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
                 if (!isCurrent(token)) return@launchOwned
+                val failureNotice = projectUiNotice(error, UiNoticeScope.Session)
                 publishFailure(token, error, "open_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
-                    notice = UiNotice.reconnecting(),
+                    notice = failureNotice ?: UiNotice.reconnecting(),
                     turnState = TurnState.Reconnecting,
                 )
-                scheduleReconnect(wasRunning = false)
+                scheduleReconnect(wasRunning = false, initialNotice = failureNotice)
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                val failureNotice = projectUiNotice(error, UiNoticeScope.Session)
                 publishFailure(token, error, "open_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
-                    notice = UiNotice.reconnecting(),
+                    notice = failureNotice ?: UiNotice.reconnecting(),
                     turnState = TurnState.Reconnecting,
                 )
-                scheduleReconnect(wasRunning = false)
+                scheduleReconnect(wasRunning = false, initialNotice = failureNotice)
+            } finally {
+                finishReconciliation(reconciliationEpoch)
             }
         }
     }
@@ -1017,11 +1121,10 @@ internal class CelesteViewModel(
             profile = selectedProfile,
         )
         launchOwned(CelesteOperation.CreateSession, token) {
+            val reconciliationEpoch = beginReconciliation()
             try {
                 awaitCurrent(token) { newGateway.connect() }
                 if (!isCurrent(token)) return@launchOwned
-                reconciling = true
-                bufferedEvents.clear()
                 val created = awaitCurrent(token) { newGateway.createSession(selectedProfile) }
                 if (!isCurrent(token)) return@launchOwned
                 val returnedProfile = created.profile?.takeIf(String::isNotBlank)
@@ -1040,9 +1143,6 @@ internal class CelesteViewModel(
                     source = "android",
                     profile = returnedProfile ?: selectedProfile,
                 )
-                val events = bufferedEvents.toList()
-                bufferedEvents.clear()
-                reconciling = false
                 mutableState.value = mutableState.value.copy(
                     sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
                         .filterNot { it.id == summary.id },
@@ -1051,30 +1151,26 @@ internal class CelesteViewModel(
                     loadingMessage = null,
                     notice = null,
                 )
-                events.forEach(::applyEvent)
+                replayBufferedEvents(reconciliationEpoch, token)
                 reconnectAttempts = 0
             } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
                 if (!isCurrent(token)) return@launchOwned
-                reconciling = false
-                bufferedEvents.clear()
                 publishFailure(token, error, "create_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
                     loadingMessage = null,
                 )
             } catch (error: CancellationException) {
-                reconciling = false
-                bufferedEvents.clear()
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
-                reconciling = false
-                bufferedEvents.clear()
                 publishFailure(token, error, "create_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
                     loadingMessage = null,
                 )
+            } finally {
+                finishReconciliation(reconciliationEpoch)
             }
         }
     }
@@ -1117,6 +1213,8 @@ internal class CelesteViewModel(
         // prompt.submit creates the durable row before work begins. From this point on,
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
+        turnGeneration += 1
+        stoppedTurnGeneration = null
         interruptionRequested = false
         val token = captureToken(
             operation = CelesteOperation.Send,
@@ -1166,6 +1264,8 @@ internal class CelesteViewModel(
         if (mutableState.value.turnState != TurnState.Running) return
         ownedJobs.remove(CelesteOperation.Send)?.cancel()
         activeOperations.remove(CelesteOperation.Send)
+        turnGeneration += 1
+        stoppedTurnGeneration = turnGeneration
         interruptionRequested = true
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Synchronizing,
@@ -1175,7 +1275,7 @@ internal class CelesteViewModel(
             operation = CelesteOperation.Interrupt,
             gateway = activeGateway,
             storedSessionId = storedId,
-            runtimeSessionId = runtimeId,
+            runtimeSessionId = null,
         )
         launchOwned(CelesteOperation.Interrupt, token) {
             try {
@@ -1211,9 +1311,20 @@ internal class CelesteViewModel(
 
     fun onBackground() {
         lifecycleGeneration += 1
-        ownedJobs.remove(CelesteOperation.Foreground)?.cancel()
-        activeOperations.remove(CelesteOperation.Foreground)
+        detachGatewayObservers()
+        listOf(
+            CelesteOperation.Foreground,
+            CelesteOperation.Reconnect,
+            CelesteOperation.Reconcile,
+        ).forEach { operation ->
+            ownedJobs.remove(operation)?.cancel()
+            activeOperations.remove(operation)
+        }
+        reconnectJob?.cancel()
+        reconnectJob = null
+        foregroundCheckJob?.cancel()
         foregroundCheckJob = null
+        invalidateReconciliation()
         val descriptor = currentDescriptor ?: return
         if (descriptor.authMode != SavedAuthMode.ProviderSession) return
         if (credential != GatewayCredential.CookieSession) return
@@ -1244,7 +1355,12 @@ internal class CelesteViewModel(
 
     fun onForeground() {
         val activeGateway = gateway ?: return
-        val storedSessionId = currentStoredSessionId ?: return
+        // ON_STOP invalidates the old collector token. Rebase both collectors
+        // before health recovery so a healthy socket does not remain silent.
+        observeGateway(activeGateway)
+        val storedSessionId = currentStoredSessionId
+            ?: mutableState.value.activeSummary?.id
+            ?: return
         if (foregroundCheckJob?.isActive == true || reconciling) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
             reconnectNow()
@@ -1254,16 +1370,16 @@ internal class CelesteViewModel(
             operation = CelesteOperation.Foreground,
             gateway = activeGateway,
             storedSessionId = storedSessionId,
-            runtimeSessionId = currentRuntimeSessionId,
+            runtimeSessionId = null,
         )
         foregroundCheckJob = launchOwned(CelesteOperation.Foreground, token) {
             try {
                 awaitCurrent(token) {
                     activeGateway.request(
-                    method = "session.list",
-                    params = buildJsonObject { put("limit", 1) },
-                    timeoutMillis = 8_000,
-                )
+                        method = "session.list",
+                        params = buildJsonObject { put("limit", 1) },
+                        timeoutMillis = 8_000,
+                    )
                 }
                 if (currentSessionCanResume) reconcile(activeGateway, storedSessionId, token)
                 if (!isCurrent(token)) return@launchOwned
@@ -1296,10 +1412,7 @@ internal class CelesteViewModel(
     private var currentStoredSessionId: String? = null
 
     private fun observeGateway(activeGateway: GatewayConnection) {
-        gatewayEventsJob?.cancel()
-        gatewayStateJob?.cancel()
-        gatewayEventsJob = null
-        gatewayStateJob = null
+        detachGatewayObservers()
         val token = captureToken(
             operation = CelesteOperation.GatewayObserver,
             gateway = activeGateway,
@@ -1331,45 +1444,48 @@ internal class CelesteViewModel(
         }
     }
 
+    private fun replayBufferedEvents(epoch: Long, owner: OperationToken) {
+        while (activeReconciliationEpoch == epoch && isCurrent(owner)) {
+            if (bufferedEvents.isEmpty()) return
+            val events = bufferedEvents.toList()
+            bufferedEvents.clear()
+            events.forEach { event ->
+                if (isCurrent(owner)) applyEvent(event)
+            }
+        }
+    }
+
     private suspend fun reconcile(
         activeGateway: GatewayConnection,
         storedSessionId: String,
         token: OperationToken? = null,
+        reconciliationEpoch: Long? = null,
     ) {
-        val owner = token ?: captureToken(
+        // Resume may replace the runtime session ID. Reconciliation owns the
+        // stored-session relationship, so do not pin it to the pre-resume ID.
+        val owner = (token ?: captureToken(
             operation = CelesteOperation.Reconcile,
             gateway = activeGateway,
             storedSessionId = storedSessionId,
-            runtimeSessionId = currentRuntimeSessionId,
-        )
+            runtimeSessionId = null,
+        )).copy(runtimeSessionId = null)
         if (!isCurrent(owner)) throw SupersededOperationCancellation()
-        reconciling = true
-        bufferedEvents.clear()
+        val epoch = reconciliationEpoch ?: beginReconciliation()
         try {
             val resumed = awaitCurrent(owner) { activeGateway.resumeStoredSession(storedSessionId) }
-            if (!isCurrent(owner)) return
+            if (!isCurrent(owner)) throw SupersededOperationCancellation()
             if (resumed.storedSessionId != storedSessionId) {
                 throw InvalidDashboardResponse("Hermes resumed a different conversation.")
             }
             applyResumedSession(resumed)
-            val events = bufferedEvents.toList()
-            bufferedEvents.clear()
-            reconciling = false
-            events.forEach { event ->
-                if (isCurrent(owner)) applyEvent(event)
+            replayBufferedEvents(epoch, owner)
+            if (isCurrent(owner) && stoppedTurnIsActive()) {
+                interruptionRequested = false
             }
-        } catch (error: CancellationException) {
-            if (isCurrent(owner)) {
-                bufferedEvents.clear()
-                reconciling = false
-            }
-            throw error
-        } catch (error: Throwable) {
-            if (isCurrent(owner)) {
-                bufferedEvents.clear()
-                reconciling = false
-            }
-            throw error
+        } finally {
+            // Always release the global reconciliation gate. An older owner
+            // must not clear a newer epoch's buffer or gate.
+            finishReconciliation(epoch)
         }
     }
 
@@ -1377,7 +1493,12 @@ internal class CelesteViewModel(
         currentRuntimeSessionId = resumed.runtimeSessionId
         currentStoredSessionId = resumed.storedSessionId
         currentSessionCanResume = true
-        if (resumed.running == false) interruptionRequested = false
+        if (resumed.running == false && interruptionRequested) {
+            // Keep the stop barrier through buffered-event replay. The
+            // authoritative snapshot settles the turn, but a late start/busy
+            // event from the old turn must not re-arm it.
+            stoppedTurnGeneration = turnGeneration
+        }
         val streamingSuffix = unpersistedInflightText(
             inflight = resumed.inflightAssistantText,
             messages = resumed.messages,
@@ -1399,7 +1520,7 @@ internal class CelesteViewModel(
         if (event.sessionId.isNotBlank() && event.sessionId != runtimeId) return
         when (event.type) {
             "message.start" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 if (mutableState.value.streamingText.isNotBlank()) finalizeAssistant()
                 mutableState.value = mutableState.value.copy(
                     streamingText = "",
@@ -1409,7 +1530,7 @@ internal class CelesteViewModel(
             }
 
             "message.delta" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 val delta = event.payload.string("text").orEmpty()
                 if (delta.isNotEmpty()) {
                     mutableState.value = mutableState.value.copy(
@@ -1420,7 +1541,7 @@ internal class CelesteViewModel(
             }
 
             "message.interim" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 val text = event.payload.string("text").orEmpty()
                 val alreadyStreamed = event.payload.boolean("already_streamed") == true
                 if (alreadyStreamed && mutableState.value.streamingText.isNotBlank()) {
@@ -1435,7 +1556,7 @@ internal class CelesteViewModel(
             }
 
             "message.complete" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 val status = event.payload.string("status")
                 val content = event.payload.string("text")
                     ?: event.payload.string("content")
@@ -1456,7 +1577,7 @@ internal class CelesteViewModel(
             }
 
             "error", "message.error" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
@@ -1472,7 +1593,7 @@ internal class CelesteViewModel(
 
             "session.busy" -> {
                 val busy = event.payload.boolean("busy") == true
-                if (busy && interruptionRequested) return
+                if (busy && (interruptionRequested || stoppedTurnIsActive())) return
                 if (!busy) interruptionRequested = false
                 mutableState.value = mutableState.value.copy(
                     turnState = if (busy) TurnState.Running else TurnState.Idle,
@@ -1481,7 +1602,7 @@ internal class CelesteViewModel(
 
             "session.info" -> {
                 event.payload.boolean("running")?.let { running ->
-                    if (running && interruptionRequested) return
+                    if (running && (interruptionRequested || stoppedTurnIsActive())) return
                     if (!running) interruptionRequested = false
                     mutableState.value = mutableState.value.copy(
                         turnState = if (running) TurnState.Running else TurnState.Idle,
@@ -1490,7 +1611,7 @@ internal class CelesteViewModel(
             }
 
             "tool.start", "tool_call" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 if (mutableState.value.streamingText.isNotBlank()) finalizeAssistant(keepRunning = true)
                 val name = event.payload.string("name") ?: "Tool"
                 val input = event.payload.string("args_text")
@@ -1509,7 +1630,7 @@ internal class CelesteViewModel(
             }
 
             "tool.complete", "tool_result" -> {
-                if (interruptionRequested) return
+                if (interruptionRequested || stoppedTurnIsActive()) return
                 val name = event.payload.string("name") ?: "Tool"
                 val output = event.payload.string("output")
                     ?: event.payload["result"]?.toString().orEmpty()
@@ -1571,11 +1692,11 @@ internal class CelesteViewModel(
         activeGateway: GatewayConnection,
         profile: String,
         token: OperationToken,
+        reconciliationEpoch: Long? = null,
     ) {
         if (!isCurrent(token)) throw SupersededOperationCancellation()
         val previousStoredId = currentStoredSessionId
-        reconciling = true
-        bufferedEvents.clear()
+        val epoch = reconciliationEpoch ?: beginReconciliation()
         try {
             val created = awaitCurrent(token) { activeGateway.createSession(normalizedProfile(profile)) }
             if (!isCurrent(token)) return
@@ -1595,55 +1716,65 @@ internal class CelesteViewModel(
                 turnState = TurnState.Idle,
                 notice = null,
             )
-            val events = bufferedEvents.toList()
-            bufferedEvents.clear()
-            reconciling = false
-            events.forEach { event -> if (isCurrent(token)) applyEvent(event) }
-        } catch (error: CancellationException) {
-            if (isCurrent(token)) {
-                bufferedEvents.clear()
-                reconciling = false
-            }
-            throw error
-        } catch (error: Throwable) {
-            if (isCurrent(token)) {
-                bufferedEvents.clear()
-                reconciling = false
-            }
-            throw error
+            replayBufferedEvents(epoch, token)
+        } finally {
+            finishReconciliation(epoch)
         }
     }
 
-    private fun scheduleReconnect(wasRunning: Boolean, immediate: Boolean = false) {
+    private fun scheduleReconnect(
+        wasRunning: Boolean,
+        immediate: Boolean = false,
+        initialNotice: UiNotice? = null,
+    ) {
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
         if (reconnectJob?.isActive == true) return
         val token = captureToken(
             operation = CelesteOperation.Reconnect,
             gateway = activeGateway,
-            storedSessionId = storedSessionId,
-            runtimeSessionId = currentRuntimeSessionId,
+            // A blank draft may be recreated with a new stored ID. Do not
+            // make that authoritative replacement look stale to the loop.
+            storedSessionId = storedSessionId.takeIf { currentSessionCanResume },
+            // A resume is allowed to replace the runtime ID.
+            runtimeSessionId = null,
         )
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Reconnecting,
-            notice = UiNotice.reconnecting(),
+            notice = initialNotice ?: UiNotice.reconnecting(),
         )
         reconnectJob = launchOwned(CelesteOperation.Reconnect, token) {
+            var lastFailureNotice: UiNotice? = null
             try {
-                while (gateway === activeGateway && isCurrent(token) && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
-                val delayMillis = if (immediate && reconnectAttempts == 0) {
-                    0L
-                } else {
-                    reconnectDelayMillis(reconnectAttempts, wasRunning)
-                }
-                if (delayMillis > 0) delay(delayMillis)
+                while (
+                    gateway === activeGateway &&
+                    isCurrent(token) &&
+                    reconnectAttempts < MAX_RECONNECT_ATTEMPTS
+                ) {
+                    val delayMillis = if (immediate && reconnectAttempts == 0) {
+                        0L
+                    } else {
+                        reconnectDelayMillis(reconnectAttempts, wasRunning)
+                    }
+                    if (delayMillis > 0) delay(delayMillis)
                     if (!isCurrent(token)) return@launchOwned
+                    val reconciliationEpoch = beginReconciliation()
                     try {
                         awaitCurrent(token) { activeGateway.connect() }
                         if (currentSessionCanResume) {
-                            reconcile(activeGateway, storedSessionId, token)
+                            reconcile(
+                                activeGateway = activeGateway,
+                                storedSessionId = storedSessionId,
+                                token = token,
+                                reconciliationEpoch = reconciliationEpoch,
+                            )
                         } else {
-                            recreateBlankSession(activeGateway, mutableState.value.selectedProfile, token)
+                            recreateBlankSession(
+                                activeGateway = activeGateway,
+                                profile = mutableState.value.selectedProfile,
+                                token = token,
+                                reconciliationEpoch = reconciliationEpoch,
+                            )
                         }
                         if (!isCurrent(token)) return@launchOwned
                         reconnectAttempts = 0
@@ -1651,12 +1782,14 @@ internal class CelesteViewModel(
                         return@launchOwned
                     } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
                         if (!isCurrent(token)) return@launchOwned
+                        lastFailureNotice = projectUiNotice(error, UiNoticeScope.Session)
                         recordFailure(token, error, "reconnect", UiNoticeScope.Session)
                     } catch (error: CancellationException) {
                         throw error
                     } catch (error: Throwable) {
                         if (!isCurrent(token)) return@launchOwned
-                        if (error is AuthenticationRejected) {
+                        lastFailureNotice = projectUiNotice(error, UiNoticeScope.Session)
+                        if (isAuthenticationFailure(error)) {
                             val descriptor = currentDescriptor
                             recordFailure(token, error, "reconnect", UiNoticeScope.Connection)
                             invalidateReusableAuthentication(descriptor, token = token)
@@ -1664,17 +1797,19 @@ internal class CelesteViewModel(
                             return@launchOwned
                         }
                         recordFailure(token, error, "reconnect", UiNoticeScope.Session)
+                    } finally {
+                        finishReconciliation(reconciliationEpoch)
                     }
-                reconnectAttempts += 1
+                    reconnectAttempts += 1
                     if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-                        val lastFailure = mutableState.value.notice
+                        val exhaustedNotice = when (lastFailureNotice?.category) {
+                            UiNoticeCategory.RateLimited,
+                            UiNoticeCategory.InvalidResponse -> lastFailureNotice
+                            else -> UiNotice.unavailable()
+                        }
                         mutableState.value = mutableState.value.copy(
                             turnState = TurnState.Reconnecting,
-                            notice = if (lastFailure?.category == UiNoticeCategory.RateLimited) {
-                                lastFailure
-                            } else {
-                                UiNotice.unavailable()
-                            },
+                            notice = exhaustedNotice,
                         )
                         return@launchOwned
                     }
@@ -1684,7 +1819,7 @@ internal class CelesteViewModel(
                     )
                 }
             } finally {
-                if (ownedJobs[CelesteOperation.Reconnect] == null || !isCurrent(token)) {
+                if (activeOperations[CelesteOperation.Reconnect] == token.operationGeneration) {
                     reconnectJob = null
                 }
             }
@@ -1693,23 +1828,19 @@ internal class CelesteViewModel(
 
     private fun closeGateway() {
         val activeGateway = gateway
-        gatewayEventsJob?.cancel()
-        gatewayStateJob?.cancel()
-        gatewayEventsJob = null
-        gatewayStateJob = null
+        detachGatewayObservers()
         gatewayGeneration += 1
         cancelGatewayOperations()
         gateway = null
         reconnectJob = null
         foregroundCheckJob = null
-        gatewayEventsJob = null
-        gatewayStateJob = null
-        reconciling = false
-        bufferedEvents.clear()
+        invalidateReconciliation()
         currentRuntimeSessionId = null
         currentStoredSessionId = null
         currentSessionCanResume = true
         interruptionRequested = false
+        turnGeneration += 1
+        stoppedTurnGeneration = null
         activeGateway?.close()
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -82,7 +82,24 @@ private enum class ForegroundRecovery {
     LoadSessions,
     OpenSession,
     CreateSession,
+    ConnectionCleanup,
 }
+
+private enum class ConnectionCleanupKind {
+    SignOut,
+    Forget,
+    AuthenticationInvalidation,
+}
+
+private data class PendingConnectionCleanup(
+    val origin: String,
+    val kind: ConnectionCleanupKind,
+    val descriptor: SavedConnectionDescriptor?,
+    val probe: DashboardProbeResult?,
+    val logoutRequired: Boolean,
+    var localComplete: Boolean = false,
+    var logoutComplete: Boolean = !logoutRequired,
+)
 
 /**
  * Application ownership is stricter than a gateway object check. A token
@@ -120,6 +137,7 @@ internal data class CelesteUiState(
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
     val notice: UiNotice? = null,
+    val localCleanupNotice: UiNotice? = null,
 )
 
 private data class LoadedDashboard(
@@ -176,6 +194,8 @@ internal class CelesteViewModel(
     private var stoppedTurnGeneration: Long? = null
     private val bufferedEvents = mutableListOf<GatewayEvent>()
     private var pendingForegroundRecovery: ForegroundRecovery? = null
+    private val pendingConnectionCleanups = mutableMapOf<String, PendingConnectionCleanup>()
+    private var pendingConnectionCleanup: PendingConnectionCleanup? = null
 
     init {
         restoreSavedConnection()
@@ -339,7 +359,7 @@ internal class CelesteViewModel(
     }
 
     private fun recordFailure(
-        token: OperationToken,
+        token: OperationToken?,
         error: Throwable,
         operation: String,
         scope: UiNoticeScope,
@@ -351,9 +371,9 @@ internal class CelesteViewModel(
                 reasonCode = diagnosticReason(error),
                 operation = operation,
                 exceptionClass = error::class.simpleName,
-                operationGeneration = token.operationGeneration,
-                gatewayGeneration = token.gatewayGeneration,
-                lifecycleGeneration = token.lifecycleGeneration,
+                operationGeneration = token?.operationGeneration,
+                gatewayGeneration = token?.gatewayGeneration,
+                lifecycleGeneration = token?.lifecycleGeneration,
                 retryCount = retryCount,
             ),
         )
@@ -375,11 +395,220 @@ internal class CelesteViewModel(
         return error is AuthenticationRejected || code == 401 || code == 403
     }
 
+    private fun cleanupOrigin(
+        descriptor: SavedConnectionDescriptor?,
+        probe: DashboardProbeResult?,
+    ): String = normalizedOrigin(
+        descriptor?.baseUrl ?: probe?.baseUrl ?: currentOrigin,
+    ).orEmpty()
+
+    private fun pendingCleanupForCurrentContext(): PendingConnectionCleanup? {
+        val origin = normalizedOrigin(mutableState.value.dashboardUrl) ?: currentOrigin ?: return null
+        return pendingConnectionCleanups[origin]
+    }
+
+    private fun isCurrentForCleanup(
+        pending: PendingConnectionCleanup,
+        token: OperationToken,
+    ): Boolean {
+        if (pending.origin.isNotBlank() && token.origin != pending.origin) return false
+        return if (pending.kind == ConnectionCleanupKind.AuthenticationInvalidation) {
+            isCurrentForAuthenticationInvalidation(token)
+        } else {
+            isCurrent(token)
+        }
+    }
+
+    private suspend fun <T> awaitCleanupCurrent(
+        pending: PendingConnectionCleanup,
+        token: OperationToken,
+        block: suspend () -> T,
+    ): T {
+        val result = block()
+        if (!isCurrentForCleanup(pending, token)) throw SupersededOperationCancellation()
+        return result
+    }
+
+    private fun sameConnectionScope(
+        first: SavedConnectionDescriptor,
+        second: SavedConnectionDescriptor,
+    ): Boolean = normalizedOrigin(first.baseUrl) == normalizedOrigin(second.baseUrl) &&
+        first.authMode == second.authMode &&
+        first.provider == second.provider &&
+        first.username == second.username
+
+    private fun cleanupTargetsStoredConnection(
+        pending: PendingConnectionCleanup,
+        stored: SavedConnectionDescriptor,
+    ): Boolean {
+        if (normalizedOrigin(stored.baseUrl) != pending.origin) return false
+        val target = pending.descriptor ?: return true
+        return sameConnectionScope(target, stored)
+    }
+
+    private fun cleanupLoadingMessage(kind: ConnectionCleanupKind): String = when (kind) {
+        ConnectionCleanupKind.SignOut -> "Signing out…"
+        ConnectionCleanupKind.Forget -> "Forgetting this connection…"
+        ConnectionCleanupKind.AuthenticationInvalidation -> "Clearing saved sign-in…"
+    }
+
+    private fun publishPendingCleanupState(
+        pending: PendingConnectionCleanup,
+        failed: Boolean,
+    ) {
+        val cleanupNotice = if (failed) UiNotice.localCleanup() else null
+        when (pending.kind) {
+            ConnectionCleanupKind.SignOut -> {
+                mutableState.value = manualState(
+                    descriptor = pending.descriptor,
+                ).copy(localCleanupNotice = cleanupNotice)
+            }
+            ConnectionCleanupKind.Forget -> {
+                mutableState.value = CelesteUiState(
+                    connectionPhase = ConnectionPhase.ManualSetup,
+                    localCleanupNotice = cleanupNotice,
+                )
+            }
+            ConnectionCleanupKind.AuthenticationInvalidation -> {
+                val snapshot = mutableState.value
+                val safeBaseUrl = pending.descriptor?.baseUrl
+                    ?: pending.probe?.baseUrl
+                    ?: snapshot.dashboardUrl
+                val safeUsername = pending.descriptor?.username ?: snapshot.username
+                mutableState.value = manualState(
+                    descriptor = pending.descriptor,
+                    phase = ConnectionPhase.AuthenticationRequired,
+                    probe = pending.probe ?: snapshot.probe,
+                    notice = UiNotice.authentication(),
+                ).copy(
+                    dashboardUrl = safeBaseUrl,
+                    savedAuthMode = pending.descriptor?.authMode ?: snapshot.savedAuthMode,
+                    username = safeUsername,
+                    localCleanupNotice = cleanupNotice,
+                )
+            }
+        }
+    }
+
+    private fun resumePendingConnectionCleanup() {
+        val pending = pendingCleanupForCurrentContext() ?: return
+        pendingConnectionCleanup = pending
+        if (ownedJobs[CelesteOperation.Connection]?.isActive == true) return
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        mutableState.value = mutableState.value.copy(
+            loadingMessage = cleanupLoadingMessage(pending.kind),
+            localCleanupNotice = null,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            runPendingConnectionCleanup(pending, token)
+        }
+    }
+
+    private suspend fun runPendingConnectionCleanup(
+        pending: PendingConnectionCleanup,
+        token: OperationToken,
+    ) {
+        if (pendingConnectionCleanups[pending.origin] !== pending ||
+            pendingConnectionCleanup !== pending ||
+            !isCurrentForCleanup(pending, token)
+        ) return
+        dashboard.clearAuthentication()
+        if (!pending.localComplete) {
+            try {
+                awaitCleanupCurrent(pending, token) {
+                    connectionStoreMutex.withLock {
+                        if (pendingConnectionCleanup !== pending || !isCurrentForCleanup(pending, token)) {
+                            throw SupersededOperationCancellation()
+                        }
+                        val stored = connectionStore.load()
+                        if (stored == null || cleanupTargetsStoredConnection(pending, stored.descriptor)) {
+                            when (pending.kind) {
+                                ConnectionCleanupKind.SignOut,
+                                ConnectionCleanupKind.AuthenticationInvalidation -> connectionStore.clearSecret()
+                                ConnectionCleanupKind.Forget -> connectionStore.forget()
+                            }
+                        }
+                    }
+                }
+                pending.localComplete = true
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (isCurrentForCleanup(pending, token) && pendingConnectionCleanup === pending) {
+                    recordFailure(token, error, "local_connection_cleanup", UiNoticeScope.Connection)
+                }
+            }
+        }
+        if (pending.logoutRequired && !pending.logoutComplete) {
+            val probe = pending.probe
+            if (probe == null) {
+                pending.logoutComplete = true
+            } else {
+                try {
+                    awaitCleanupCurrent(pending, token) { dashboard.logout(probe.baseUrl) }
+                    pending.logoutComplete = true
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    if (isCurrentForCleanup(pending, token) && pendingConnectionCleanup === pending) {
+                        recordFailure(token, error, "remote_logout", UiNoticeScope.Connection)
+                    }
+                }
+            }
+        }
+        if (!isCurrentForCleanup(pending, token) || pendingConnectionCleanup !== pending) return
+        if (pending.localComplete && pending.logoutComplete) {
+            if (pendingConnectionCleanups[pending.origin] === pending) {
+                pendingConnectionCleanups.remove(pending.origin)
+            }
+            pendingConnectionCleanup = null
+            publishPendingCleanupState(pending, failed = false)
+        } else {
+            publishPendingCleanupState(pending, failed = true)
+        }
+    }
+
+    private fun beginPendingConnectionCleanup(
+        kind: ConnectionCleanupKind,
+        descriptor: SavedConnectionDescriptor?,
+        probe: DashboardProbeResult?,
+        logoutRequired: Boolean,
+    ): PendingConnectionCleanup {
+        val origin = cleanupOrigin(descriptor, probe)
+        val pending = pendingConnectionCleanups[origin]
+            ?.takeIf { it.kind == kind }
+            ?: PendingConnectionCleanup(
+                origin = origin,
+                kind = kind,
+                descriptor = descriptor,
+                probe = probe,
+                logoutRequired = logoutRequired,
+            )
+        pendingConnectionCleanups[origin] = pending
+        pendingConnectionCleanup = pending
+        return pending
+    }
+
+    /** A successful explicit connection supersedes cleanup for that origin. */
+    private fun supersedePendingConnectionCleanup(origin: String?) {
+        val normalized = normalizedOrigin(origin) ?: return
+        val pending = pendingConnectionCleanups.remove(normalized) ?: return
+        if (pendingConnectionCleanup === pending) {
+            pendingConnectionCleanup = null
+        }
+    }
+
     fun updateDashboardUrl(value: String) {
         mutableState.value = mutableState.value.copy(
             dashboardUrl = value,
             probe = null,
             notice = null,
+            localCleanupNotice = null,
         )
     }
 
@@ -422,6 +651,7 @@ internal class CelesteViewModel(
                 null
             },
             notice = null,
+            localCleanupNotice = null,
         )
 
         if (connection == null || activeCredential == null) return
@@ -478,6 +708,7 @@ internal class CelesteViewModel(
             draft = "",
             loadingMessage = "Finding Hermes…",
             notice = null,
+            localCleanupNotice = null,
         )
         val token = captureToken(
             operation = CelesteOperation.Connection,
@@ -528,6 +759,7 @@ internal class CelesteViewModel(
             turnState = TurnState.Idle,
             loadingMessage = "Loading your conversations…",
             notice = null,
+            localCleanupNotice = null,
         )
         val token = captureToken(
             operation = CelesteOperation.Connection,
@@ -617,33 +849,13 @@ internal class CelesteViewModel(
             } catch (error: Throwable) {
                 if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
                 if (isAuthenticationFailure(error)) {
-                    val clearError = try {
-                        awaitCurrent(token) {
-                            connectionStoreMutex.withLock {
-                                if (!isCurrent(token)) throw SupersededOperationCancellation()
-                                connectionStore.clearSecret()
-                            }
-                        }
-                        null
-                    } catch (clearError: CancellationException) {
-                        throw clearError
-                    } catch (clearError: Throwable) {
-                        clearError
-                    }
-                    if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
-                    dashboard.clearAuthentication()
-                    credential = null
-                    currentAuthMode = null
-                    clearError?.let {
-                        recordFailure(token, it, "clear_rejected_auth", UiNoticeScope.Connection)
-                    }
-                    if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
-                    mutableState.value = mutableState.value.copy(
-                        connectionPhase = ConnectionPhase.AuthenticationRequired,
-                        notice = UiNotice.authentication(),
-                        password = "",
-                        sessionToken = "",
+                    invalidateReusableAuthentication(
+                        descriptor = null,
+                        probe = connection,
+                        token = token,
                     )
+                    if (!isCurrentConnectionAttempt(attempt)) return@launchOwned
+                    mutableState.value = mutableState.value.copy(password = "", sessionToken = "")
                 } else {
                     dashboard.clearAuthentication()
                     credential = null
@@ -679,6 +891,12 @@ internal class CelesteViewModel(
     }
 
     fun retrySavedConnection() {
+        if (pendingConnectionCleanups.isNotEmpty()) {
+            if (pendingCleanupForCurrentContext() != null) {
+                resumePendingConnectionCleanup()
+            }
+            return
+        }
         restoreSavedConnection()
     }
 
@@ -693,14 +911,37 @@ internal class CelesteViewModel(
         mutableState.value = CelesteUiState(connectionPhase = ConnectionPhase.ManualSetup)
     }
 
+    private fun descriptorForCleanup(state: CelesteUiState): SavedConnectionDescriptor? {
+        currentDescriptor?.let { return it }
+        val authMode = state.savedAuthMode ?: return null
+        if (state.dashboardUrl.isBlank()) return null
+        return runCatching {
+            SavedConnectionDescriptor(
+                baseUrl = state.dashboardUrl,
+                authMode = authMode,
+                provider = state.probe?.providers?.firstOrNull { it.supportsPassword }?.name,
+                username = state.username.takeIf(String::isNotBlank),
+                expectsSecret = authMode != SavedAuthMode.Open,
+            )
+        }.getOrNull()
+    }
+
     fun signOut() {
         val snapshot = mutableState.value
         val activeCredential = credential
-        val attempt = beginConnectionAttempt()
+        val descriptor = descriptorForCleanup(snapshot)
+        val pending = beginPendingConnectionCleanup(
+            kind = ConnectionCleanupKind.SignOut,
+            descriptor = descriptor,
+            probe = snapshot.probe,
+            logoutRequired = activeCredential == GatewayCredential.CookieSession && snapshot.probe != null,
+        )
+        beginConnectionAttempt()
         closeGateway()
         credential = null
         currentDescriptor = null
         currentAuthMode = null
+        if (pending.origin.isNotBlank()) currentOrigin = pending.origin
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             sessions = null,
@@ -712,101 +953,34 @@ internal class CelesteViewModel(
             sessionToken = "",
             loadingMessage = "Signing out…",
             notice = null,
+            localCleanupNotice = null,
         )
-        val token = captureToken(
-            operation = CelesteOperation.Connection,
-            gateway = null,
-            storedSessionId = null,
-            runtimeSessionId = null,
-        )
-        connectionJob = launchOwned(CelesteOperation.Connection, token) {
-            val clearError = try {
-                awaitCurrent(token) {
-                    connectionStoreMutex.withLock {
-                        if (!isCurrent(token)) throw SupersededOperationCancellation()
-                        connectionStore.clearSecret()
-                    }
-                }
-                null
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
-                error
-            }
-            val saved = try {
-                awaitCurrent(token) { connectionStoreMutex.withLock { connectionStore.load() } }
-            } catch (error: CancellationException) {
-                throw error
-            } catch (_: Throwable) {
-                null
-            }
-            if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
-                try {
-                    awaitCurrent(token) { dashboard.logout(snapshot.probe.baseUrl) }
-                } catch (error: CancellationException) {
-                    throw error
-                } catch (error: Throwable) {
-                    recordFailure(token, error, "sign_out", UiNoticeScope.Connection)
-                }
-            }
-            dashboard.clearAuthentication()
-            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
-            currentDescriptor = saved?.descriptor
-            mutableState.value = manualState(
-                descriptor = saved?.descriptor,
-                notice = if (clearError == null) null else UiNotice.persistence(),
-            )
-        }
+        dashboard.clearAuthentication()
+        resumePendingConnectionCleanup()
     }
 
     fun forgetConnection() {
         val snapshot = mutableState.value
         val activeCredential = credential
-        val attempt = beginConnectionAttempt()
+        val descriptor = descriptorForCleanup(snapshot)
+        val pending = beginPendingConnectionCleanup(
+            kind = ConnectionCleanupKind.Forget,
+            descriptor = descriptor,
+            probe = snapshot.probe,
+            logoutRequired = activeCredential == GatewayCredential.CookieSession && snapshot.probe != null,
+        )
+        beginConnectionAttempt()
         closeGateway()
         credential = null
         currentDescriptor = null
         currentAuthMode = null
+        if (pending.origin.isNotBlank()) currentOrigin = pending.origin
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Forgetting this connection…",
         )
-        val token = captureToken(
-            operation = CelesteOperation.Connection,
-            gateway = null,
-            storedSessionId = null,
-            runtimeSessionId = null,
-        )
-        connectionJob = launchOwned(CelesteOperation.Connection, token) {
-            val error = try {
-                awaitCurrent(token) {
-                    connectionStoreMutex.withLock {
-                        if (!isCurrent(token)) throw SupersededOperationCancellation()
-                        connectionStore.forget()
-                    }
-                }
-                null
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
-                error
-            }
-            if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
-                try {
-                    awaitCurrent(token) { dashboard.logout(snapshot.probe.baseUrl) }
-                } catch (error: CancellationException) {
-                    throw error
-                } catch (logoutError: Throwable) {
-                    recordFailure(token, logoutError, "forget_connection", UiNoticeScope.Connection)
-                }
-            }
-            dashboard.clearAuthentication()
-            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
-            mutableState.value = CelesteUiState(
-                connectionPhase = ConnectionPhase.ManualSetup,
-                notice = if (error == null) null else UiNotice.persistence(),
-            )
-        }
+        dashboard.clearAuthentication()
+        resumePendingConnectionCleanup()
     }
 
     private fun restoreSavedConnection() {
@@ -957,23 +1131,10 @@ internal class CelesteViewModel(
         } catch (error: Throwable) {
             if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
             if (isAuthenticationFailure(error)) {
-                awaitCurrent(token) {
-                    connectionStoreMutex.withLock {
-                        if (!isCurrent(token)) throw SupersededOperationCancellation()
-                        connectionStore.clearSecret()
-                    }
-                }
-                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
-                credential = null
-                currentDescriptor = null
-                dashboard.clearAuthentication()
-                currentAuthMode = null
-                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
-                mutableState.value = manualState(
+                invalidateReusableAuthentication(
                     descriptor = descriptor,
-                    phase = ConnectionPhase.AuthenticationRequired,
                     probe = restoredProbe,
-                    notice = UiNotice.authentication(),
+                    token = token,
                 )
             } else {
                 dashboard.clearAuthentication()
@@ -1010,36 +1171,45 @@ internal class CelesteViewModel(
         token: OperationToken? = null,
     ) {
         val snapshot = mutableState.value
-        val safeBaseUrl = descriptor?.baseUrl ?: probe?.baseUrl ?: snapshot.dashboardUrl
-        val safeUsername = descriptor?.username ?: snapshot.username
-        val safeProbe = probe ?: snapshot.probe
-        if (token == null) {
-            connectionStoreMutex.withLock { connectionStore.clearSecret() }
-        } else {
-            if (!isCurrent(token)) return
-            awaitCurrent(token) {
-                connectionStoreMutex.withLock {
-                    if (!isCurrent(token)) throw SupersededOperationCancellation()
-                    connectionStore.clearSecret()
-                }
-            }
-            if (!isCurrent(token)) return
-        }
+        val pending = beginPendingConnectionCleanup(
+            kind = ConnectionCleanupKind.AuthenticationInvalidation,
+            descriptor = descriptor,
+            probe = probe ?: snapshot.probe,
+            logoutRequired = false,
+        )
+        if (pending.origin.isNotBlank()) currentOrigin = pending.origin
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
         currentAuthMode = null
-        if (token != null && !isCurrentForAuthenticationInvalidation(token)) return
-        mutableState.value = manualState(
-            descriptor = descriptor,
-            phase = ConnectionPhase.AuthenticationRequired,
-            probe = safeProbe,
-            notice = UiNotice.authentication(),
-        ).copy(
-            dashboardUrl = safeBaseUrl,
-            savedAuthMode = descriptor?.authMode ?: snapshot.savedAuthMode,
-            username = safeUsername,
-        )
+        if (token != null) {
+            if (!isCurrentForCleanup(pending, token)) return
+            runPendingConnectionCleanup(pending, token)
+            return
+        }
+
+        try {
+            connectionStoreMutex.withLock {
+                val stored = connectionStore.load()
+                if (stored == null || cleanupTargetsStoredConnection(pending, stored.descriptor)) {
+                    connectionStore.clearSecret()
+                }
+            }
+            pending.localComplete = true
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            recordFailure(null, error, "local_connection_cleanup", UiNoticeScope.Connection)
+        }
+        if (pending.localComplete) {
+            if (pendingConnectionCleanups[pending.origin] === pending) {
+                pendingConnectionCleanups.remove(pending.origin)
+            }
+            pendingConnectionCleanup = null
+            publishPendingCleanupState(pending, failed = false)
+        } else {
+            publishPendingCleanupState(pending, failed = true)
+        }
     }
 
     private fun publishConnectedDashboard(
@@ -1048,6 +1218,7 @@ internal class CelesteViewModel(
         sessionToken: String = "",
         notice: UiNotice? = null,
     ) {
+        supersedePendingConnectionCleanup(currentOrigin)
         val selectedProfile = mutableState.value.selectedProfile
             .takeIf { selected -> loaded.profiles.any { it.name == selected } }
             ?: loaded.profiles.firstOrNull(DashboardProfile::isDefault)?.name
@@ -1065,6 +1236,7 @@ internal class CelesteViewModel(
             sessionToken = sessionToken,
             loadingMessage = null,
             notice = notice,
+            localCleanupNotice = null,
         )
     }
 
@@ -1491,6 +1663,9 @@ internal class CelesteViewModel(
     }
 
     private fun foregroundRecoveryFor(state: CelesteUiState): ForegroundRecovery? {
+        if (pendingCleanupForCurrentContext() != null) {
+            return ForegroundRecovery.ConnectionCleanup
+        }
         if (activeOperations[CelesteOperation.Connection] != null) {
             when {
                 state.connectionPhase == ConnectionPhase.CheckingSavedConnection ||
@@ -1531,6 +1706,7 @@ internal class CelesteViewModel(
             ForegroundRecovery.CreateSession -> {
                 if (mutableState.value.probe != null && credential != null) createNewConversation()
             }
+            ForegroundRecovery.ConnectionCleanup -> resumePendingConnectionCleanup()
         }
     }
 
@@ -1554,7 +1730,10 @@ internal class CelesteViewModel(
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         invalidateReconciliation()
-        if (recovery == ForegroundRecovery.OpenSession || recovery == ForegroundRecovery.CreateSession) {
+        if (recovery == ForegroundRecovery.OpenSession ||
+            recovery == ForegroundRecovery.CreateSession ||
+            recovery == ForegroundRecovery.ConnectionCleanup
+        ) {
             closeGateway()
         }
         val descriptor = currentDescriptor ?: return
@@ -1591,6 +1770,12 @@ internal class CelesteViewModel(
     fun onForeground() {
         val recovery = pendingForegroundRecovery ?: foregroundRecoveryFor(mutableState.value)
         val activeGateway = gateway
+        if (recovery == ForegroundRecovery.ConnectionCleanup) {
+            pendingForegroundRecovery = null
+            if (activeGateway != null) closeGateway()
+            resumePendingConnectionCleanup()
+            return
+        }
         if (activeGateway == null) {
             pendingForegroundRecovery = null
             recovery?.let(::recoverWithoutGateway)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -216,11 +216,10 @@ internal class CelesteViewModel(
         )
     }
 
-    private fun isCurrent(token: OperationToken): Boolean {
+    private fun isCurrentIgnoringAuthMode(token: OperationToken): Boolean {
         if (activeOperations[token.operation] != token.operationGeneration) return false
         if (token.contextGeneration != contextGeneration) return false
         if (token.origin != null && token.origin != currentOrigin) return false
-        if (token.authMode != null && token.authMode != currentAuthMode) return false
         if (token.profile != normalizedProfile(mutableState.value.selectedProfile)) return false
         if (token.gateway != null && gateway !== token.gateway) return false
         if (token.gatewayGeneration != gatewayGeneration) return false
@@ -233,6 +232,19 @@ internal class CelesteViewModel(
         }
         return true
     }
+
+    private fun isCurrent(token: OperationToken): Boolean =
+        isCurrentIgnoringAuthMode(token) &&
+            (token.authMode == null || token.authMode == currentAuthMode)
+
+    /**
+     * Authentication rejection clears the current auth mode as part of the
+     * invalidation. Keep every other token identity strict while allowing that
+     * one deliberate transition to publish the sign-in recovery state.
+     */
+    private fun isCurrentForAuthenticationInvalidation(token: OperationToken): Boolean =
+        isCurrentIgnoringAuthMode(token) &&
+            (currentAuthMode == null || token.authMode == currentAuthMode)
 
     private fun cancelOwnedOperations() {
         ownedJobs.values.toList().forEach(Job::cancel)
@@ -1017,7 +1029,7 @@ internal class CelesteViewModel(
         currentDescriptor = null
         dashboard.clearAuthentication()
         currentAuthMode = null
-        if (token != null && !isCurrent(token)) return
+        if (token != null && !isCurrentForAuthenticationInvalidation(token)) return
         mutableState.value = manualState(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
@@ -1748,7 +1760,7 @@ internal class CelesteViewModel(
         )
         mutableState.value = mutableState.value.copy(
             messages = resumed.messages,
-            streamingText = streamingSuffix,
+            streamingText = if (resumed.running == false) "" else streamingSuffix,
             turnState = when (resumed.running) {
                 true -> TurnState.Running
                 false -> TurnState.Idle
@@ -1756,6 +1768,52 @@ internal class CelesteViewModel(
             },
             notice = null,
         )
+        if (resumed.running == false) {
+            settleStreamingOutput(resumed.inflightAssistantText.takeIf(String::isNotBlank))
+        }
+    }
+
+    /** Settle an in-flight assistant projection when the server says the turn ended. */
+    private fun settleStreamingOutput(authoritativeInflight: String? = null) {
+        val snapshot = mutableState.value
+        if (authoritativeInflight != null) {
+            val settledText = authoritativeInflight.trimEnd()
+            val previousAssistant = snapshot.messages.lastOrNull()?.takeIf {
+                it.role == "assistant" && it.text.isNotBlank()
+            }
+            val messages = if (
+                settledText.isNotBlank() &&
+                previousAssistant != null &&
+                settledText.startsWith(previousAssistant.text)
+            ) {
+                snapshot.messages.dropLast(1) + previousAssistant.copy(
+                    text = settledText,
+                    pending = false,
+                    interim = false,
+                )
+            } else if (settledText.isNotBlank()) {
+                snapshot.messages + ConversationMessage(
+                    role = "assistant",
+                    text = settledText,
+                )
+            } else {
+                snapshot.messages
+            }
+            mutableState.value = snapshot.copy(
+                messages = messages,
+                streamingText = "",
+                turnState = TurnState.Idle,
+            )
+            return
+        }
+        if (snapshot.streamingText.isBlank()) {
+            mutableState.value = snapshot.copy(
+                streamingText = "",
+                turnState = TurnState.Idle,
+            )
+        } else {
+            finalizeAssistant(keepRunning = false)
+        }
     }
 
     private fun applyEvent(event: GatewayEvent) {
@@ -1801,22 +1859,35 @@ internal class CelesteViewModel(
             "message.complete" -> {
                 if (interruptionRequested || stoppedTurnIsActive()) return
                 val status = event.payload.string("status")
+                val isError = status == "error" || event.payload["error"] != null
+                val isPartial = event.payload.boolean("partial") == true
                 val content = event.payload.string("text")
                     ?: event.payload.string("content")
                     ?: event.payload.string("rendered")
                     ?: ""
-                finalizeAssistant(
-                    suppliedContent = content,
-                    keepRunning = false,
-                )
-                mutableState.value = mutableState.value.copy(
-                    turnState = TurnState.Idle,
-                    notice = if (status == "error") {
-                        UiNotice.serverTurnFailure()
-                    } else {
-                        mutableState.value.notice
-                    },
-                )
+                if (isError && !isPartial) {
+                    // The terminal error frame is authoritative: without a
+                    // partial flag its text belongs to the failure detail, not
+                    // to the assistant transcript.
+                    mutableState.value = mutableState.value.copy(
+                        streamingText = "",
+                        turnState = TurnState.Idle,
+                        notice = UiNotice.serverTurnFailure(),
+                    )
+                } else {
+                    finalizeAssistant(
+                        suppliedContent = content,
+                        keepRunning = false,
+                    )
+                    mutableState.value = mutableState.value.copy(
+                        turnState = TurnState.Idle,
+                        notice = if (isError) {
+                            UiNotice.serverTurnFailure()
+                        } else {
+                            mutableState.value.notice
+                        },
+                    )
+                }
             }
 
             "error", "message.error" -> {
@@ -1837,7 +1908,10 @@ internal class CelesteViewModel(
             "session.busy" -> {
                 val busy = event.payload.boolean("busy") == true
                 if (busy && (interruptionRequested || stoppedTurnIsActive())) return
-                if (!busy) interruptionRequested = false
+                if (!busy) {
+                    interruptionRequested = false
+                    settleStreamingOutput()
+                }
                 mutableState.value = mutableState.value.copy(
                     turnState = if (busy) TurnState.Running else TurnState.Idle,
                 )
@@ -1846,7 +1920,10 @@ internal class CelesteViewModel(
             "session.info" -> {
                 event.payload.boolean("running")?.let { running ->
                     if (running && (interruptionRequested || stoppedTurnIsActive())) return
-                    if (!running) interruptionRequested = false
+                    if (!running) {
+                        interruptionRequested = false
+                        settleStreamingOutput()
+                    }
                     mutableState.value = mutableState.value.copy(
                         turnState = if (running) TurnState.Running else TurnState.Idle,
                     )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -76,6 +76,14 @@ internal enum class CelesteOperation {
     GatewayObserver,
 }
 
+private enum class ForegroundRecovery {
+    RestoreSavedConnection,
+    ProbeDashboard,
+    LoadSessions,
+    OpenSession,
+    CreateSession,
+}
+
 /**
  * Application ownership is stricter than a gateway object check. A token
  * carries every identity that can change while a suspend function is away.
@@ -167,6 +175,7 @@ internal class CelesteViewModel(
     private var turnGeneration = 0L
     private var stoppedTurnGeneration: Long? = null
     private val bufferedEvents = mutableListOf<GatewayEvent>()
+    private var pendingForegroundRecovery: ForegroundRecovery? = null
 
     init {
         restoreSavedConnection()
@@ -233,6 +242,7 @@ internal class CelesteViewModel(
 
     private fun invalidateContext() {
         contextGeneration += 1
+        pendingForegroundRecovery = null
         cancelOwnedOperations()
     }
 
@@ -280,9 +290,13 @@ internal class CelesteViewModel(
             CelesteOperation.Reconnect,
             CelesteOperation.GatewayObserver,
         ).forEach { operation ->
-            ownedJobs.remove(operation)?.cancel()
-            activeOperations.remove(operation)
+            cancelOwnedOperation(operation)
         }
+    }
+
+    private fun cancelOwnedOperation(operation: CelesteOperation) {
+        ownedJobs.remove(operation)?.cancel()
+        activeOperations.remove(operation)
     }
 
     private fun launchOwned(
@@ -559,7 +573,9 @@ internal class CelesteViewModel(
                 val persistenceError = try {
                     awaitCurrent(token) {
                         connectionStoreMutex.withLock {
-                            if (!isCurrentConnectionAttempt(attempt)) throw SupersededOperationCancellation()
+                            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) {
+                                throw SupersededOperationCancellation()
+                            }
                             connectionStore.replace(descriptor, reusableSecret)
                         }
                     }
@@ -588,21 +604,28 @@ internal class CelesteViewModel(
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
-                dashboard.clearAuthentication()
-                credential = null
                 if (isAuthenticationFailure(error)) {
-                    currentAuthMode = null
-                    connectionStoreMutex.withLock {
-                        if (isCurrent(token)) {
-                            try {
+                    val clearError = try {
+                        awaitCurrent(token) {
+                            connectionStoreMutex.withLock {
+                                if (!isCurrent(token)) throw SupersededOperationCancellation()
                                 connectionStore.clearSecret()
-                            } catch (clearError: CancellationException) {
-                                throw clearError
-                            } catch (clearError: Throwable) {
-                                recordFailure(token, clearError, "clear_rejected_auth", UiNoticeScope.Connection)
                             }
                         }
+                        null
+                    } catch (clearError: CancellationException) {
+                        throw clearError
+                    } catch (clearError: Throwable) {
+                        clearError
                     }
+                    if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
+                    dashboard.clearAuthentication()
+                    credential = null
+                    currentAuthMode = null
+                    clearError?.let {
+                        recordFailure(token, it, "clear_rejected_auth", UiNoticeScope.Connection)
+                    }
+                    if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
                     mutableState.value = mutableState.value.copy(
                         connectionPhase = ConnectionPhase.AuthenticationRequired,
                         notice = UiNotice.authentication(),
@@ -610,6 +633,8 @@ internal class CelesteViewModel(
                         sessionToken = "",
                     )
                 } else {
+                    dashboard.clearAuthentication()
+                    credential = null
                     publishFailure(token, error, "load_sessions", UiNoticeScope.Connection)
                     mutableState.value = mutableState.value.copy(
                         password = "",
@@ -685,7 +710,10 @@ internal class CelesteViewModel(
         connectionJob = launchOwned(CelesteOperation.Connection, token) {
             val clearError = try {
                 awaitCurrent(token) {
-                    connectionStoreMutex.withLock { connectionStore.clearSecret() }
+                    connectionStoreMutex.withLock {
+                        if (!isCurrent(token)) throw SupersededOperationCancellation()
+                        connectionStore.clearSecret()
+                    }
                 }
                 null
             } catch (error: CancellationException) {
@@ -740,7 +768,10 @@ internal class CelesteViewModel(
         connectionJob = launchOwned(CelesteOperation.Connection, token) {
             val error = try {
                 awaitCurrent(token) {
-                    connectionStoreMutex.withLock { connectionStore.forget() }
+                    connectionStoreMutex.withLock {
+                        if (!isCurrent(token)) throw SupersededOperationCancellation()
+                        connectionStore.forget()
+                    }
                 }
                 null
             } catch (error: CancellationException) {
@@ -872,7 +903,7 @@ internal class CelesteViewModel(
                     try {
                         awaitCurrent(token) {
                             connectionStoreMutex.withLock {
-                                if (!isCurrentConnectionAttempt(attempt)) {
+                                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) {
                                     throw SupersededOperationCancellation()
                                 }
                                 connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
@@ -888,6 +919,7 @@ internal class CelesteViewModel(
             } else {
                 null
             }
+            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
             credential = loaded.credential
             currentDescriptor = descriptor
             currentOrigin = normalizedOrigin(probe.baseUrl)
@@ -913,13 +945,18 @@ internal class CelesteViewModel(
         } catch (error: Throwable) {
             if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
             if (isAuthenticationFailure(error)) {
+                awaitCurrent(token) {
+                    connectionStoreMutex.withLock {
+                        if (!isCurrent(token)) throw SupersededOperationCancellation()
+                        connectionStore.clearSecret()
+                    }
+                }
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
                 credential = null
                 currentDescriptor = null
                 dashboard.clearAuthentication()
-                awaitCurrent(token) {
-                    connectionStoreMutex.withLock { connectionStore.clearSecret() }
-                }
                 currentAuthMode = null
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
                 mutableState.value = manualState(
                     descriptor = descriptor,
                     phase = ConnectionPhase.AuthenticationRequired,
@@ -964,19 +1001,23 @@ internal class CelesteViewModel(
         val safeBaseUrl = descriptor?.baseUrl ?: probe?.baseUrl ?: snapshot.dashboardUrl
         val safeUsername = descriptor?.username ?: snapshot.username
         val safeProbe = probe ?: snapshot.probe
+        if (token == null) {
+            connectionStoreMutex.withLock { connectionStore.clearSecret() }
+        } else {
+            if (!isCurrent(token)) return
+            awaitCurrent(token) {
+                connectionStoreMutex.withLock {
+                    if (!isCurrent(token)) throw SupersededOperationCancellation()
+                    connectionStore.clearSecret()
+                }
+            }
+            if (!isCurrent(token)) return
+        }
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
-        if (token == null || isCurrent(token)) {
-            if (token == null) {
-                connectionStoreMutex.withLock { connectionStore.clearSecret() }
-            } else {
-                awaitCurrent(token) {
-                    connectionStoreMutex.withLock { connectionStore.clearSecret() }
-                }
-            }
-        }
         currentAuthMode = null
+        if (token != null && !isCurrent(token)) return
         mutableState.value = manualState(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
@@ -1324,6 +1365,73 @@ internal class CelesteViewModel(
         }
     }
 
+    private suspend fun publishInterruptRecoveryFailure(
+        activeGateway: GatewayConnection,
+        token: OperationToken,
+        error: Throwable,
+        operation: String,
+    ) {
+        if (!isCurrent(token)) return
+        if (isAuthenticationFailure(error)) {
+            val descriptor = currentDescriptor
+            invalidateReusableAuthentication(
+                descriptor = descriptor,
+                probe = mutableState.value.probe,
+                token = token,
+            )
+            closeGateway()
+            return
+        }
+        val failureNotice = projectUiNotice(error, UiNoticeScope.Turn)
+        publishFailure(token, error, operation, UiNoticeScope.Turn)
+        if (!isCurrent(token)) return
+        mutableState.value = mutableState.value.copy(
+            turnState = TurnState.Reconnecting,
+            notice = failureNotice ?: UiNotice.reconnecting(),
+        )
+        activeGateway.close()
+        scheduleReconnect(
+            wasRunning = true,
+            immediate = true,
+            initialNotice = failureNotice,
+        )
+    }
+
+    private suspend fun reconcileAfterInterruptFailure(
+        activeGateway: GatewayConnection,
+        storedId: String,
+        token: OperationToken,
+        error: Throwable,
+    ) {
+        if (!isCurrent(token)) return
+        if (isAuthenticationFailure(error)) {
+            publishInterruptRecoveryFailure(activeGateway, token, error, "interrupt")
+            return
+        }
+        recordFailure(token, error, "interrupt", UiNoticeScope.Turn)
+        try {
+            reconcile(activeGateway, storedId, token)
+            if (!isCurrent(token)) return
+            mutableState.value = mutableState.value.copy(notice = null)
+        } catch (reconcileError: kotlinx.coroutines.TimeoutCancellationException) {
+            publishInterruptRecoveryFailure(
+                activeGateway,
+                token,
+                reconcileError,
+                "reconcile_after_interrupt",
+            )
+        } catch (reconcileError: CancellationException) {
+            throw reconcileError
+        } catch (reconcileError: Throwable) {
+            publishInterruptRecoveryFailure(
+                activeGateway,
+                token,
+                reconcileError,
+                "reconcile_after_interrupt",
+            )
+        }
+    }
+
     fun interrupt() {
         val activeGateway = gateway ?: return
         val runtimeId = currentRuntimeSessionId ?: return
@@ -1349,29 +1457,13 @@ internal class CelesteViewModel(
                 awaitCurrent(token) { activeGateway.interruptSession(runtimeId) }
                 reconcile(activeGateway, storedId, token)
                 if (!isCurrent(token)) return@launchOwned
-                mutableState.value = mutableState.value.copy(turnState = TurnState.Idle, notice = null)
+                mutableState.value = mutableState.value.copy(notice = null)
             } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
-                if (!isCurrent(token)) return@launchOwned
-                publishFailure(token, error, "interrupt", UiNoticeScope.Turn)
-                mutableState.value = mutableState.value.copy(turnState = TurnState.Idle)
+                reconcileAfterInterruptFailure(activeGateway, storedId, token, error)
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
-                if (!isCurrent(token)) return@launchOwned
-                if (isAuthenticationFailure(error)) {
-                    val descriptor = currentDescriptor
-                    invalidateReusableAuthentication(
-                        descriptor = descriptor,
-                        probe = mutableState.value.probe,
-                        token = token,
-                    )
-                    closeGateway()
-                    return@launchOwned
-                }
-                publishFailure(token, error, "interrupt", UiNoticeScope.Turn)
-                mutableState.value = mutableState.value.copy(
-                    turnState = TurnState.Idle,
-                )
+                reconcileAfterInterruptFailure(activeGateway, storedId, token, error)
             }
         }
     }
@@ -1386,22 +1478,73 @@ internal class CelesteViewModel(
         scheduleReconnect(wasRunning = mutableState.value.turnState == TurnState.Running, immediate = true)
     }
 
+    private fun foregroundRecoveryFor(state: CelesteUiState): ForegroundRecovery? {
+        if (activeOperations[CelesteOperation.Connection] != null) {
+            when {
+                state.connectionPhase == ConnectionPhase.CheckingSavedConnection ||
+                    state.connectionPhase == ConnectionPhase.Restoring ->
+                    return ForegroundRecovery.RestoreSavedConnection
+                state.loadingMessage == "Finding Hermes…" -> return ForegroundRecovery.ProbeDashboard
+                state.loadingMessage == "Loading your conversations…" && state.probe != null ->
+                    return ForegroundRecovery.LoadSessions
+            }
+        }
+        if (activeOperations[CelesteOperation.OpenSession] != null) {
+            return ForegroundRecovery.OpenSession
+        }
+        if (activeOperations[CelesteOperation.CreateSession] != null) {
+            return ForegroundRecovery.CreateSession
+        }
+        return when {
+            state.connectionPhase == ConnectionPhase.CheckingSavedConnection ||
+                state.connectionPhase == ConnectionPhase.Restoring ->
+                ForegroundRecovery.RestoreSavedConnection
+            state.loadingMessage == "Finding Hermes…" -> ForegroundRecovery.ProbeDashboard
+            state.loadingMessage == "Loading your conversations…" && state.probe != null ->
+                ForegroundRecovery.LoadSessions
+            state.loadingMessage?.startsWith("Opening ") == true && state.activeSummary != null ->
+                ForegroundRecovery.OpenSession
+            state.loadingMessage?.startsWith("Starting a new ") == true && state.probe != null ->
+                ForegroundRecovery.CreateSession
+            else -> null
+        }
+    }
+
+    private fun recoverWithoutGateway(recovery: ForegroundRecovery) {
+        when (recovery) {
+            ForegroundRecovery.RestoreSavedConnection -> restoreSavedConnection()
+            ForegroundRecovery.ProbeDashboard -> findDashboard()
+            ForegroundRecovery.LoadSessions -> if (mutableState.value.probe != null) loadSessions()
+            ForegroundRecovery.OpenSession -> mutableState.value.activeSummary?.let(::openSession)
+            ForegroundRecovery.CreateSession -> {
+                if (mutableState.value.probe != null && credential != null) createNewConversation()
+            }
+        }
+    }
+
     fun onBackground() {
+        val stateAtBackground = mutableState.value
+        val recovery = foregroundRecoveryFor(stateAtBackground)
+        if (recovery != null) pendingForegroundRecovery = recovery
         lifecycleGeneration += 1
         detachGatewayObservers()
+        cancelOwnedOperation(CelesteOperation.Connection)
+        connectionJob = null
         listOf(
             CelesteOperation.Foreground,
             CelesteOperation.Reconnect,
             CelesteOperation.Reconcile,
-        ).forEach { operation ->
-            ownedJobs.remove(operation)?.cancel()
-            activeOperations.remove(operation)
-        }
+            CelesteOperation.OpenSession,
+            CelesteOperation.CreateSession,
+        ).forEach { operation -> cancelOwnedOperation(operation) }
         reconnectJob?.cancel()
         reconnectJob = null
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         invalidateReconciliation()
+        if (recovery == ForegroundRecovery.OpenSession || recovery == ForegroundRecovery.CreateSession) {
+            closeGateway()
+        }
         val descriptor = currentDescriptor ?: return
         if (descriptor.authMode != SavedAuthMode.ProviderSession) return
         if (credential != GatewayCredential.CookieSession) return
@@ -1416,7 +1559,10 @@ internal class CelesteViewModel(
             try {
                 awaitCurrent(token) {
                     connectionStoreMutex.withLock {
-                        if (credential != GatewayCredential.CookieSession || currentDescriptor != descriptor) {
+                        if (!isCurrent(token) ||
+                            credential != GatewayCredential.CookieSession ||
+                            currentDescriptor != descriptor
+                        ) {
                             throw SupersededOperationCancellation()
                         }
                         connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
@@ -1431,7 +1577,14 @@ internal class CelesteViewModel(
     }
 
     fun onForeground() {
-        val activeGateway = gateway ?: return
+        val recovery = pendingForegroundRecovery ?: foregroundRecoveryFor(mutableState.value)
+        val activeGateway = gateway
+        if (activeGateway == null) {
+            pendingForegroundRecovery = null
+            recovery?.let(::recoverWithoutGateway)
+            return
+        }
+        pendingForegroundRecovery = null
         // ON_STOP invalidates the old collector token. Rebase both collectors
         // before health recovery so a healthy socket does not remain silent.
         observeGateway(activeGateway)
@@ -1653,7 +1806,7 @@ internal class CelesteViewModel(
                     ?: event.payload.string("rendered")
                     ?: ""
                 finalizeAssistant(
-                    suppliedContent = if (status == "error") "" else content,
+                    suppliedContent = content,
                     keepRunning = false,
                 )
                 mutableState.value = mutableState.value.copy(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -411,7 +411,7 @@ internal class CelesteViewModel(
         pending: PendingConnectionCleanup,
         token: OperationToken,
     ): Boolean {
-        if (pending.origin.isNotBlank() && token.origin != pending.origin) return false
+        if (pending.origin.isNotBlank() && token.origin != null && token.origin != pending.origin) return false
         return if (pending.kind == ConnectionCleanupKind.AuthenticationInvalidation) {
             isCurrentForAuthenticationInvalidation(token)
         } else {
@@ -419,13 +419,20 @@ internal class CelesteViewModel(
         }
     }
 
+    private fun isCurrentCleanup(
+        pending: PendingConnectionCleanup,
+        token: OperationToken,
+    ): Boolean = pendingConnectionCleanups[pending.origin] === pending &&
+        pendingConnectionCleanup === pending &&
+        isCurrentForCleanup(pending, token)
+
     private suspend fun <T> awaitCleanupCurrent(
         pending: PendingConnectionCleanup,
         token: OperationToken,
         block: suspend () -> T,
     ): T {
         val result = block()
-        if (!isCurrentForCleanup(pending, token)) throw SupersededOperationCancellation()
+        if (!isCurrentCleanup(pending, token)) throw SupersededOperationCancellation()
         return result
     }
 
@@ -515,35 +522,8 @@ internal class CelesteViewModel(
     ) {
         if (pendingConnectionCleanups[pending.origin] !== pending ||
             pendingConnectionCleanup !== pending ||
-            !isCurrentForCleanup(pending, token)
+            !isCurrentCleanup(pending, token)
         ) return
-        dashboard.clearAuthentication()
-        if (!pending.localComplete) {
-            try {
-                awaitCleanupCurrent(pending, token) {
-                    connectionStoreMutex.withLock {
-                        if (pendingConnectionCleanup !== pending || !isCurrentForCleanup(pending, token)) {
-                            throw SupersededOperationCancellation()
-                        }
-                        val stored = connectionStore.load()
-                        if (stored == null || cleanupTargetsStoredConnection(pending, stored.descriptor)) {
-                            when (pending.kind) {
-                                ConnectionCleanupKind.SignOut,
-                                ConnectionCleanupKind.AuthenticationInvalidation -> connectionStore.clearSecret()
-                                ConnectionCleanupKind.Forget -> connectionStore.forget()
-                            }
-                        }
-                    }
-                }
-                pending.localComplete = true
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Throwable) {
-                if (isCurrentForCleanup(pending, token) && pendingConnectionCleanup === pending) {
-                    recordFailure(token, error, "local_connection_cleanup", UiNoticeScope.Connection)
-                }
-            }
-        }
         if (pending.logoutRequired && !pending.logoutComplete) {
             val probe = pending.probe
             if (probe == null) {
@@ -555,13 +535,51 @@ internal class CelesteViewModel(
                 } catch (error: CancellationException) {
                     throw error
                 } catch (error: Throwable) {
-                    if (isCurrentForCleanup(pending, token) && pendingConnectionCleanup === pending) {
+                    if (isCurrentCleanup(pending, token)) {
                         recordFailure(token, error, "remote_logout", UiNoticeScope.Connection)
                     }
                 }
             }
         }
-        if (!isCurrentForCleanup(pending, token) || pendingConnectionCleanup !== pending) return
+        if (!isCurrentCleanup(pending, token)) return
+        dashboard.clearAuthentication()
+        if (!pending.localComplete) {
+            try {
+                awaitCleanupCurrent(pending, token) {
+                    connectionStoreMutex.withLock {
+                        if (!isCurrentCleanup(pending, token)) {
+                            throw SupersededOperationCancellation()
+                        }
+                        val stored = connectionStore.load()
+                        if (stored == null || cleanupTargetsStoredConnection(pending, stored.descriptor)) {
+                            when (pending.kind) {
+                                ConnectionCleanupKind.SignOut,
+                                ConnectionCleanupKind.AuthenticationInvalidation -> {
+                                    if (!isCurrentCleanup(pending, token)) {
+                                        throw SupersededOperationCancellation()
+                                    }
+                                    connectionStore.clearSecret()
+                                }
+                                ConnectionCleanupKind.Forget -> {
+                                    if (!isCurrentCleanup(pending, token)) {
+                                        throw SupersededOperationCancellation()
+                                    }
+                                    connectionStore.forget()
+                                }
+                            }
+                        }
+                    }
+                }
+                pending.localComplete = true
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (isCurrentCleanup(pending, token)) {
+                    recordFailure(token, error, "local_connection_cleanup", UiNoticeScope.Connection)
+                }
+            }
+        }
+        if (!isCurrentCleanup(pending, token)) return
         if (pending.localComplete && pending.logoutComplete) {
             if (pendingConnectionCleanups[pending.origin] === pending) {
                 pendingConnectionCleanups.remove(pending.origin)
@@ -955,7 +973,6 @@ internal class CelesteViewModel(
             notice = null,
             localCleanupNotice = null,
         )
-        dashboard.clearAuthentication()
         resumePendingConnectionCleanup()
     }
 
@@ -979,7 +996,6 @@ internal class CelesteViewModel(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Forgetting this connection…",
         )
-        dashboard.clearAuthentication()
         resumePendingConnectionCleanup()
     }
 
@@ -1168,7 +1184,7 @@ internal class CelesteViewModel(
     private suspend fun invalidateReusableAuthentication(
         descriptor: SavedConnectionDescriptor?,
         probe: DashboardProbeResult? = null,
-        token: OperationToken? = null,
+        token: OperationToken,
     ) {
         val snapshot = mutableState.value
         val pending = beginPendingConnectionCleanup(
@@ -1180,36 +1196,9 @@ internal class CelesteViewModel(
         if (pending.origin.isNotBlank()) currentOrigin = pending.origin
         credential = null
         currentDescriptor = null
-        dashboard.clearAuthentication()
         currentAuthMode = null
-        if (token != null) {
-            if (!isCurrentForCleanup(pending, token)) return
-            runPendingConnectionCleanup(pending, token)
-            return
-        }
-
-        try {
-            connectionStoreMutex.withLock {
-                val stored = connectionStore.load()
-                if (stored == null || cleanupTargetsStoredConnection(pending, stored.descriptor)) {
-                    connectionStore.clearSecret()
-                }
-            }
-            pending.localComplete = true
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Throwable) {
-            recordFailure(null, error, "local_connection_cleanup", UiNoticeScope.Connection)
-        }
-        if (pending.localComplete) {
-            if (pendingConnectionCleanups[pending.origin] === pending) {
-                pendingConnectionCleanups.remove(pending.origin)
-            }
-            pendingConnectionCleanup = null
-            publishPendingCleanupState(pending, failed = false)
-        } else {
-            publishPendingCleanupState(pending, failed = true)
-        }
+        if (!isCurrentForCleanup(pending, token)) return
+        runPendingConnectionCleanup(pending, token)
     }
 
     private fun publishConnectedDashboard(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -21,6 +21,7 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
 import dev.hazydreams.hermesceleste.network.ResumedSession
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.boolean
@@ -33,6 +34,7 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,7 +43,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -61,6 +62,37 @@ internal enum class ConnectionPhase {
     Connected,
 }
 
+internal enum class CelesteOperation {
+    Connection,
+    OpenSession,
+    CreateSession,
+    Send,
+    Interrupt,
+    Reconcile,
+    Foreground,
+    Reconnect,
+    Persistence,
+    GatewayObserver,
+}
+
+/**
+ * Application ownership is stricter than a gateway object check. A token
+ * carries every identity that can change while a suspend function is away.
+ */
+internal data class OperationToken(
+    val operation: CelesteOperation,
+    val operationGeneration: Long,
+    val contextGeneration: Long,
+    val origin: String?,
+    val authMode: SavedAuthMode?,
+    val profile: String,
+    val storedSessionId: String?,
+    val runtimeSessionId: String?,
+    val gateway: GatewayConnection?,
+    val gatewayGeneration: Long,
+    val lifecycleGeneration: Long,
+)
+
 internal data class CelesteUiState(
     val connectionPhase: ConnectionPhase = ConnectionPhase.CheckingSavedConnection,
     val dashboardUrl: String = "",
@@ -78,7 +110,7 @@ internal data class CelesteUiState(
     val draft: String = "",
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
-    val errorMessage: String? = null,
+    val notice: UiNotice? = null,
 )
 
 private data class LoadedDashboard(
@@ -93,12 +125,15 @@ private data class RememberedDashboard(
     val persistenceError: Throwable?,
 )
 
+private class SupersededOperationCancellation : CancellationException()
+
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
     private val reconnectDelayMillis: (attempt: Int, wasRunning: Boolean) -> Long = { attempt, wasRunning ->
         if (wasRunning && attempt == 0) 100L else min(5_000L, 1_000L shl attempt.coerceAtMost(2))
     },
+    private val diagnosticsSink: DiagnosticsSink = NoopDiagnosticsSink,
 ) : ViewModel() {
     private val mutableState = MutableStateFlow(CelesteUiState())
     val state: StateFlow<CelesteUiState> = mutableState.asStateFlow()
@@ -112,22 +147,170 @@ internal class CelesteViewModel(
     private var foregroundCheckJob: Job? = null
     private var connectionJob: Job? = null
     private var connectionAttempt = 0L
+    private var contextGeneration = 0L
+    private var operationGeneration = 0L
+    private var gatewayGeneration = 0L
+    private var lifecycleGeneration = 0L
+    private var currentOrigin: String? = null
+    private var currentAuthMode: SavedAuthMode? = null
+    private val activeOperations = mutableMapOf<CelesteOperation, Long>()
+    private val ownedJobs = mutableMapOf<CelesteOperation, Job>()
     private val connectionStoreMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
     private var reconciling = false
     private var currentSessionCanResume = true
+    private var interruptionRequested = false
     private val bufferedEvents = mutableListOf<GatewayEvent>()
 
     init {
         restoreSavedConnection()
     }
 
+    private fun normalizedProfile(name: String): String =
+        name.trim().ifBlank { "default" }
+
+    private fun normalizedOrigin(baseUrl: String?): String? = baseUrl?.let { raw ->
+        runCatching { DashboardUrlPolicy.normalize(raw) }
+            .getOrElse { raw.trim().trimEnd('/') }
+            .takeIf(String::isNotBlank)
+    }
+
+    private fun captureToken(
+        operation: CelesteOperation,
+        gateway: GatewayConnection? = this.gateway,
+        storedSessionId: String? = currentStoredSessionId,
+        runtimeSessionId: String? = currentRuntimeSessionId,
+        profile: String = mutableState.value.selectedProfile,
+    ): OperationToken {
+        ownedJobs[operation]?.cancel()
+        ownedJobs.remove(operation)
+        val generation = ++operationGeneration
+        activeOperations[operation] = generation
+        return OperationToken(
+            operation = operation,
+            operationGeneration = generation,
+            contextGeneration = contextGeneration,
+            origin = currentOrigin,
+            authMode = currentAuthMode,
+            profile = normalizedProfile(profile),
+            storedSessionId = storedSessionId,
+            runtimeSessionId = runtimeSessionId,
+            gateway = gateway,
+            gatewayGeneration = gatewayGeneration,
+            lifecycleGeneration = lifecycleGeneration,
+        )
+    }
+
+    private fun isCurrent(token: OperationToken): Boolean {
+        if (activeOperations[token.operation] != token.operationGeneration) return false
+        if (token.contextGeneration != contextGeneration) return false
+        if (token.origin != null && token.origin != currentOrigin) return false
+        if (token.authMode != null && token.authMode != currentAuthMode) return false
+        if (token.profile != normalizedProfile(mutableState.value.selectedProfile)) return false
+        if (token.gateway != null && gateway !== token.gateway) return false
+        if (token.gatewayGeneration != gatewayGeneration) return false
+        if (token.lifecycleGeneration != lifecycleGeneration) return false
+        token.storedSessionId?.let { stored ->
+            if (currentStoredSessionId != stored && mutableState.value.activeSummary?.id != stored) return false
+        }
+        token.runtimeSessionId?.let { runtime ->
+            if (currentRuntimeSessionId != runtime) return false
+        }
+        return true
+    }
+
+    private fun cancelOwnedOperations() {
+        ownedJobs.values.toList().forEach(Job::cancel)
+        ownedJobs.clear()
+        activeOperations.clear()
+    }
+
+    private fun invalidateContext() {
+        contextGeneration += 1
+        cancelOwnedOperations()
+    }
+
+    private fun cancelGatewayOperations() {
+        listOf(
+            CelesteOperation.OpenSession,
+            CelesteOperation.CreateSession,
+            CelesteOperation.Send,
+            CelesteOperation.Interrupt,
+            CelesteOperation.Reconcile,
+            CelesteOperation.Foreground,
+            CelesteOperation.Reconnect,
+            CelesteOperation.GatewayObserver,
+        ).forEach { operation ->
+            ownedJobs.remove(operation)?.cancel()
+            activeOperations.remove(operation)
+        }
+    }
+
+    private fun launchOwned(
+        operation: CelesteOperation,
+        token: OperationToken,
+        block: suspend () -> Unit,
+    ): Job {
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            try {
+                block()
+            } finally {
+                if (activeOperations[operation] == token.operationGeneration) {
+                    activeOperations.remove(operation)
+                    ownedJobs.remove(operation)
+                }
+            }
+        }
+        ownedJobs[operation]?.cancel()
+        ownedJobs[operation] = job
+        job.start()
+        return job
+    }
+
+    private suspend fun <T> awaitCurrent(token: OperationToken, block: suspend () -> T): T {
+        val result = block()
+        if (!isCurrent(token)) throw SupersededOperationCancellation()
+        return result
+    }
+
+    private fun recordFailure(
+        token: OperationToken,
+        error: Throwable,
+        operation: String,
+        scope: UiNoticeScope,
+        retryCount: Int = reconnectAttempts,
+    ) {
+        diagnosticsSink.record(
+            SanitizedDiagnostic(
+                category = diagnosticCategory(error, scope),
+                reasonCode = diagnosticReason(error),
+                operation = operation,
+                exceptionClass = error::class.simpleName,
+                operationGeneration = token.operationGeneration,
+                gatewayGeneration = token.gatewayGeneration,
+                lifecycleGeneration = token.lifecycleGeneration,
+                retryCount = retryCount,
+            ),
+        )
+    }
+
+    private fun publishFailure(
+        token: OperationToken,
+        error: Throwable,
+        operation: String,
+        scope: UiNoticeScope,
+    ) {
+        if (!isCurrent(token) || isExpectedCancellation(error)) return
+        recordFailure(token, error, operation, scope)
+        mutableState.value = mutableState.value.copy(notice = projectUiNotice(error, scope))
+    }
+
     fun updateDashboardUrl(value: String) {
         mutableState.value = mutableState.value.copy(
             dashboardUrl = value,
             probe = null,
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -149,12 +332,20 @@ internal class CelesteViewModel(
 
     fun selectProfile(name: String) {
         if (mutableState.value.profiles.none { it.name == name }) return
-        mutableState.value = mutableState.value.copy(selectedProfile = name)
+        if (normalizedProfile(mutableState.value.selectedProfile) == normalizedProfile(name)) return
+        invalidateContext()
+        if (mutableState.value.activeSummary != null) closeGateway()
+        mutableState.value = mutableState.value.copy(
+            selectedProfile = name,
+            notice = null,
+        )
     }
 
     fun findDashboard() {
         val rawUrl = mutableState.value.dashboardUrl
         if (rawUrl.isBlank()) return
+        currentOrigin = normalizedOrigin(rawUrl)
+        currentAuthMode = null
         val attempt = beginConnectionAttempt()
         closeGateway()
         credential = null
@@ -168,50 +359,69 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             loadingMessage = "Finding Hermes…",
-            errorMessage = null,
+            notice = null,
         )
-        connectionJob = viewModelScope.launch {
-            runCatching { dashboard.probe(rawUrl) }
-                .onSuccess { result ->
-                    if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
-                    mutableState.value = mutableState.value.copy(
-                        dashboardUrl = result.baseUrl,
-                        probe = result,
-                    )
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            try {
+                val result = awaitCurrent(token) { dashboard.probe(rawUrl) }
+                currentOrigin = normalizedOrigin(result.baseUrl)
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
+                mutableState.value = mutableState.value.copy(
+                    dashboardUrl = result.baseUrl,
+                    probe = result,
+                )
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                publishFailure(token, error, "probe", UiNoticeScope.Connection)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                publishFailure(token, error, "probe", UiNoticeScope.Connection)
+            } finally {
+                if (isCurrentConnectionAttempt(attempt) && isCurrent(token)) {
+                    mutableState.value = mutableState.value.copy(loadingMessage = null)
                 }
-                .onFailure { error ->
-                    if (!isCurrentConnectionAttempt(attempt)) return@onFailure
-                    mutableState.value = mutableState.value.copy(
-                        errorMessage = error.message ?: "Could not reach the Hermes dashboard.",
-                    )
-                }
-            if (!isCurrentConnectionAttempt(attempt)) return@launch
-            mutableState.value = mutableState.value.copy(loadingMessage = null)
+            }
         }
     }
 
     fun loadSessions() {
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
+        currentOrigin = normalizedOrigin(connection.baseUrl)
+        currentAuthMode = null
         val attempt = beginConnectionAttempt()
         dashboard.clearAuthentication()
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Loading your conversations…",
-            errorMessage = null,
+            notice = null,
         )
-        connectionJob = viewModelScope.launch {
-            runCatching {
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            try {
                 val passwordProvider = connection.providers.firstOrNull { it.supportsPassword }
                 val selectedCredential = if (connection.authRequired) {
                     passwordProvider
                         ?: error("This dashboard requires browser sign-in, which is not in this build yet.")
-                    dashboard.passwordLogin(
-                        baseUrl = connection.baseUrl,
-                        provider = passwordProvider.name,
-                        username = snapshot.username,
-                        password = snapshot.password,
-                    )
+                    awaitCurrent(token) {
+                        dashboard.passwordLogin(
+                            baseUrl = connection.baseUrl,
+                            provider = passwordProvider.name,
+                            username = snapshot.username,
+                            password = snapshot.password,
+                        )
+                    }
                     GatewayCredential.CookieSession
                 } else {
                     snapshot.sessionToken
@@ -219,7 +429,7 @@ internal class CelesteViewModel(
                         ?.let(GatewayCredential::StaticToken)
                         ?: GatewayCredential.None
                 }
-                val loaded = loadDashboard(connection.baseUrl, selectedCredential)
+                val loaded = loadDashboard(connection.baseUrl, selectedCredential, token)
                 val descriptor = when {
                     connection.authRequired -> SavedConnectionDescriptor(
                         baseUrl = connection.baseUrl,
@@ -245,38 +455,71 @@ internal class CelesteViewModel(
                     SavedAuthMode.StaticToken -> ReusableSecret(snapshot.sessionToken)
                     SavedAuthMode.Open -> null
                 }
-                val persistenceError = connectionStoreMutex.withLock {
-                    if (!isCurrentConnectionAttempt(attempt)) throw CancellationException()
-                    runCatching {
-                        connectionStore.replace(descriptor, reusableSecret)
-                    }.exceptionOrNull()
+                val persistenceError = try {
+                    awaitCurrent(token) {
+                        connectionStoreMutex.withLock {
+                            if (!isCurrentConnectionAttempt(attempt)) throw SupersededOperationCancellation()
+                            connectionStore.replace(descriptor, reusableSecret)
+                        }
+                    }
+                    null
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    error
                 }
-                RememberedDashboard(loaded, descriptor, persistenceError)
-            }.onSuccess { remembered ->
-                if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
+                val remembered = RememberedDashboard(loaded, descriptor, persistenceError)
+
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
                 credential = remembered.loaded.credential
                 currentDescriptor = remembered.descriptor
+                currentAuthMode = remembered.descriptor.authMode
+                mutableState.value = mutableState.value.copy(connectionPhase = ConnectionPhase.Connected)
                 publishConnectedDashboard(
                     loaded = remembered.loaded,
                     password = "",
                     sessionToken = "",
-                    errorMessage = if (remembered.persistenceError == null) {
-                        null
-                    } else {
-                        "Connected, but Celeste could not remember this connection."
-                    },
+                    notice = if (remembered.persistenceError == null) null else UiNotice.persistence(),
                 )
-            }.onFailure { error ->
-                if (!isCurrentConnectionAttempt(attempt)) return@onFailure
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                publishFailure(token, error, "load_sessions", UiNoticeScope.Connection)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
                 dashboard.clearAuthentication()
-                mutableState.value = mutableState.value.copy(
-                    errorMessage = error.message ?: "Could not load Hermes conversations.",
-                    password = "",
-                    sessionToken = "",
-                )
+                credential = null
+                if (error is AuthenticationRejected) {
+                    currentAuthMode = null
+                    connectionStoreMutex.withLock {
+                        if (isCurrent(token)) {
+                            try {
+                                connectionStore.clearSecret()
+                            } catch (clearError: CancellationException) {
+                                throw clearError
+                            } catch (clearError: Throwable) {
+                                recordFailure(token, clearError, "clear_rejected_auth", UiNoticeScope.Connection)
+                            }
+                        }
+                    }
+                    mutableState.value = mutableState.value.copy(
+                        connectionPhase = ConnectionPhase.AuthenticationRequired,
+                        notice = UiNotice.authentication(),
+                        password = "",
+                        sessionToken = "",
+                    )
+                } else {
+                    publishFailure(token, error, "load_sessions", UiNoticeScope.Connection)
+                    mutableState.value = mutableState.value.copy(
+                        password = "",
+                        sessionToken = "",
+                    )
+                }
+            } finally {
+                if (isCurrentConnectionAttempt(attempt) && isCurrent(token)) {
+                    mutableState.value = mutableState.value.copy(loadingMessage = null)
+                }
             }
-            if (!isCurrentConnectionAttempt(attempt)) return@launch
-            mutableState.value = mutableState.value.copy(loadingMessage = null)
         }
     }
 
@@ -284,6 +527,8 @@ internal class CelesteViewModel(
         beginConnectionAttempt()
         closeGateway()
         credential = null
+        currentOrigin = null
+        currentAuthMode = null
         mutableState.value = mutableState.value.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             sessions = null,
@@ -291,7 +536,7 @@ internal class CelesteViewModel(
             messages = emptyList(),
             streamingText = "",
             draft = "",
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -304,6 +549,8 @@ internal class CelesteViewModel(
         closeGateway()
         credential = null
         currentDescriptor = null
+        currentOrigin = null
+        currentAuthMode = null
         dashboard.clearAuthentication()
         mutableState.value = CelesteUiState(connectionPhase = ConnectionPhase.ManualSetup)
     }
@@ -315,6 +562,7 @@ internal class CelesteViewModel(
         closeGateway()
         credential = null
         currentDescriptor = null
+        currentAuthMode = null
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             sessions = null,
@@ -325,24 +573,47 @@ internal class CelesteViewModel(
             password = "",
             sessionToken = "",
             loadingMessage = "Signing out…",
-            errorMessage = null,
+            notice = null,
         )
-        connectionJob = viewModelScope.launch {
-            val (error, saved) = connectionStoreMutex.withLock {
-                val clearError = runCatching { connectionStore.clearSecret() }.exceptionOrNull()
-                clearError to runCatching { connectionStore.load() }.getOrNull()
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            val clearError = try {
+                awaitCurrent(token) {
+                    connectionStoreMutex.withLock { connectionStore.clearSecret() }
+                }
+                null
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                error
+            }
+            val saved = try {
+                awaitCurrent(token) { connectionStoreMutex.withLock { connectionStore.load() } }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                null
             }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
-                runCatching { dashboard.logout(snapshot.probe.baseUrl) }
+                try {
+                    awaitCurrent(token) { dashboard.logout(snapshot.probe.baseUrl) }
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    recordFailure(token, error, "sign_out", UiNoticeScope.Connection)
+                }
             }
             dashboard.clearAuthentication()
-            if (!isCurrentConnectionAttempt(attempt)) return@launch
+            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
             currentDescriptor = saved?.descriptor
             mutableState.value = manualState(
                 descriptor = saved?.descriptor,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved sign-in. Try Forget connection."
-                },
+                notice = if (clearError == null) null else UiNotice.persistence(),
             )
         }
     }
@@ -354,24 +625,42 @@ internal class CelesteViewModel(
         closeGateway()
         credential = null
         currentDescriptor = null
+        currentAuthMode = null
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Forgetting this connection…",
         )
-        connectionJob = viewModelScope.launch {
-            val error = connectionStoreMutex.withLock {
-                runCatching { connectionStore.forget() }.exceptionOrNull()
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            val error = try {
+                awaitCurrent(token) {
+                    connectionStoreMutex.withLock { connectionStore.forget() }
+                }
+                null
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                error
             }
             if (activeCredential == GatewayCredential.CookieSession && snapshot.probe != null) {
-                runCatching { dashboard.logout(snapshot.probe.baseUrl) }
+                try {
+                    awaitCurrent(token) { dashboard.logout(snapshot.probe.baseUrl) }
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (logoutError: Throwable) {
+                    recordFailure(token, logoutError, "forget_connection", UiNoticeScope.Connection)
+                }
             }
             dashboard.clearAuthentication()
-            if (!isCurrentConnectionAttempt(attempt)) return@launch
+            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
             mutableState.value = CelesteUiState(
                 connectionPhase = ConnectionPhase.ManualSetup,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved connection. Try again."
-                },
+                notice = if (error == null) null else UiNotice.persistence(),
             )
         }
     }
@@ -380,32 +669,49 @@ internal class CelesteViewModel(
         val attempt = beginConnectionAttempt()
         closeGateway()
         credential = null
+        currentOrigin = null
+        currentAuthMode = null
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.CheckingSavedConnection,
             loadingMessage = "Checking this device…",
         )
-        connectionJob = viewModelScope.launch {
-            val savedResult = connectionStoreMutex.withLock {
-                runCatching { connectionStore.load() }
-            }
-            if (!isCurrentConnectionAttempt(attempt)) return@launch
-            val saved = savedResult.getOrElse {
+        val token = captureToken(
+            operation = CelesteOperation.Connection,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        connectionJob = launchOwned(CelesteOperation.Connection, token) {
+            try {
+                val saved = awaitCurrent(token) {
+                    connectionStoreMutex.withLock { connectionStore.load() }
+                }
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
+                when (val decision = connectionBootstrapDecision(saved)) {
+                    ConnectionBootstrapDecision.ManualSetup -> {
+                        mutableState.value = manualState()
+                    }
+                    is ConnectionBootstrapDecision.Prefill -> {
+                        currentOrigin = normalizedOrigin(decision.descriptor.baseUrl)
+                        currentAuthMode = decision.descriptor.authMode
+                        mutableState.value = manualState(decision.descriptor)
+                    }
+                    is ConnectionBootstrapDecision.Restore -> {
+                        currentOrigin = normalizedOrigin(decision.descriptor.baseUrl)
+                        currentAuthMode = decision.descriptor.authMode
+                        restoreConnection(decision, attempt, token)
+                    }
+                }
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                publishFailure(token, error, "restore_saved_connection", UiNoticeScope.Connection)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
                 mutableState.value = manualState(
                     descriptor = null,
-                    errorMessage = "Celeste could not read the saved connection. Sign in again.",
+                    notice = UiNotice.persistence(),
                 )
-                return@launch
-            }
-            when (val decision = connectionBootstrapDecision(saved)) {
-                ConnectionBootstrapDecision.ManualSetup -> {
-                    mutableState.value = manualState()
-                }
-                is ConnectionBootstrapDecision.Prefill -> {
-                    mutableState.value = manualState(decision.descriptor)
-                }
-                is ConnectionBootstrapDecision.Restore -> {
-                    restoreConnection(decision, attempt)
-                }
             }
         }
     }
@@ -413,6 +719,7 @@ internal class CelesteViewModel(
     private suspend fun restoreConnection(
         decision: ConnectionBootstrapDecision.Restore,
         attempt: Long,
+        token: OperationToken,
     ) {
         val descriptor = decision.descriptor
         var restoredProbe: DashboardProbeResult? = null
@@ -424,12 +731,12 @@ internal class CelesteViewModel(
             loadingMessage = "Reconnecting to your Hermes…",
         )
         dashboard.clearAuthentication()
-        runCatching {
+        try {
             val normalized = DashboardUrlPolicy.normalize(descriptor.baseUrl)
             if (normalized != descriptor.baseUrl) {
                 throw AuthenticationRejected("The saved dashboard address changed.")
             }
-            val probe = dashboard.probe(normalized)
+            val probe = awaitCurrent(token) { dashboard.probe(normalized) }
             restoredProbe = probe
             val restoredCredential = when (descriptor.authMode) {
                 SavedAuthMode.Open -> {
@@ -453,19 +760,27 @@ internal class CelesteViewModel(
                     GatewayCredential.CookieSession
                 }
             }
-            probe to loadDashboard(normalized, restoredCredential)
-        }.onSuccess { (probe, loaded) ->
-            if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
+            val loaded = loadDashboard(normalized, restoredCredential, token)
+            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
             val persistenceError = if (descriptor.authMode == SavedAuthMode.ProviderSession) {
                 val refreshed = dashboard.exportAuthentication(descriptor.baseUrl)
                 if (refreshed == null) {
                     IOException("The refreshed Hermes session was unavailable.")
                 } else {
-                    connectionStoreMutex.withLock {
-                        if (!isCurrentConnectionAttempt(attempt)) throw CancellationException()
-                        runCatching {
-                            connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
-                        }.exceptionOrNull()
+                    try {
+                        awaitCurrent(token) {
+                            connectionStoreMutex.withLock {
+                                if (!isCurrentConnectionAttempt(attempt)) {
+                                    throw SupersededOperationCancellation()
+                                }
+                                connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
+                            }
+                        }
+                        null
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Throwable) {
+                        error
                     }
                 }
             } else {
@@ -473,22 +788,41 @@ internal class CelesteViewModel(
             }
             credential = loaded.credential
             currentDescriptor = descriptor
+            currentOrigin = normalizedOrigin(probe.baseUrl)
+            currentAuthMode = descriptor.authMode
             mutableState.value = mutableState.value.copy(
                 dashboardUrl = probe.baseUrl,
                 probe = probe,
             )
             publishConnectedDashboard(
                 loaded,
-                errorMessage = if (persistenceError == null) null else {
-                    "Connected, but Celeste could not refresh the saved sign-in."
-                },
+                notice = if (persistenceError == null) null else UiNotice.persistence(),
             )
-        }.onFailure { error ->
-            if (!isCurrentConnectionAttempt(attempt)) return@onFailure
+        } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+            if (isCurrentConnectionAttempt(attempt) && isCurrent(token)) {
+                mutableState.value = mutableState.value.copy(
+                    connectionPhase = ConnectionPhase.RestoreFailed,
+                    notice = projectUiNotice(error, UiNoticeScope.Connection),
+                    loadingMessage = null,
+                )
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
             if (error is AuthenticationRejected) {
-                invalidateReusableAuthentication(
+                credential = null
+                currentDescriptor = null
+                dashboard.clearAuthentication()
+                awaitCurrent(token) {
+                    connectionStoreMutex.withLock { connectionStore.clearSecret() }
+                }
+                currentAuthMode = null
+                mutableState.value = manualState(
                     descriptor = descriptor,
+                    phase = ConnectionPhase.AuthenticationRequired,
                     probe = restoredProbe,
+                    notice = UiNotice.authentication(),
                 )
             } else {
                 dashboard.clearAuthentication()
@@ -499,8 +833,12 @@ internal class CelesteViewModel(
                     dashboardUrl = descriptor.baseUrl,
                     savedAuthMode = descriptor.authMode,
                     username = descriptor.username.orEmpty(),
-                    errorMessage = error.message ?: "Could not reconnect to Hermes.",
+                    notice = projectUiNotice(error, UiNoticeScope.Connection),
                 )
+            }
+        } finally {
+            if (isCurrentConnectionAttempt(attempt) && isCurrent(token)) {
+                mutableState.value = mutableState.value.copy(loadingMessage = null)
             }
         }
     }
@@ -508,27 +846,35 @@ internal class CelesteViewModel(
     private suspend fun loadDashboard(
         baseUrl: String,
         selectedCredential: GatewayCredential,
+        token: OperationToken,
     ): LoadedDashboard {
-        val sessions = dashboard.listSessions(baseUrl, selectedCredential)
-        val profiles = dashboard.listProfiles(baseUrl, selectedCredential)
+        val sessions = awaitCurrent(token) { dashboard.listSessions(baseUrl, selectedCredential) }
+        val profiles = awaitCurrent(token) { dashboard.listProfiles(baseUrl, selectedCredential) }
         return LoadedDashboard(selectedCredential, sessions, profiles)
     }
 
     private suspend fun invalidateReusableAuthentication(
         descriptor: SavedConnectionDescriptor?,
         probe: DashboardProbeResult? = null,
+        token: OperationToken? = null,
     ) {
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
-        connectionStoreMutex.withLock {
-            runCatching { connectionStore.clearSecret() }
+        if (token == null || isCurrent(token)) {
+            if (token == null) {
+                connectionStoreMutex.withLock { connectionStore.clearSecret() }
+            } else {
+                awaitCurrent(token) {
+                    connectionStoreMutex.withLock { connectionStore.clearSecret() }
+                }
+            }
         }
         mutableState.value = manualState(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
             probe = probe,
-            errorMessage = "Saved sign-in is no longer valid. Sign in again.",
+            notice = UiNotice.authentication(),
         )
     }
 
@@ -536,7 +882,7 @@ internal class CelesteViewModel(
         loaded: LoadedDashboard,
         password: String = "",
         sessionToken: String = "",
-        errorMessage: String? = null,
+        notice: UiNotice? = null,
     ) {
         val selectedProfile = mutableState.value.selectedProfile
             .takeIf { selected -> loaded.profiles.any { it.name == selected } }
@@ -554,7 +900,7 @@ internal class CelesteViewModel(
             password = password,
             sessionToken = sessionToken,
             loadingMessage = null,
-            errorMessage = errorMessage,
+            notice = notice,
         )
     }
 
@@ -562,19 +908,19 @@ internal class CelesteViewModel(
         descriptor: SavedConnectionDescriptor? = null,
         phase: ConnectionPhase = ConnectionPhase.ManualSetup,
         probe: DashboardProbeResult? = null,
-        errorMessage: String? = null,
+        notice: UiNotice? = null,
     ): CelesteUiState = CelesteUiState(
         connectionPhase = phase,
         dashboardUrl = descriptor?.baseUrl.orEmpty(),
         probe = probe,
         savedAuthMode = descriptor?.authMode,
         username = descriptor?.username.orEmpty(),
-        errorMessage = errorMessage,
+        notice = notice,
     )
 
     private fun beginConnectionAttempt(): Long {
         connectionAttempt += 1
-        connectionJob?.cancel()
+        invalidateContext()
         connectionJob = null
         return connectionAttempt
     }
@@ -584,8 +930,11 @@ internal class CelesteViewModel(
     fun openSession(summary: StoredSession) {
         val connection = mutableState.value.probe ?: return
         val activeCredential = credential ?: return
+        invalidateContext()
         closeGateway()
         currentSessionCanResume = true
+        currentRuntimeSessionId = null
+        currentStoredSessionId = null
         mutableState.value = mutableState.value.copy(
             activeSummary = summary,
             messages = emptyList(),
@@ -593,23 +942,43 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Synchronizing,
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
-            errorMessage = null,
+            notice = null,
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
         gateway = newGateway
+        gatewayGeneration += 1
         observeGateway(newGateway)
-        viewModelScope.launch {
-            runCatching {
-                newGateway.connect()
-                reconcile(newGateway, summary.id)
-            }.onSuccess {
+        val token = captureToken(
+            operation = CelesteOperation.OpenSession,
+            gateway = newGateway,
+            storedSessionId = summary.id,
+            runtimeSessionId = null,
+        )
+        launchOwned(CelesteOperation.OpenSession, token) {
+            try {
+                awaitCurrent(token) { newGateway.connect() }
+                reconcile(newGateway, summary.id, token)
+                if (!isCurrent(token)) return@launchOwned
                 reconnectAttempts = 0
                 mutableState.value = mutableState.value.copy(loadingMessage = null)
-            }.onFailure { error ->
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "open_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
-                    errorMessage = error.message ?: "Could not open that Hermes conversation.",
+                    notice = UiNotice.reconnecting(),
+                    turnState = TurnState.Reconnecting,
+                )
+                scheduleReconnect(wasRunning = false)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "open_session", UiNoticeScope.Session)
+                mutableState.value = mutableState.value.copy(
+                    loadingMessage = null,
+                    notice = UiNotice.reconnecting(),
                     turnState = TurnState.Reconnecting,
                 )
                 scheduleReconnect(wasRunning = false)
@@ -621,8 +990,11 @@ internal class CelesteViewModel(
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
-        val selectedProfile = snapshot.selectedProfile
+        val selectedProfile = normalizedProfile(snapshot.selectedProfile)
+        invalidateContext()
         closeGateway()
+        currentRuntimeSessionId = null
+        currentStoredSessionId = null
         mutableState.value = snapshot.copy(
             activeSummary = null,
             messages = emptyList(),
@@ -630,19 +1002,28 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Synchronizing,
             loadingMessage = "Starting a new $selectedProfile conversation…",
-            errorMessage = null,
+            notice = null,
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
         gateway = newGateway
+        gatewayGeneration += 1
         observeGateway(newGateway)
-        viewModelScope.launch {
-            runCatching {
-                newGateway.connect()
+        val token = captureToken(
+            operation = CelesteOperation.CreateSession,
+            gateway = newGateway,
+            storedSessionId = null,
+            runtimeSessionId = null,
+            profile = selectedProfile,
+        )
+        launchOwned(CelesteOperation.CreateSession, token) {
+            try {
+                awaitCurrent(token) { newGateway.connect() }
+                if (!isCurrent(token)) return@launchOwned
                 reconciling = true
                 bufferedEvents.clear()
-                val created = newGateway.createSession(selectedProfile)
-                if (gateway !== newGateway) throw IOException("The Hermes connection changed while creating the conversation.")
+                val created = awaitCurrent(token) { newGateway.createSession(selectedProfile) }
+                if (!isCurrent(token)) return@launchOwned
                 val returnedProfile = created.profile?.takeIf(String::isNotBlank)
                 if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
                     throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
@@ -657,7 +1038,7 @@ internal class CelesteViewModel(
                     startedAt = 0.0,
                     messageCount = 0,
                     source = "android",
-                    profile = selectedProfile,
+                    profile = returnedProfile ?: selectedProfile,
                 )
                 val events = bufferedEvents.toList()
                 bufferedEvents.clear()
@@ -668,23 +1049,38 @@ internal class CelesteViewModel(
                     activeSummary = summary,
                     turnState = TurnState.Idle,
                     loadingMessage = null,
-                    errorMessage = null,
+                    notice = null,
                 )
                 events.forEach(::applyEvent)
-            }.onSuccess {
                 reconnectAttempts = 0
-            }.onFailure { error ->
-                if (gateway === newGateway) closeGateway()
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                if (!isCurrent(token)) return@launchOwned
+                reconciling = false
+                bufferedEvents.clear()
+                publishFailure(token, error, "create_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
                     loadingMessage = null,
-                    errorMessage = error.message ?: "Could not create a Hermes conversation.",
+                )
+            } catch (error: CancellationException) {
+                reconciling = false
+                bufferedEvents.clear()
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchOwned
+                reconciling = false
+                bufferedEvents.clear()
+                publishFailure(token, error, "create_session", UiNoticeScope.Session)
+                mutableState.value = mutableState.value.copy(
+                    turnState = TurnState.Idle,
+                    loadingMessage = null,
                 )
             }
         }
     }
 
     fun leaveConversation() {
+        invalidateContext()
         closeGateway()
         mutableState.value = mutableState.value.copy(
             activeSummary = null,
@@ -693,7 +1089,7 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Idle,
             loadingMessage = null,
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -701,6 +1097,7 @@ internal class CelesteViewModel(
         val activeGateway = gateway ?: return
         val snapshot = mutableState.value
         val runtimeId = currentRuntimeSessionId ?: return
+        val storedId = currentStoredSessionId ?: snapshot.activeSummary?.id ?: return
         val text = snapshot.draft.trim()
         if (text.isBlank() || snapshot.turnState != TurnState.Idle) return
 
@@ -715,46 +1112,88 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Running,
-            errorMessage = null,
+            notice = null,
         )
         // prompt.submit creates the durable row before work begins. From this point on,
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
-        viewModelScope.launch {
-            runCatching { activeGateway.submitPrompt(runtimeId, text) }
-                .onSuccess {
-                    mutableState.value = mutableState.value.copy(
-                        messages = mutableState.value.messages.map { message ->
-                            if (message.id == localId) message.copy(pending = false) else message
-                        },
-                    )
+        interruptionRequested = false
+        val token = captureToken(
+            operation = CelesteOperation.Send,
+            gateway = activeGateway,
+            storedSessionId = storedId,
+            runtimeSessionId = runtimeId,
+        )
+        launchOwned(CelesteOperation.Send, token) {
+            try {
+                awaitCurrent(token) { activeGateway.submitPrompt(runtimeId, text) }
+                if (!isCurrent(token)) return@launchOwned
+                mutableState.value = mutableState.value.copy(
+                    messages = mutableState.value.messages.map { message ->
+                        if (message.id == localId) message.copy(pending = false) else message
+                    },
+                )
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "send_message", UiNoticeScope.Turn)
+                try {
+                    reconcile(activeGateway, storedId, token)
+                } catch (reconcileError: CancellationException) {
+                    throw reconcileError
+                } catch (reconcileError: Throwable) {
+                    publishFailure(token, reconcileError, "reconcile_after_send", UiNoticeScope.Turn)
                 }
-                .onFailure { error ->
-                    mutableState.value = mutableState.value.copy(
-                        errorMessage = error.message ?: "Hermes could not send that message.",
-                    )
-                    if (gateway === activeGateway) {
-                        runCatching { reconcile(activeGateway, currentStoredSessionId ?: return@launch) }
-                    }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "send_message", UiNoticeScope.Turn)
+                try {
+                    reconcile(activeGateway, storedId, token)
+                } catch (reconcileError: CancellationException) {
+                    throw reconcileError
+                } catch (reconcileError: Throwable) {
+                    publishFailure(token, reconcileError, "reconcile_after_send", UiNoticeScope.Turn)
                 }
+            }
         }
     }
 
     fun interrupt() {
         val activeGateway = gateway ?: return
         val runtimeId = currentRuntimeSessionId ?: return
+        val storedId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
         if (mutableState.value.turnState != TurnState.Running) return
+        ownedJobs.remove(CelesteOperation.Send)?.cancel()
+        activeOperations.remove(CelesteOperation.Send)
+        interruptionRequested = true
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Synchronizing,
-            errorMessage = null,
+            notice = null,
         )
-        viewModelScope.launch {
-            runCatching {
-                activeGateway.interruptSession(runtimeId)
-                reconcile(activeGateway, currentStoredSessionId ?: return@launch)
-            }.onFailure { error ->
+        val token = captureToken(
+            operation = CelesteOperation.Interrupt,
+            gateway = activeGateway,
+            storedSessionId = storedId,
+            runtimeSessionId = runtimeId,
+        )
+        launchOwned(CelesteOperation.Interrupt, token) {
+            try {
+                awaitCurrent(token) { activeGateway.interruptSession(runtimeId) }
+                reconcile(activeGateway, storedId, token)
+                if (!isCurrent(token)) return@launchOwned
+                mutableState.value = mutableState.value.copy(turnState = TurnState.Idle, notice = null)
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "interrupt", UiNoticeScope.Turn)
+                mutableState.value = mutableState.value.copy(turnState = TurnState.Idle)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchOwned
+                publishFailure(token, error, "interrupt", UiNoticeScope.Turn)
                 mutableState.value = mutableState.value.copy(
-                    errorMessage = error.message ?: "Hermes could not stop that turn.",
+                    turnState = TurnState.Idle,
                 )
             }
         }
@@ -762,6 +1201,8 @@ internal class CelesteViewModel(
 
     fun reconnectNow() {
         if (gateway == null || mutableState.value.activeSummary == null) return
+        ownedJobs.remove(CelesteOperation.Reconnect)?.cancel()
+        activeOperations.remove(CelesteOperation.Reconnect)
         reconnectJob?.cancel()
         reconnectJob = null
         reconnectAttempts = 0
@@ -769,18 +1210,34 @@ internal class CelesteViewModel(
     }
 
     fun onBackground() {
+        lifecycleGeneration += 1
+        ownedJobs.remove(CelesteOperation.Foreground)?.cancel()
+        activeOperations.remove(CelesteOperation.Foreground)
+        foregroundCheckJob = null
         val descriptor = currentDescriptor ?: return
         if (descriptor.authMode != SavedAuthMode.ProviderSession) return
         if (credential != GatewayCredential.CookieSession) return
         val refreshed = dashboard.exportAuthentication(descriptor.baseUrl) ?: return
-        val attempt = connectionAttempt
-        viewModelScope.launch {
-            connectionStoreMutex.withLock {
-                if (!isCurrentConnectionAttempt(attempt)) return@withLock
-                if (credential != GatewayCredential.CookieSession || currentDescriptor != descriptor) return@withLock
-                runCatching {
-                    connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
+        val token = captureToken(
+            operation = CelesteOperation.Persistence,
+            gateway = null,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
+        launchOwned(CelesteOperation.Persistence, token) {
+            try {
+                awaitCurrent(token) {
+                    connectionStoreMutex.withLock {
+                        if (credential != GatewayCredential.CookieSession || currentDescriptor != descriptor) {
+                            throw SupersededOperationCancellation()
+                        }
+                        connectionStore.replace(descriptor, ReusableSecret(refreshed.value))
+                    }
                 }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (isCurrent(token)) recordFailure(token, error, "persist_background_auth", UiNoticeScope.Connection)
             }
         }
     }
@@ -793,25 +1250,45 @@ internal class CelesteViewModel(
             reconnectNow()
             return
         }
-        foregroundCheckJob = viewModelScope.launch {
-            val health = runCatching {
-                activeGateway.request(
+        val token = captureToken(
+            operation = CelesteOperation.Foreground,
+            gateway = activeGateway,
+            storedSessionId = storedSessionId,
+            runtimeSessionId = currentRuntimeSessionId,
+        )
+        foregroundCheckJob = launchOwned(CelesteOperation.Foreground, token) {
+            try {
+                awaitCurrent(token) {
+                    activeGateway.request(
                     method = "session.list",
                     params = buildJsonObject { put("limit", 1) },
                     timeoutMillis = 8_000,
                 )
-                if (currentSessionCanResume) reconcile(activeGateway, storedSessionId)
-            }
-            if (health.isFailure && gateway === activeGateway) {
+                }
+                if (currentSessionCanResume) reconcile(activeGateway, storedSessionId, token)
+                if (!isCurrent(token)) return@launchOwned
+            } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                if (!isCurrent(token)) return@launchOwned
                 val wasRunning = mutableState.value.turnState == TurnState.Running
-                activeGateway.close()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
-                    errorMessage = health.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
+                    notice = UiNotice.reconnecting(),
                 )
+                activeGateway.close()
+                scheduleReconnect(wasRunning = wasRunning, immediate = true)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchOwned
+                recordFailure(token, error, "foreground_health", UiNoticeScope.Session)
+                val wasRunning = mutableState.value.turnState == TurnState.Running
+                mutableState.value = mutableState.value.copy(
+                    turnState = TurnState.Reconnecting,
+                    notice = UiNotice.reconnecting(),
+                )
+                activeGateway.close()
                 scheduleReconnect(wasRunning = wasRunning, immediate = true)
             }
-            foregroundCheckJob = null
         }
     }
 
@@ -819,9 +1296,19 @@ internal class CelesteViewModel(
     private var currentStoredSessionId: String? = null
 
     private fun observeGateway(activeGateway: GatewayConnection) {
+        gatewayEventsJob?.cancel()
+        gatewayStateJob?.cancel()
+        gatewayEventsJob = null
+        gatewayStateJob = null
+        val token = captureToken(
+            operation = CelesteOperation.GatewayObserver,
+            gateway = activeGateway,
+            storedSessionId = null,
+            runtimeSessionId = null,
+        )
         gatewayEventsJob = viewModelScope.launch {
             activeGateway.events.collect { event ->
-                if (gateway !== activeGateway) return@collect
+                if (!isCurrent(token)) return@collect
                 if (reconciling) {
                     bufferedEvents += event
                 } else {
@@ -831,12 +1318,12 @@ internal class CelesteViewModel(
         }
         gatewayStateJob = viewModelScope.launch {
             activeGateway.state.collect { connectionState ->
-                if (gateway !== activeGateway) return@collect
+                if (!isCurrent(token)) return@collect
                 if (connectionState is GatewayConnectionState.Disconnected) {
                     val wasRunning = mutableState.value.turnState == TurnState.Running
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
-                        errorMessage = connectionState.reason,
+                        notice = UiNotice.reconnecting(),
                     )
                     scheduleReconnect(wasRunning)
                 }
@@ -844,20 +1331,44 @@ internal class CelesteViewModel(
         }
     }
 
-    private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
+    private suspend fun reconcile(
+        activeGateway: GatewayConnection,
+        storedSessionId: String,
+        token: OperationToken? = null,
+    ) {
+        val owner = token ?: captureToken(
+            operation = CelesteOperation.Reconcile,
+            gateway = activeGateway,
+            storedSessionId = storedSessionId,
+            runtimeSessionId = currentRuntimeSessionId,
+        )
+        if (!isCurrent(owner)) throw SupersededOperationCancellation()
         reconciling = true
         bufferedEvents.clear()
         try {
-            val resumed = activeGateway.resumeStoredSession(storedSessionId)
-            if (gateway !== activeGateway) return
+            val resumed = awaitCurrent(owner) { activeGateway.resumeStoredSession(storedSessionId) }
+            if (!isCurrent(owner)) return
+            if (resumed.storedSessionId != storedSessionId) {
+                throw InvalidDashboardResponse("Hermes resumed a different conversation.")
+            }
             applyResumedSession(resumed)
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false
-            events.forEach(::applyEvent)
+            events.forEach { event ->
+                if (isCurrent(owner)) applyEvent(event)
+            }
+        } catch (error: CancellationException) {
+            if (isCurrent(owner)) {
+                bufferedEvents.clear()
+                reconciling = false
+            }
+            throw error
         } catch (error: Throwable) {
-            bufferedEvents.clear()
-            reconciling = false
+            if (isCurrent(owner)) {
+                bufferedEvents.clear()
+                reconciling = false
+            }
             throw error
         }
     }
@@ -866,6 +1377,7 @@ internal class CelesteViewModel(
         currentRuntimeSessionId = resumed.runtimeSessionId
         currentStoredSessionId = resumed.storedSessionId
         currentSessionCanResume = true
+        if (resumed.running == false) interruptionRequested = false
         val streamingSuffix = unpersistedInflightText(
             inflight = resumed.inflightAssistantText,
             messages = resumed.messages,
@@ -873,12 +1385,12 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             messages = resumed.messages,
             streamingText = streamingSuffix,
-            turnState = if (resumed.running == true || resumed.hasLiveProjection) {
-                TurnState.Running
-            } else {
-                TurnState.Idle
+            turnState = when (resumed.running) {
+                true -> TurnState.Running
+                false -> TurnState.Idle
+                null -> if (resumed.hasLiveProjection) TurnState.Running else TurnState.Idle
             },
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -887,15 +1399,17 @@ internal class CelesteViewModel(
         if (event.sessionId.isNotBlank() && event.sessionId != runtimeId) return
         when (event.type) {
             "message.start" -> {
+                if (interruptionRequested) return
                 if (mutableState.value.streamingText.isNotBlank()) finalizeAssistant()
                 mutableState.value = mutableState.value.copy(
                     streamingText = "",
                     turnState = TurnState.Running,
-                    errorMessage = null,
+                    notice = null,
                 )
             }
 
             "message.delta" -> {
+                if (interruptionRequested) return
                 val delta = event.payload.string("text").orEmpty()
                 if (delta.isNotEmpty()) {
                     mutableState.value = mutableState.value.copy(
@@ -906,6 +1420,7 @@ internal class CelesteViewModel(
             }
 
             "message.interim" -> {
+                if (interruptionRequested) return
                 val text = event.payload.string("text").orEmpty()
                 val alreadyStreamed = event.payload.boolean("already_streamed") == true
                 if (alreadyStreamed && mutableState.value.streamingText.isNotBlank()) {
@@ -920,43 +1435,54 @@ internal class CelesteViewModel(
             }
 
             "message.complete" -> {
+                if (interruptionRequested) return
                 val status = event.payload.string("status")
                 val content = event.payload.string("text")
                     ?: event.payload.string("content")
                     ?: event.payload.string("rendered")
                     ?: ""
-                finalizeAssistant(content, keepRunning = false)
+                finalizeAssistant(
+                    suppliedContent = if (status == "error") "" else content,
+                    keepRunning = false,
+                )
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = if (status == "error") {
-                        event.payload.string("error") ?: "Hermes could not finish that response."
+                    notice = if (status == "error") {
+                        UiNotice.serverTurnFailure()
                     } else {
-                        mutableState.value.errorMessage
+                        mutableState.value.notice
                     },
                 )
             }
 
             "error", "message.error" -> {
+                if (interruptionRequested) return
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = event.payload.string("message") ?: "Hermes reported an error.",
+                    notice = UiNotice.genericTurnFailure(),
                 )
             }
 
             "message.interrupted", "session.interrupted" -> {
+                interruptionRequested = false
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(turnState = TurnState.Idle)
             }
 
             "session.busy" -> {
+                val busy = event.payload.boolean("busy") == true
+                if (busy && interruptionRequested) return
+                if (!busy) interruptionRequested = false
                 mutableState.value = mutableState.value.copy(
-                    turnState = if (event.payload.boolean("busy") == true) TurnState.Running else TurnState.Idle,
+                    turnState = if (busy) TurnState.Running else TurnState.Idle,
                 )
             }
 
             "session.info" -> {
                 event.payload.boolean("running")?.let { running ->
+                    if (running && interruptionRequested) return
+                    if (!running) interruptionRequested = false
                     mutableState.value = mutableState.value.copy(
                         turnState = if (running) TurnState.Running else TurnState.Idle,
                     )
@@ -964,6 +1490,7 @@ internal class CelesteViewModel(
             }
 
             "tool.start", "tool_call" -> {
+                if (interruptionRequested) return
                 if (mutableState.value.streamingText.isNotBlank()) finalizeAssistant(keepRunning = true)
                 val name = event.payload.string("name") ?: "Tool"
                 val input = event.payload.string("args_text")
@@ -982,6 +1509,7 @@ internal class CelesteViewModel(
             }
 
             "tool.complete", "tool_result" -> {
+                if (interruptionRequested) return
                 val name = event.payload.string("name") ?: "Tool"
                 val output = event.payload.string("output")
                     ?: event.payload["result"]?.toString().orEmpty()
@@ -1042,33 +1570,46 @@ internal class CelesteViewModel(
     private suspend fun recreateBlankSession(
         activeGateway: GatewayConnection,
         profile: String,
+        token: OperationToken,
     ) {
+        if (!isCurrent(token)) throw SupersededOperationCancellation()
         val previousStoredId = currentStoredSessionId
         reconciling = true
         bufferedEvents.clear()
         try {
-            val created = activeGateway.createSession(profile)
-            if (gateway !== activeGateway) return
+            val created = awaitCurrent(token) { activeGateway.createSession(normalizedProfile(profile)) }
+            if (!isCurrent(token)) return
             currentRuntimeSessionId = created.runtimeSessionId
             currentStoredSessionId = created.storedSessionId
             val previousSummary = mutableState.value.activeSummary
                 ?: throw IOException("No draft conversation is open.")
-            val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
+            val updatedSummary = previousSummary.copy(
+                id = created.storedSessionId,
+                profile = created.profile?.takeIf(String::isNotBlank) ?: normalizedProfile(profile),
+            )
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
                 sessions = mutableState.value.sessions?.map { session ->
                     if (session.id == previousStoredId) updatedSummary else session
                 },
                 turnState = TurnState.Idle,
-                errorMessage = null,
+                notice = null,
             )
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false
-            events.forEach(::applyEvent)
+            events.forEach { event -> if (isCurrent(token)) applyEvent(event) }
+        } catch (error: CancellationException) {
+            if (isCurrent(token)) {
+                bufferedEvents.clear()
+                reconciling = false
+            }
+            throw error
         } catch (error: Throwable) {
-            bufferedEvents.clear()
-            reconciling = false
+            if (isCurrent(token)) {
+                bufferedEvents.clear()
+                reconciling = false
+            }
             throw error
         }
     }
@@ -1077,67 +1618,103 @@ internal class CelesteViewModel(
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
         if (reconnectJob?.isActive == true) return
-        mutableState.value = mutableState.value.copy(turnState = TurnState.Reconnecting)
-        reconnectJob = viewModelScope.launch {
-            while (gateway === activeGateway) {
+        val token = captureToken(
+            operation = CelesteOperation.Reconnect,
+            gateway = activeGateway,
+            storedSessionId = storedSessionId,
+            runtimeSessionId = currentRuntimeSessionId,
+        )
+        mutableState.value = mutableState.value.copy(
+            turnState = TurnState.Reconnecting,
+            notice = UiNotice.reconnecting(),
+        )
+        reconnectJob = launchOwned(CelesteOperation.Reconnect, token) {
+            try {
+                while (gateway === activeGateway && isCurrent(token) && reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
                 val delayMillis = if (immediate && reconnectAttempts == 0) {
                     0L
                 } else {
                     reconnectDelayMillis(reconnectAttempts, wasRunning)
                 }
                 if (delayMillis > 0) delay(delayMillis)
-                val result = runCatching {
-                    activeGateway.connect()
-                    if (currentSessionCanResume) {
-                        reconcile(activeGateway, storedSessionId)
-                    } else {
-                        recreateBlankSession(activeGateway, mutableState.value.selectedProfile)
+                    if (!isCurrent(token)) return@launchOwned
+                    try {
+                        awaitCurrent(token) { activeGateway.connect() }
+                        if (currentSessionCanResume) {
+                            reconcile(activeGateway, storedSessionId, token)
+                        } else {
+                            recreateBlankSession(activeGateway, mutableState.value.selectedProfile, token)
+                        }
+                        if (!isCurrent(token)) return@launchOwned
+                        reconnectAttempts = 0
+                        mutableState.value = mutableState.value.copy(notice = null)
+                        return@launchOwned
+                    } catch (error: kotlinx.coroutines.TimeoutCancellationException) {
+                        if (!isCurrent(token)) return@launchOwned
+                        recordFailure(token, error, "reconnect", UiNoticeScope.Session)
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Throwable) {
+                        if (!isCurrent(token)) return@launchOwned
+                        if (error is AuthenticationRejected) {
+                            val descriptor = currentDescriptor
+                            recordFailure(token, error, "reconnect", UiNoticeScope.Connection)
+                            invalidateReusableAuthentication(descriptor, token = token)
+                            closeGateway()
+                            return@launchOwned
+                        }
+                        recordFailure(token, error, "reconnect", UiNoticeScope.Session)
                     }
-                }
-                if (result.isSuccess) {
-                    reconnectAttempts = 0
-                    reconnectJob = null
-                    return@launch
-                }
-                val failure = result.exceptionOrNull()
-                if (failure is AuthenticationRejected) {
-                    val descriptor = currentDescriptor
-                    reconnectJob = null
-                    closeGateway()
-                    invalidateReusableAuthentication(descriptor)
-                    return@launch
-                }
                 reconnectAttempts += 1
-                mutableState.value = mutableState.value.copy(
-                    turnState = TurnState.Reconnecting,
-                    errorMessage = failure?.message ?: "Reconnecting to Hermes…",
-                )
+                    if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+                        val lastFailure = mutableState.value.notice
+                        mutableState.value = mutableState.value.copy(
+                            turnState = TurnState.Reconnecting,
+                            notice = if (lastFailure?.category == UiNoticeCategory.RateLimited) {
+                                lastFailure
+                            } else {
+                                UiNotice.unavailable()
+                            },
+                        )
+                        return@launchOwned
+                    }
+                    mutableState.value = mutableState.value.copy(
+                        turnState = TurnState.Reconnecting,
+                        notice = UiNotice.reconnecting(),
+                    )
+                }
+            } finally {
+                if (ownedJobs[CelesteOperation.Reconnect] == null || !isCurrent(token)) {
+                    reconnectJob = null
+                }
             }
-            reconnectJob = null
         }
     }
 
     private fun closeGateway() {
         val activeGateway = gateway
-        gateway = null
-        reconnectJob?.cancel()
-        reconnectJob = null
-        foregroundCheckJob?.cancel()
-        foregroundCheckJob = null
         gatewayEventsJob?.cancel()
-        gatewayEventsJob = null
         gatewayStateJob?.cancel()
+        gatewayEventsJob = null
+        gatewayStateJob = null
+        gatewayGeneration += 1
+        cancelGatewayOperations()
+        gateway = null
+        reconnectJob = null
+        foregroundCheckJob = null
+        gatewayEventsJob = null
         gatewayStateJob = null
         reconciling = false
         bufferedEvents.clear()
         currentRuntimeSessionId = null
         currentStoredSessionId = null
         currentSessionCanResume = true
+        interruptionRequested = false
         activeGateway?.close()
     }
 
     override fun onCleared() {
-        connectionJob?.cancel()
+        invalidateContext()
         connectionJob = null
         closeGateway()
         dashboard.clearAuthentication()
@@ -1145,6 +1722,8 @@ internal class CelesteViewModel(
     }
 
     companion object {
+        private const val MAX_RECONNECT_ATTEMPTS = 3
+
         internal fun unpersistedInflightText(
             inflight: String,
             messages: List<ConversationMessage>,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -416,6 +416,14 @@ internal class CelesteViewModel(
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                if (isAuthenticationFailure(error)) {
+                    invalidateReusableAuthentication(
+                        descriptor = currentDescriptor,
+                        probe = connection,
+                        token = token,
+                    )
+                    return@launchOwned
+                }
                 publishFailure(token, error, "select_profile", UiNoticeScope.Connection)
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
@@ -582,7 +590,7 @@ internal class CelesteViewModel(
                 if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return@launchOwned
                 dashboard.clearAuthentication()
                 credential = null
-                if (error is AuthenticationRejected) {
+                if (isAuthenticationFailure(error)) {
                     currentAuthMode = null
                     connectionStoreMutex.withLock {
                         if (isCurrent(token)) {
@@ -904,7 +912,7 @@ internal class CelesteViewModel(
             throw error
         } catch (error: Throwable) {
             if (!isCurrentConnectionAttempt(attempt) || !isCurrent(token)) return
-            if (error is AuthenticationRejected) {
+            if (isAuthenticationFailure(error)) {
                 credential = null
                 currentDescriptor = null
                 dashboard.clearAuthentication()
@@ -952,6 +960,10 @@ internal class CelesteViewModel(
         probe: DashboardProbeResult? = null,
         token: OperationToken? = null,
     ) {
+        val snapshot = mutableState.value
+        val safeBaseUrl = descriptor?.baseUrl ?: probe?.baseUrl ?: snapshot.dashboardUrl
+        val safeUsername = descriptor?.username ?: snapshot.username
+        val safeProbe = probe ?: snapshot.probe
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
@@ -964,11 +976,16 @@ internal class CelesteViewModel(
                 }
             }
         }
+        currentAuthMode = null
         mutableState.value = manualState(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
-            probe = probe,
+            probe = safeProbe,
             notice = UiNotice.authentication(),
+        ).copy(
+            dashboardUrl = safeBaseUrl,
+            savedAuthMode = descriptor?.authMode ?: snapshot.savedAuthMode,
+            username = safeUsername,
         )
     }
 
@@ -1076,6 +1093,16 @@ internal class CelesteViewModel(
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                if (isAuthenticationFailure(error)) {
+                    val descriptor = currentDescriptor
+                    invalidateReusableAuthentication(
+                        descriptor = descriptor,
+                        probe = connection,
+                        token = token,
+                    )
+                    closeGateway()
+                    return@launchOwned
+                }
                 val failureNotice = projectUiNotice(error, UiNoticeScope.Session)
                 publishFailure(token, error, "open_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
@@ -1164,6 +1191,16 @@ internal class CelesteViewModel(
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                if (isAuthenticationFailure(error)) {
+                    val descriptor = currentDescriptor
+                    invalidateReusableAuthentication(
+                        descriptor = descriptor,
+                        probe = connection,
+                        token = token,
+                    )
+                    closeGateway()
+                    return@launchOwned
+                }
                 publishFailure(token, error, "create_session", UiNoticeScope.Session)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
@@ -1239,18 +1276,48 @@ internal class CelesteViewModel(
                 } catch (reconcileError: CancellationException) {
                     throw reconcileError
                 } catch (reconcileError: Throwable) {
+                    if (isAuthenticationFailure(reconcileError)) {
+                        val descriptor = currentDescriptor
+                        invalidateReusableAuthentication(
+                            descriptor = descriptor,
+                            probe = mutableState.value.probe,
+                            token = token,
+                        )
+                        closeGateway()
+                        return@launchOwned
+                    }
                     publishFailure(token, reconcileError, "reconcile_after_send", UiNoticeScope.Turn)
                 }
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                if (isAuthenticationFailure(error)) {
+                    val descriptor = currentDescriptor
+                    invalidateReusableAuthentication(
+                        descriptor = descriptor,
+                        probe = mutableState.value.probe,
+                        token = token,
+                    )
+                    closeGateway()
+                    return@launchOwned
+                }
                 publishFailure(token, error, "send_message", UiNoticeScope.Turn)
                 try {
                     reconcile(activeGateway, storedId, token)
                 } catch (reconcileError: CancellationException) {
                     throw reconcileError
                 } catch (reconcileError: Throwable) {
+                    if (isAuthenticationFailure(reconcileError)) {
+                        val descriptor = currentDescriptor
+                        invalidateReusableAuthentication(
+                            descriptor = descriptor,
+                            probe = mutableState.value.probe,
+                            token = token,
+                        )
+                        closeGateway()
+                        return@launchOwned
+                    }
                     publishFailure(token, reconcileError, "reconcile_after_send", UiNoticeScope.Turn)
                 }
             }
@@ -1291,6 +1358,16 @@ internal class CelesteViewModel(
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                if (isAuthenticationFailure(error)) {
+                    val descriptor = currentDescriptor
+                    invalidateReusableAuthentication(
+                        descriptor = descriptor,
+                        probe = mutableState.value.probe,
+                        token = token,
+                    )
+                    closeGateway()
+                    return@launchOwned
+                }
                 publishFailure(token, error, "interrupt", UiNoticeScope.Turn)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
@@ -1396,6 +1473,16 @@ internal class CelesteViewModel(
                 throw error
             } catch (error: Throwable) {
                 if (!isCurrent(token)) return@launchOwned
+                if (isAuthenticationFailure(error)) {
+                    val descriptor = currentDescriptor
+                    invalidateReusableAuthentication(
+                        descriptor = descriptor,
+                        probe = mutableState.value.probe,
+                        token = token,
+                    )
+                    closeGateway()
+                    return@launchOwned
+                }
                 recordFailure(token, error, "foreground_health", UiNoticeScope.Session)
                 val wasRunning = mutableState.value.turnState == TurnState.Running
                 mutableState.value = mutableState.value.copy(
@@ -1476,6 +1563,9 @@ internal class CelesteViewModel(
             if (!isCurrent(owner)) throw SupersededOperationCancellation()
             if (resumed.storedSessionId != storedSessionId) {
                 throw InvalidDashboardResponse("Hermes resumed a different conversation.")
+            }
+            if (activeReconciliationEpoch != epoch || !isCurrent(owner)) {
+                throw SupersededOperationCancellation()
             }
             applyResumedSession(resumed)
             replayBufferedEvents(epoch, owner)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
@@ -129,7 +129,16 @@ internal fun projectUiNotice(error: Throwable, scope: UiNoticeScope): UiNotice? 
         is dev.hazydreams.hermesceleste.network.RateLimited -> UiNotice.rateLimited(scope)
         is dev.hazydreams.hermesceleste.network.InvalidDashboardResponse -> UiNotice.invalidResponse(scope)
         is dev.hazydreams.hermesceleste.network.TransportUnavailable -> UiNotice.unavailable(scope)
-        is dev.hazydreams.hermesceleste.network.GatewayRpcException -> UiNotice.genericTurnFailure()
+        is dev.hazydreams.hermesceleste.network.GatewayRpcException -> when (error.code) {
+            401, 403 -> UiNotice.authentication(scope)
+            429 -> UiNotice.rateLimited(scope)
+            -32600, -32601, -32602, -32603 -> UiNotice.invalidResponse(scope)
+            else -> if (scope == UiNoticeScope.Turn) {
+                UiNotice.genericTurnFailure()
+            } else {
+                UiNotice.invalidResponse(scope)
+            }
+        }
         else -> if (scope == UiNoticeScope.Turn) UiNotice.genericTurnFailure() else UiNotice.unavailable(scope)
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
@@ -1,0 +1,194 @@
+package dev.hazydreams.hermesceleste
+
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.serialization.Serializable
+
+/**
+ * Product-facing recovery categories. These values, rather than exception text,
+ * are the contract between application state and Compose.
+ */
+internal enum class UiNoticeCategory {
+    AuthenticationRequired,
+    RateLimited,
+    Reconnecting,
+    TransportUnavailable,
+    InvalidResponse,
+    ServerTurnFailure,
+    GenericTurnFailure,
+    Persistence,
+}
+
+internal enum class UiNoticeScope {
+    Connection,
+    Session,
+    Turn,
+}
+
+internal enum class UiRecoveryAction {
+    None,
+    Retry,
+    SignIn,
+}
+
+internal data class UiNotice(
+    val category: UiNoticeCategory,
+    val copyKey: String,
+    val recovery: UiRecoveryAction,
+    val scope: UiNoticeScope,
+) {
+    /** Stable, catalogued product copy. No server or exception text enters here. */
+    val message: String
+        get() = copyFor(copyKey)
+
+    val recoveryLabel: String?
+        get() = when (recovery) {
+            UiRecoveryAction.None -> null
+            UiRecoveryAction.Retry -> "Retry"
+            UiRecoveryAction.SignIn -> "Sign in"
+        }
+
+    companion object {
+        fun authentication(scope: UiNoticeScope = UiNoticeScope.Connection) = UiNotice(
+            category = UiNoticeCategory.AuthenticationRequired,
+            copyKey = "authentication_required",
+            recovery = UiRecoveryAction.SignIn,
+            scope = scope,
+        )
+
+        fun rateLimited(scope: UiNoticeScope = UiNoticeScope.Connection) = UiNotice(
+            category = UiNoticeCategory.RateLimited,
+            copyKey = "rate_limited",
+            recovery = UiRecoveryAction.Retry,
+            scope = scope,
+        )
+
+        fun reconnecting(scope: UiNoticeScope = UiNoticeScope.Session) = UiNotice(
+            category = UiNoticeCategory.Reconnecting,
+            copyKey = "reconnecting",
+            recovery = UiRecoveryAction.None,
+            scope = scope,
+        )
+
+        fun unavailable(scope: UiNoticeScope = UiNoticeScope.Session) = UiNotice(
+            category = UiNoticeCategory.TransportUnavailable,
+            copyKey = "transport_unavailable",
+            recovery = UiRecoveryAction.Retry,
+            scope = scope,
+        )
+
+        fun invalidResponse(scope: UiNoticeScope = UiNoticeScope.Connection) = UiNotice(
+            category = UiNoticeCategory.InvalidResponse,
+            copyKey = "invalid_response",
+            recovery = UiRecoveryAction.Retry,
+            scope = scope,
+        )
+
+        fun serverTurnFailure() = UiNotice(
+            category = UiNoticeCategory.ServerTurnFailure,
+            copyKey = "server_turn_failure",
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Turn,
+        )
+
+        fun genericTurnFailure() = UiNotice(
+            category = UiNoticeCategory.GenericTurnFailure,
+            copyKey = "generic_turn_failure",
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Turn,
+        )
+
+        fun persistence() = UiNotice(
+            category = UiNoticeCategory.Persistence,
+            copyKey = "persistence_warning",
+            recovery = UiRecoveryAction.None,
+            scope = UiNoticeScope.Connection,
+        )
+    }
+}
+
+private fun copyFor(copyKey: String): String = when (copyKey) {
+    "authentication_required" -> "Your Hermes sign-in has expired. Sign in again."
+    "rate_limited" -> "Hermes is busy right now. Try again shortly."
+    "reconnecting" -> "Reconnecting to Hermes…"
+    "transport_unavailable" -> "Hermes is unavailable right now. Try again."
+    "invalid_response" -> "Hermes returned an unexpected response. Try again."
+    "server_turn_failure" -> "Hermes couldn’t finish that response."
+    "generic_turn_failure" -> "Hermes reported an error. Try again."
+    "persistence_warning" -> "Connected, but Celeste could not remember this connection."
+    else -> "Hermes could not complete that action. Try again."
+}
+
+internal fun projectUiNotice(error: Throwable, scope: UiNoticeScope): UiNotice? {
+    if (isExpectedCancellation(error)) return null
+    if (containsTimeoutCancellation(error)) return UiNotice.unavailable(scope)
+    return when (error) {
+        is dev.hazydreams.hermesceleste.network.AuthenticationRejected -> UiNotice.authentication(scope)
+        is dev.hazydreams.hermesceleste.network.RateLimited -> UiNotice.rateLimited(scope)
+        is dev.hazydreams.hermesceleste.network.InvalidDashboardResponse -> UiNotice.invalidResponse(scope)
+        is dev.hazydreams.hermesceleste.network.TransportUnavailable -> UiNotice.unavailable(scope)
+        is dev.hazydreams.hermesceleste.network.GatewayRpcException -> UiNotice.genericTurnFailure()
+        else -> if (scope == UiNoticeScope.Turn) UiNotice.genericTurnFailure() else UiNotice.unavailable(scope)
+    }
+}
+/**
+ * Cancellation is structural control flow. A wrapped cancellation is also
+ * silent at the UI boundary; only an intentionally-created timeout is a
+ * current operation failure.
+ */
+internal fun isExpectedCancellation(error: Throwable): Boolean {
+    if (containsTimeoutCancellation(error)) return false
+    return findCause(error) { it is CancellationException } != null
+}
+
+private fun containsTimeoutCancellation(error: Throwable): Boolean =
+    findCause(error) { it is TimeoutCancellationException } != null
+
+private fun findCause(error: Throwable, predicate: (Throwable) -> Boolean): Throwable? {
+    val seen: MutableSet<Throwable> =
+        Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
+    var current: Throwable? = error
+    while (current != null && seen.add(current)) {
+        if (predicate(current)) return current
+        current = current.cause
+    }
+    return null
+}
+
+/** A content-free record suitable for a diagnostics sink or forced-redaction export. */
+@Serializable
+internal data class SanitizedDiagnostic(
+    val category: String,
+    val reasonCode: String,
+    val operation: String,
+    val exceptionClass: String? = null,
+    val operationGeneration: Long? = null,
+    val gatewayGeneration: Long? = null,
+    val lifecycleGeneration: Long? = null,
+    val retryCount: Int = 0,
+)
+
+internal fun interface DiagnosticsSink {
+    fun record(diagnostic: SanitizedDiagnostic)
+}
+
+internal object NoopDiagnosticsSink : DiagnosticsSink {
+    override fun record(diagnostic: SanitizedDiagnostic) = Unit
+}
+
+internal fun diagnosticReason(error: Throwable): String = when {
+    isExpectedCancellation(error) -> "cancelled"
+    containsTimeoutCancellation(error) -> "timeout"
+    error is dev.hazydreams.hermesceleste.network.AuthenticationRejected -> "authentication_rejected"
+    error is dev.hazydreams.hermesceleste.network.RateLimited -> "rate_limited"
+    error is dev.hazydreams.hermesceleste.network.InvalidDashboardResponse -> "invalid_response"
+    error is dev.hazydreams.hermesceleste.network.TransportUnavailable -> "transport_unavailable"
+    error is dev.hazydreams.hermesceleste.network.GatewayRpcException -> "rpc_failure"
+    error is TimeoutCancellationException -> "timeout"
+    else -> "unexpected_failure"
+}
+
+internal fun diagnosticCategory(error: Throwable, scope: UiNoticeScope): String =
+    projectUiNotice(error, scope)?.category?.name ?: "control_flow"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
@@ -106,6 +106,13 @@ internal data class UiNotice(
             recovery = UiRecoveryAction.None,
             scope = UiNoticeScope.Connection,
         )
+
+        fun localCleanup() = UiNotice(
+            category = UiNoticeCategory.Persistence,
+            copyKey = "local_cleanup_pending",
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Connection,
+        )
     }
 }
 
@@ -118,6 +125,7 @@ private fun copyFor(copyKey: String): String = when (copyKey) {
     "server_turn_failure" -> "Hermes couldn’t finish that response."
     "generic_turn_failure" -> "Hermes reported an error. Try again."
     "persistence_warning" -> "Connected, but Celeste could not remember this connection."
+    "local_cleanup_pending" -> "Celeste could not finish clearing this saved sign-in. Try again."
     else -> "Hermes could not complete that action. Try again."
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -630,7 +630,8 @@ class DashboardClient(
                     }
                 if ((root["id"] as? JsonPrimitive)?.contentOrNull != expectedId) return
                 (root["error"] as? JsonObject)?.let { error ->
-                    fail(IOException((error["message"] as? JsonPrimitive)?.contentOrNull ?: "$operation failed."))
+                    val code = (error["code"] as? JsonPrimitive)?.intOrNull
+                    fail(GatewayRpcException(code, "$operation returned a JSON-RPC error."))
                     return
                 }
                 val result = root["result"]

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -27,6 +28,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
@@ -374,9 +377,11 @@ class DashboardClient(
             .post(ByteArray(0).toRequestBody(null))
             .build()
         try {
-            httpClient.newCall(request).execute().use { response ->
+            executeHttp(request).use { response ->
                 if (response.code !in 200..399) throw failureFor(response.code, "Hermes sign-out")
             }
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: DashboardFailure) {
             throw error
         } catch (error: IOException) {
@@ -444,7 +449,7 @@ class DashboardClient(
         }
     }
 
-    private fun fetchProviders(baseUrl: String): List<AuthProvider> {
+    private suspend fun fetchProviders(baseUrl: String): List<AuthProvider> {
         val root = executeJson(
             Request.Builder()
                 .url("$baseUrl/api/auth/providers")
@@ -462,7 +467,7 @@ class DashboardClient(
             .getOrElse { throw IOException("Hermes authentication providers could not be read.") }
     }
 
-    private fun mintWebSocketTicket(baseUrl: String): String {
+    private suspend fun mintWebSocketTicket(baseUrl: String): String {
         val root = executeJson(
             Request.Builder()
                 .url("$baseUrl/api/auth/ws-ticket")
@@ -476,18 +481,50 @@ class DashboardClient(
             ?: throw IOException("Hermes did not return a WebSocket ticket.")
     }
 
-    private fun executeJson(request: Request, operation: String) = try {
-        httpClient.newCall(request).execute().use { response ->
+    private suspend fun executeJson(request: Request, operation: String) = try {
+        executeHttp(request).use { response ->
             if (!response.isSuccessful) throw failureFor(response.code, operation)
             val body = response.body.string()
             runCatching { json.parseToJsonElement(body) }
                 .getOrElse { throw InvalidDashboardResponse("$operation returned an unreadable response.", it) }
         }
+    } catch (error: CancellationException) {
+        throw error
     } catch (error: DashboardFailure) {
         throw error
     } catch (error: IOException) {
         throw TransportUnavailable("Could not reach Hermes for $operation.", error)
     }
+
+    /**
+     * OkHttp's blocking execute does not reliably observe coroutine cancellation.
+     * Keep the call cancellable so parent/job cancellation reaches the socket and
+     * remains CancellationException rather than becoming a dashboard failure.
+     */
+    private suspend fun executeHttp(request: Request): Response =
+        suspendCancellableCoroutine { continuation ->
+            val call = httpClient.newCall(request)
+            val completed = AtomicBoolean(false)
+            continuation.invokeOnCancellation {
+                if (completed.compareAndSet(false, true)) call.cancel()
+            }
+            call.enqueue(object : Callback {
+                override fun onFailure(call: Call, error: IOException) {
+                    if (completed.compareAndSet(false, true)) {
+                        continuation.resumeWithException(error)
+                    }
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (completed.compareAndSet(false, true)) {
+                        continuation.resume(response)
+                    } else {
+                        response.close()
+                    }
+                }
+            })
+        }
+
 
     private fun failureFor(code: Int, operation: String): DashboardFailure = when (code) {
         401, 403 -> AuthenticationRejected("$operation needs sign-in.")

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -4,6 +4,8 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -102,10 +104,10 @@ class HermesGateway(
 
         val endpoint = try {
             endpointProvider()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
-            mutableState.value = GatewayConnectionState.Disconnected(
-                error.message ?: "Could not refresh the Hermes connection.",
-            )
+            mutableState.value = GatewayConnectionState.Disconnected(connectionFailureReason(error))
             throw error
         }
 
@@ -145,22 +147,20 @@ class HermesGateway(
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 if (generation != socketGeneration.get()) return
                 handleDisconnect(
-                    reason = reason.ifBlank { "Hermes closed the connection ($code)." },
+                    reason = "Hermes connection closed.",
                     opened = opened,
+                    error = TransportUnavailable("Hermes connection closed before a response was received."),
                 )
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 if (generation != socketGeneration.get()) return
-                val reason = when (response?.code) {
-                    401, 403 -> "Hermes rejected the dashboard credential."
-                    else -> t.message ?: "The Hermes connection failed."
-                }
                 val error = when (response?.code) {
-                    401, 403 -> AuthenticationRejected(reason)
-                    else -> IOException(reason, t)
+                    401, 403 -> AuthenticationRejected("Hermes rejected the dashboard credential.")
+                    429 -> RateLimited("Hermes rate-limited the dashboard connection.")
+                    else -> TransportUnavailable("Could not open the Hermes connection.", t)
                 }
-                handleDisconnect(reason, opened, error)
+                handleDisconnect(connectionFailureReason(error), opened, error)
             }
         }
 
@@ -168,13 +168,26 @@ class HermesGateway(
         socket = candidate
         try {
             withTimeout(connectTimeoutMillis) { opened.await() }
+        } catch (error: CancellationException) {
+            if (socket === candidate) {
+                candidate.cancel()
+                socket = null
+                if (error is TimeoutCancellationException &&
+                    mutableState.value !is GatewayConnectionState.Disconnected
+                ) {
+                    mutableState.value = GatewayConnectionState.Disconnected(
+                        "Hermes did not finish connecting.",
+                    )
+                }
+            }
+            throw error
         } catch (error: Throwable) {
             if (socket === candidate) {
                 candidate.cancel()
                 socket = null
                 if (mutableState.value !is GatewayConnectionState.Disconnected) {
                     mutableState.value = GatewayConnectionState.Disconnected(
-                        error.message ?: "Hermes did not finish connecting.",
+                        connectionFailureReason(error),
                     )
                 }
             }
@@ -222,6 +235,15 @@ class HermesGateway(
         mutableState.value = GatewayConnectionState.Closed
         failPending(IOException("Hermes connection closed."))
         active?.close(1000, "Celeste closed the connection")
+    }
+
+    private fun connectionFailureReason(error: Throwable): String = when (error) {
+        is AuthenticationRejected -> "Hermes rejected the dashboard credential."
+        is RateLimited -> "Hermes is busy right now."
+        is InvalidDashboardResponse -> "Hermes returned an unexpected response."
+        is TransportUnavailable -> "Hermes is unavailable right now."
+        is TimeoutCancellationException -> "Hermes did not finish connecting."
+        else -> "The Hermes connection failed."
     }
 
     private fun handleFrame(root: JsonObject) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -255,8 +255,7 @@ class HermesGateway(
                 deferred.completeExceptionally(
                     GatewayRpcException(
                         code = error["code"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
-                        message = error["message"]?.jsonPrimitive?.contentOrNull
-                            ?: "Hermes request failed.",
+                        message = "Hermes returned a JSON-RPC error.",
                     ),
                 )
             } else {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -162,6 +162,7 @@ private fun GatewaySettingsRoute(
             connectionPhase = ui.connectionPhase,
             loadingMessage = ui.loadingMessage,
             notice = ui.notice,
+            localCleanupNotice = ui.localCleanupNotice,
         ),
         actions = GatewaySettingsActions(
             onUsernameChange = viewModel::updateUsername,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.CelesteUiState
 import dev.hazydreams.hermesceleste.CelesteViewModel
 import dev.hazydreams.hermesceleste.ConnectionPhase
+import dev.hazydreams.hermesceleste.UiRecoveryAction
 import dev.hazydreams.hermesceleste.ui.conversation.ConversationScreen
 import dev.hazydreams.hermesceleste.ui.gateway.ConnectionLoadingScreen
 import dev.hazydreams.hermesceleste.ui.gateway.ConnectionUnavailableScreen
@@ -93,6 +94,13 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     onSend = viewModel::sendMessage,
                     onInterrupt = viewModel::interrupt,
                     onReconnect = viewModel::reconnectNow,
+                    onNoticeAction = {
+                        if (ui.notice?.recovery == UiRecoveryAction.SignIn) {
+                            destination = CelesteDestination.Gateway
+                        } else {
+                            viewModel.reconnectNow()
+                        }
+                    },
                     onBack = viewModel::leaveConversation,
                 )
             }
@@ -107,6 +115,13 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,
                 onRetry = viewModel::loadSessions,
+                onNoticeAction = {
+                    when (ui.notice?.recovery) {
+                        UiRecoveryAction.SignIn -> destination = CelesteDestination.Gateway
+                        UiRecoveryAction.Retry -> viewModel.loadSessions()
+                        UiRecoveryAction.None, null -> Unit
+                    }
+                },
                 onSettings = { destination = CelesteDestination.Settings },
             )
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -86,7 +88,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     draft = ui.draft,
                     turnState = ui.turnState,
                     loadingMessage = ui.loadingMessage,
-                    errorMessage = ui.errorMessage,
+                    notice = ui.notice,
                     onDraftChange = viewModel::updateDraft,
                     onSend = viewModel::sendMessage,
                     onInterrupt = viewModel::interrupt,
@@ -100,10 +102,11 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 profiles = ui.profiles,
                 selectedProfile = ui.selectedProfile,
                 loadingMessage = ui.loadingMessage,
-                errorMessage = ui.errorMessage,
+                notice = ui.notice,
                 onProfileSelected = viewModel::selectProfile,
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,
+                onRetry = viewModel::loadSessions,
                 onSettings = { destination = CelesteDestination.Settings },
             )
 
@@ -111,7 +114,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 ui.connectionPhase == ConnectionPhase.Restoring -> ConnectionLoadingScreen()
 
             ui.connectionPhase == ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(
-                errorMessage = ui.errorMessage,
+                notice = ui.notice,
                 onRetry = viewModel::retrySavedConnection,
                 onSettings = { destination = CelesteDestination.Gateway },
             )
@@ -143,7 +146,7 @@ private fun GatewaySettingsRoute(
             sessionToken = ui.sessionToken,
             connectionPhase = ui.connectionPhase,
             loadingMessage = ui.loadingMessage,
-            errorMessage = ui.errorMessage,
+            notice = ui.notice,
         ),
         actions = GatewaySettingsActions(
             onUsernameChange = viewModel::updateUsername,
@@ -284,6 +287,7 @@ internal fun EditorialDivider(modifier: Modifier = Modifier) {
 @Composable
 internal fun StatusMessage(message: String, color: Color, showSpinner: Boolean = false) {
     Row(
+        modifier = Modifier.semantics { stateDescription = message },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(9.dp),
     ) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -77,6 +77,7 @@ internal fun ConversationScreen(
     onSend: () -> Unit,
     onInterrupt: () -> Unit,
     onReconnect: () -> Unit,
+    onNoticeAction: (() -> Unit)? = null,
     onBack: () -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -150,7 +151,14 @@ internal fun ConversationScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    notice?.let { StatusMessage(it.message, CelesteError) }
+                    notice?.let { currentNotice ->
+                        StatusMessage(currentNotice.message, CelesteError)
+                        currentNotice.recoveryLabel?.let { label ->
+                            TextButton(onClick = { (onNoticeAction ?: onReconnect)() }) {
+                                Text(label, color = CelesteBlue)
+                            }
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.TurnState
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -71,7 +72,7 @@ internal fun ConversationScreen(
     draft: String,
     turnState: TurnState,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
     onInterrupt: () -> Unit,
@@ -143,13 +144,13 @@ internal fun ConversationScreen(
                 }
             }
 
-            if (loadingMessage != null || errorMessage != null) {
+            if (loadingMessage != null || notice != null) {
                 Column(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    notice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.ConnectionPhase
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -83,7 +84,7 @@ internal data class GatewaySettingsUiState(
     val sessionToken: String,
     val connectionPhase: ConnectionPhase,
     val loadingMessage: String?,
-    val errorMessage: String?,
+    val notice: UiNotice?,
 )
 
 internal data class GatewaySettingsActions(
@@ -125,7 +126,7 @@ internal fun ConnectionLoadingScreen() {
 
 @Composable
 internal fun ConnectionUnavailableScreen(
-    errorMessage: String?,
+    notice: UiNotice?,
     onRetry: () -> Unit,
     onSettings: () -> Unit,
 ) {
@@ -147,9 +148,9 @@ internal fun ConnectionUnavailableScreen(
                 color = CelesteMuted,
                 style = MaterialTheme.typography.bodyLarge,
             )
-            errorMessage?.let {
+            notice?.let {
                 Spacer(Modifier.height(26.dp))
-                StatusMessage(it, CelesteError)
+                StatusMessage(it.message, CelesteError)
             }
             Spacer(Modifier.height(34.dp))
             CelestePrimaryButton(
@@ -233,7 +234,7 @@ internal fun GatewaySettingsScreen(
     val sessionToken = state.sessionToken
     val connectionPhase = state.connectionPhase
     val loadingMessage = state.loadingMessage
-    val errorMessage = state.errorMessage
+    val notice = state.notice
     val onBack = actions.onBack
     var address by rememberSaveable(dashboardUrl) { mutableStateOf(dashboardUrl) }
     var confirmForgetConnection by remember { mutableStateOf(false) }
@@ -366,14 +367,12 @@ internal fun GatewaySettingsScreen(
                 EditorialDivider()
             }
 
-            val visibleError = errorMessage.takeUnless {
-                connectionPhase == ConnectionPhase.AuthenticationRequired
-            }
-            AnimatedVisibility(visibleError != null || loadingMessage != null) {
+            val visibleNotice = notice
+            AnimatedVisibility(visibleNotice != null || loadingMessage != null) {
                 Column(modifier = Modifier.padding(vertical = 22.dp)) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    if (loadingMessage != null && visibleError != null) Spacer(Modifier.height(10.dp))
-                    visibleError?.let { StatusMessage(it, CelesteError) }
+                    if (loadingMessage != null && visibleNotice != null) Spacer(Modifier.height(10.dp))
+                    visibleNotice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 
@@ -385,7 +384,7 @@ internal fun GatewaySettingsScreen(
             }
             val showPrimaryAction = !isConnected || addressChanged
             if (showPrimaryAction) {
-                Spacer(Modifier.height(if (visibleError == null && loadingMessage == null) 28.dp else 4.dp))
+                Spacer(Modifier.height(if (visibleNotice == null && loadingMessage == null) 28.dp else 4.dp))
                 CelestePrimaryButton(
                     text = when {
                         effectiveProbe == null -> "Find my Hermes"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -85,6 +85,7 @@ internal data class GatewaySettingsUiState(
     val connectionPhase: ConnectionPhase,
     val loadingMessage: String?,
     val notice: UiNotice?,
+    val localCleanupNotice: UiNotice? = null,
 )
 
 internal data class GatewaySettingsActions(
@@ -235,6 +236,7 @@ internal fun GatewaySettingsScreen(
     val connectionPhase = state.connectionPhase
     val loadingMessage = state.loadingMessage
     val notice = state.notice
+    val localCleanupNotice = state.localCleanupNotice
     val onBack = actions.onBack
     var address by rememberSaveable(dashboardUrl) { mutableStateOf(dashboardUrl) }
     var confirmForgetConnection by remember { mutableStateOf(false) }
@@ -368,11 +370,20 @@ internal fun GatewaySettingsScreen(
             }
 
             val visibleNotice = notice
-            AnimatedVisibility(visibleNotice != null || loadingMessage != null) {
+            AnimatedVisibility(visibleNotice != null || localCleanupNotice != null || loadingMessage != null) {
                 Column(modifier = Modifier.padding(vertical = 22.dp)) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
                     if (loadingMessage != null && visibleNotice != null) Spacer(Modifier.height(10.dp))
                     visibleNotice?.let { StatusMessage(it.message, CelesteError) }
+                    localCleanupNotice?.let { cleanupNotice ->
+                        if (visibleNotice != null) Spacer(Modifier.height(10.dp))
+                        StatusMessage(cleanupNotice.message, CelesteError)
+                        cleanupNotice.recoveryLabel?.let { label ->
+                            TextButton(onClick = actions.onRetry) {
+                                Text(label, color = CelesteBlue)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -384,7 +395,15 @@ internal fun GatewaySettingsScreen(
             }
             val showPrimaryAction = !isConnected || addressChanged
             if (showPrimaryAction) {
-                Spacer(Modifier.height(if (visibleNotice == null && loadingMessage == null) 28.dp else 4.dp))
+                Spacer(
+                    Modifier.height(
+                        if (visibleNotice == null && localCleanupNotice == null && loadingMessage == null) {
+                            28.dp
+                        } else {
+                            4.dp
+                        },
+                    ),
+                )
                 CelestePrimaryButton(
                     text = when {
                         effectiveProbe == null -> "Find my Hermes"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hazydreams.hermesceleste.UiNotice
+import dev.hazydreams.hermesceleste.UiRecoveryAction
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -56,10 +58,11 @@ internal fun SessionListScreen(
     profiles: List<DashboardProfile>,
     selectedProfile: String,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
     onProfileSelected: (String) -> Unit,
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
+    onRetry: () -> Unit,
     onSettings: () -> Unit,
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
@@ -144,13 +147,18 @@ internal fun SessionListScreen(
                 }
             }
 
-            if (loadingMessage != null || errorMessage != null) {
+            if (loadingMessage != null || notice != null) {
                 Column(
                     modifier = Modifier.padding(horizontal = 28.dp, vertical = 4.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    notice?.let {
+                        StatusMessage(it.message, CelesteError)
+                        if (it.recovery == UiRecoveryAction.Retry) {
+                            TextButton(onClick = onRetry) { Text("Retry", color = CelesteBlue) }
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.UiNotice
-import dev.hazydreams.hermesceleste.UiRecoveryAction
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -63,6 +62,7 @@ internal fun SessionListScreen(
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
     onRetry: () -> Unit,
+    onNoticeAction: (() -> Unit)? = null,
     onSettings: () -> Unit,
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
@@ -153,10 +153,12 @@ internal fun SessionListScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    notice?.let {
-                        StatusMessage(it.message, CelesteError)
-                        if (it.recovery == UiRecoveryAction.Retry) {
-                            TextButton(onClick = onRetry) { Text("Retry", color = CelesteBlue) }
+                    notice?.let { currentNotice ->
+                        StatusMessage(currentNotice.message, CelesteError)
+                        currentNotice.recoveryLabel?.let { label ->
+                            TextButton(
+                                onClick = { (onNoticeAction ?: onRetry)() },
+                            ) { Text(label, color = CelesteBlue) }
                         }
                     }
                 }

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -83,7 +83,7 @@ private val gatewaySetupState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.ManualSetup,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private val passwordSignInState = GatewaySettingsUiState(
@@ -100,7 +100,7 @@ private val passwordSignInState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.AuthenticationRequired,
     loadingMessage = null,
-    errorMessage = "Sign in required.",
+    notice = UiNotice.authentication(),
 )
 
 private val sessionTokenState = GatewaySettingsUiState(
@@ -117,7 +117,7 @@ private val sessionTokenState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.ManualSetup,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private val connectedGatewayState = GatewaySettingsUiState(
@@ -134,7 +134,7 @@ private val connectedGatewayState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.Connected,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private fun gatewayPreviewActions(onBack: (() -> Unit)?): GatewaySettingsActions =
@@ -227,7 +227,7 @@ fun RestoringConnectionPreviewScreenshot() {
 fun RestoreFailedPreviewScreenshot() {
     HermesCelesteTheme {
         ConnectionUnavailableScreen(
-            errorMessage = "Could not reach Hermes.",
+            notice = UiNotice.unavailable(),
             onRetry = {},
             onSettings = {},
         )
@@ -247,10 +247,11 @@ fun SessionListPreviewScreenshot() {
             ),
             selectedProfile = "work",
             loadingMessage = null,
-            errorMessage = null,
+            notice = null,
             onProfileSelected = {},
             onNewConversation = {},
             onSessionSelected = {},
+            onRetry = {},
             onSettings = {},
         )
     }
@@ -339,7 +340,7 @@ fun ReconnectingPreviewScreenshot() {
         PreviewConversation(
             draft = "This draft stays here while the connection recovers.",
             turnState = TurnState.Reconnecting,
-            errorMessage = "The dashboard connection closed before Hermes finished responding.",
+            notice = UiNotice.reconnecting(),
         )
     }
 }
@@ -351,7 +352,7 @@ private fun PreviewConversation(
     streamingText: String = "",
     draft: String = "",
     turnState: TurnState,
-    errorMessage: String? = null,
+    notice: UiNotice? = null,
 ) {
     ConversationScreen(
         summary = summary,
@@ -360,7 +361,7 @@ private fun PreviewConversation(
         draft = draft,
         turnState = turnState,
         loadingMessage = null,
-        errorMessage = errorMessage,
+        notice = notice,
         onDraftChange = {},
         onSend = {},
         onInterrupt = {},

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
@@ -23,6 +23,7 @@ import dev.hazydreams.hermesceleste.network.TransportUnavailable
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -33,6 +34,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import org.junit.After
@@ -297,13 +299,18 @@ class CelesteViewModelAutoLoginTest {
         )
         val clearGate = CompletableDeferred<Unit>()
         val store = BackgroundCleanupStore(
-            initial = StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
+            saved = StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
             clearGate = clearGate,
         )
         val dashboard = AutoLoginDashboard(passwordProbe)
         val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
         advanceUntilIdle()
-        dashboard.onLogout = { assertNull(store.load()?.secret) }
+        val clearCallsBeforeSignOut = dashboard.clearAuthenticationCalls
+        dashboard.onLogout = {
+            assertTrue(dashboard.authenticationPresent)
+            assertTrue(store.load()?.secret != null)
+            assertEquals(clearCallsBeforeSignOut, dashboard.clearAuthenticationCalls)
+        }
 
         viewModel.signOut()
         store.clearEntered.await()
@@ -312,7 +319,8 @@ class CelesteViewModelAutoLoginTest {
 
         assertEquals("Signing out…", viewModel.state.value.loadingMessage)
         assertTrue(store.load()?.secret != null)
-        assertEquals(0, dashboard.logoutCalls)
+        assertEquals(1, dashboard.logoutCalls)
+        assertEquals(clearCallsBeforeSignOut + 1, dashboard.clearAuthenticationCalls)
 
         clearGate.complete(Unit)
         viewModel.onForeground()
@@ -336,7 +344,7 @@ class CelesteViewModelAutoLoginTest {
             expectsSecret = true,
         )
         val store = BackgroundCleanupStore(
-            initial = StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
+            saved = StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
         )
         val logoutGate = CompletableDeferred<Unit>()
         val dashboard = AutoLoginDashboard(passwordProbe).apply {
@@ -345,16 +353,22 @@ class CelesteViewModelAutoLoginTest {
         }
         val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
         advanceUntilIdle()
-        dashboard.onLogout = { assertNull(store.load()) }
+        val clearCallsBeforeForget = dashboard.clearAuthenticationCalls
+        dashboard.onLogout = {
+            assertTrue(dashboard.authenticationPresent)
+            assertTrue(store.load() != null)
+            assertEquals(clearCallsBeforeForget, dashboard.clearAuthenticationCalls)
+        }
 
         viewModel.forgetConnection()
         dashboard.logoutEntered?.await()
         viewModel.onBackground()
         runCurrent()
 
-        assertNull(store.load())
+        assertTrue(store.load() != null)
         assertEquals("Forgetting this connection…", viewModel.state.value.loadingMessage)
         assertEquals(1, dashboard.logoutCalls)
+        assertEquals(clearCallsBeforeForget, dashboard.clearAuthenticationCalls)
 
         logoutGate.complete(Unit)
         viewModel.onForeground()
@@ -446,6 +460,84 @@ class CelesteViewModelAutoLoginTest {
     }
 
     @Test
+    fun supersededSignOutCannotClearReplacementOrigin() = runTest {
+        val descriptor = SavedConnectionDescriptor(
+            baseUrl = "https://old-hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        val loadGate = CompletableDeferred<Unit>()
+        val store = GenerationGuardConnectionStore(
+            saved = StoredConnection(descriptor, ReusableSecret("old-session-cookies")),
+            loadGate = loadGate,
+        )
+        val dashboard = AutoLoginDashboard(passwordProbe)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+
+        store.blockNextLoad()
+        viewModel.signOut()
+        store.loadEntered.await()
+        viewModel.useAnotherConnection()
+        loadGate.complete(Unit)
+        advanceUntilIdle()
+
+        val replacement = SavedConnectionDescriptor(
+            baseUrl = "https://new-hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        store.replace(replacement, ReusableSecret("new-session-cookies"))
+
+        assertEquals(0, store.clearCalls)
+        assertEquals(replacement, store.load()?.descriptor)
+        assertEquals("new-session-cookies", store.load()?.secret?.value)
+    }
+
+    @Test
+    fun supersededForgetCannotDeleteReplacementOrigin() = runTest {
+        val descriptor = SavedConnectionDescriptor(
+            baseUrl = "https://old-hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        val loadGate = CompletableDeferred<Unit>()
+        val store = GenerationGuardConnectionStore(
+            saved = StoredConnection(descriptor, ReusableSecret("old-session-cookies")),
+            loadGate = loadGate,
+        )
+        val dashboard = AutoLoginDashboard(passwordProbe)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+
+        store.blockNextLoad()
+        viewModel.forgetConnection()
+        store.loadEntered.await()
+        viewModel.useAnotherConnection()
+        loadGate.complete(Unit)
+        advanceUntilIdle()
+
+        val replacement = SavedConnectionDescriptor(
+            baseUrl = "https://new-hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        store.replace(replacement, ReusableSecret("new-session-cookies"))
+
+        assertEquals(0, store.forgetCalls)
+        assertEquals(replacement, store.load()?.descriptor)
+        assertEquals("new-session-cookies", store.load()?.secret?.value)
+    }
+
+    @Test
     fun signOutRetainsSafePrefillWhileForgetRemovesEverything() = runTest {
         val descriptor = SavedConnectionDescriptor(
             baseUrl = "https://hermes.example.net",
@@ -460,7 +552,12 @@ class CelesteViewModelAutoLoginTest {
         val dashboard = AutoLoginDashboard(passwordProbe)
         val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
         advanceUntilIdle()
-        dashboard.onLogout = { assertNull(store.load()?.secret) }
+        val clearCallsBeforeSignOut = dashboard.clearAuthenticationCalls
+        dashboard.onLogout = {
+            assertTrue(dashboard.authenticationPresent)
+            assertTrue(store.load()?.secret != null)
+            assertEquals(clearCallsBeforeSignOut, dashboard.clearAuthenticationCalls)
+        }
 
         viewModel.signOut()
         advanceUntilIdle()
@@ -482,7 +579,12 @@ class CelesteViewModelAutoLoginTest {
             connectionStore = forgetStore,
         )
         advanceUntilIdle()
-        forgetDashboard.onLogout = { assertNull(forgetStore.load()) }
+        val clearCallsBeforeForget = forgetDashboard.clearAuthenticationCalls
+        forgetDashboard.onLogout = {
+            assertTrue(forgetDashboard.authenticationPresent)
+            assertTrue(forgetStore.load() != null)
+            assertEquals(clearCallsBeforeForget, forgetDashboard.clearAuthenticationCalls)
+        }
 
         forgetViewModel.forgetConnection()
         advanceUntilIdle()
@@ -557,6 +659,49 @@ class CelesteViewModelAutoLoginTest {
         }
     }
 
+    private class GenerationGuardConnectionStore(
+        private var saved: StoredConnection?,
+        private val loadGate: CompletableDeferred<Unit>,
+    ) : ConnectionStore {
+        val loadEntered = CompletableDeferred<Unit>()
+        var clearCalls = 0
+        var forgetCalls = 0
+        private var blockLoad = false
+
+        fun blockNextLoad() {
+            blockLoad = true
+        }
+
+        override suspend fun load(): StoredConnection? {
+            if (blockLoad) {
+                blockLoad = false
+                loadEntered.complete(Unit)
+                withContext(NonCancellable) { loadGate.await() }
+            }
+            return saved
+        }
+
+        override suspend fun replace(
+            descriptor: SavedConnectionDescriptor,
+            secret: ReusableSecret?,
+        ) {
+            saved = StoredConnection(descriptor, secret)
+        }
+
+        override suspend fun clearSecret() {
+            clearCalls += 1
+            saved = saved?.copy(
+                descriptor = saved!!.descriptor.copy(autoLoginEnabled = false),
+                secret = null,
+            )
+        }
+
+        override suspend fun forget() {
+            forgetCalls += 1
+            saved = null
+        }
+    }
+
     private class AutoLoginDashboard(
         private val probeResult: DashboardProbeResult,
     ) : DashboardService {
@@ -570,6 +715,7 @@ class CelesteViewModelAutoLoginTest {
         var restoreAuthenticationCalls = 0
         var logoutCalls = 0
         var clearAuthenticationCalls = 0
+        var authenticationPresent = false
         var logoutGate: CompletableDeferred<Unit>? = null
         var logoutEntered: CompletableDeferred<Unit>? = null
         var onLogout: (suspend () -> Unit)? = null
@@ -588,6 +734,7 @@ class CelesteViewModelAutoLoginTest {
         ) {
             passwordLoginCalls += 1
             passwordFailure?.let { throw it }
+            authenticationPresent = true
         }
 
         override suspend fun listSessions(
@@ -621,6 +768,7 @@ class CelesteViewModelAutoLoginTest {
             material: AuthenticationMaterial,
         ): Boolean {
             restoreAuthenticationCalls += 1
+            authenticationPresent = restoreAccepted
             return restoreAccepted
         }
 
@@ -633,6 +781,7 @@ class CelesteViewModelAutoLoginTest {
 
         override fun clearAuthentication() {
             clearAuthenticationCalls += 1
+            authenticationPresent = false
         }
 
         override fun createGateway(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
@@ -15,6 +15,7 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
 import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.TransportUnavailable
@@ -168,6 +169,43 @@ class CelesteViewModelAutoLoginTest {
     }
 
     @Test
+    fun jsonRpcAuthenticationFailureDuringRestoreClearsReusableAuth() = runTest {
+        listOf(401, 403).forEach { code ->
+            val descriptor = SavedConnectionDescriptor(
+                baseUrl = "https://hermes.example.net",
+                authMode = SavedAuthMode.ProviderSession,
+                provider = "password",
+                username = "celeste",
+                expectsSecret = true,
+            )
+            val store = InMemoryConnectionStore(
+                StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
+            )
+            val dashboard = AutoLoginDashboard(passwordProbe).apply {
+                sessionFailure = GatewayRpcException(
+                    code = code,
+                    message = "raw JSON-RPC auth failure at https://private.example/path",
+                )
+            }
+
+            val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            val notice = requireNotNull(state.notice)
+            assertEquals(ConnectionPhase.AuthenticationRequired, state.connectionPhase)
+            assertEquals(UiNoticeCategory.AuthenticationRequired, notice.category)
+            assertEquals(UiRecoveryAction.SignIn, notice.recovery)
+            assertEquals("Your Hermes sign-in has expired. Sign in again.", notice.message)
+            assertEquals("https://hermes.example.net", state.dashboardUrl)
+            assertEquals("celeste", state.username)
+            assertNull(store.load()?.secret)
+            assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
+            assertFalse(notice.message.contains("private.example"))
+        }
+    }
+
+    @Test
     fun transientRestoreFailureKeepsTheSavedConnectionAndRetrySucceeds() = runTest {
         val descriptor = SavedConnectionDescriptor(
             baseUrl = "https://hermes.example.net",
@@ -299,6 +337,7 @@ class CelesteViewModelAutoLoginTest {
     ) : DashboardService {
         var probeFailure: Throwable? = null
         var passwordFailure: Throwable? = null
+        var sessionFailure: Throwable? = null
         var restoreAccepted = true
         var exportedMaterial = "synthetic-session-cookies"
         var probeCalls = 0
@@ -328,16 +367,19 @@ class CelesteViewModelAutoLoginTest {
             baseUrl: String,
             credential: GatewayCredential,
             limit: Int,
-        ): List<StoredSession> = listOf(
-            StoredSession(
-                id = "stored-1",
-                title = "Choose me manually",
-                preview = "",
-                startedAt = 1.0,
-                messageCount = 1,
-                source = "desktop",
-            ),
-        )
+        ): List<StoredSession> {
+            sessionFailure?.let { throw it }
+            return listOf(
+                StoredSession(
+                    id = "stored-1",
+                    title = "Choose me manually",
+                    preview = "",
+                    startedAt = 1.0,
+                    messageCount = 1,
+                    source = "desktop",
+                ),
+            )
+        }
 
         override suspend fun listProfiles(
             baseUrl: String,

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
@@ -1,5 +1,6 @@
 package dev.hazydreams.hermesceleste
 
+import dev.hazydreams.hermesceleste.connection.ConnectionStore
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
 import dev.hazydreams.hermesceleste.connection.ReusableSecret
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
@@ -19,6 +20,7 @@ import dev.hazydreams.hermesceleste.network.GatewayRpcException
 import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.TransportUnavailable
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.JsonElement
@@ -284,6 +287,165 @@ class CelesteViewModelAutoLoginTest {
     }
 
     @Test
+    fun backgroundDuringSignOutResumesIdempotentSecretCleanupOnForeground() = runTest {
+        val descriptor = SavedConnectionDescriptor(
+            baseUrl = "https://hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        val clearGate = CompletableDeferred<Unit>()
+        val store = BackgroundCleanupStore(
+            initial = StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
+            clearGate = clearGate,
+        )
+        val dashboard = AutoLoginDashboard(passwordProbe)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+        dashboard.onLogout = { assertNull(store.load()?.secret) }
+
+        viewModel.signOut()
+        store.clearEntered.await()
+        viewModel.onBackground()
+        runCurrent()
+
+        assertEquals("Signing out…", viewModel.state.value.loadingMessage)
+        assertTrue(store.load()?.secret != null)
+        assertEquals(0, dashboard.logoutCalls)
+
+        clearGate.complete(Unit)
+        viewModel.onForeground()
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
+        assertNull(store.load()?.secret)
+        assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
+        assertEquals(2, store.clearCalls)
+        assertEquals(1, dashboard.logoutCalls)
+        assertNull(viewModel.state.value.notice)
+    }
+
+    @Test
+    fun backgroundDuringForgetResumesIdempotentLogoutOnForeground() = runTest {
+        val descriptor = SavedConnectionDescriptor(
+            baseUrl = "https://hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        val store = BackgroundCleanupStore(
+            initial = StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
+        )
+        val logoutGate = CompletableDeferred<Unit>()
+        val dashboard = AutoLoginDashboard(passwordProbe).apply {
+            this.logoutGate = logoutGate
+            logoutEntered = CompletableDeferred()
+        }
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+        dashboard.onLogout = { assertNull(store.load()) }
+
+        viewModel.forgetConnection()
+        dashboard.logoutEntered?.await()
+        viewModel.onBackground()
+        runCurrent()
+
+        assertNull(store.load())
+        assertEquals("Forgetting this connection…", viewModel.state.value.loadingMessage)
+        assertEquals(1, dashboard.logoutCalls)
+
+        logoutGate.complete(Unit)
+        viewModel.onForeground()
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
+        assertNull(store.load())
+        assertEquals(2, dashboard.logoutCalls)
+        assertNull(viewModel.state.value.notice)
+    }
+
+    @Test
+    fun failedSecretClearStillPublishesAuthenticationRequiredWithRetryableLocalCleanup() = runTest {
+        val descriptor = SavedConnectionDescriptor(
+            baseUrl = "https://hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        val store = RetryingClearConnectionStore(
+            StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
+        )
+        val dashboard = AutoLoginDashboard(passwordProbe).apply {
+            sessionFailure = GatewayRpcException(
+                code = 401,
+                message = "raw auth detail https://private.example/path",
+            )
+        }
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+
+        val failedState = viewModel.state.value
+        assertEquals(ConnectionPhase.AuthenticationRequired, failedState.connectionPhase)
+        assertEquals(UiNoticeCategory.AuthenticationRequired, failedState.notice?.category)
+        assertEquals(UiRecoveryAction.SignIn, failedState.notice?.recovery)
+        assertEquals(UiNoticeCategory.Persistence, failedState.localCleanupNotice?.category)
+        assertEquals(UiRecoveryAction.Retry, failedState.localCleanupNotice?.recovery)
+        assertEquals("Your Hermes sign-in has expired. Sign in again.", failedState.notice?.message)
+        assertTrue(dashboard.clearAuthenticationCalls > 0)
+        assertFalse(failedState.localCleanupNotice?.message.orEmpty().contains("synthetic-session-cookies"))
+
+        viewModel.retrySavedConnection()
+        advanceUntilIdle()
+
+        assertNull(store.load()?.secret)
+        assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
+        assertEquals(UiNoticeCategory.AuthenticationRequired, viewModel.state.value.notice?.category)
+        assertNull(viewModel.state.value.localCleanupNotice)
+    }
+
+    @Test
+    fun failedCleanupCannotRetryAgainstAReplacementOrigin() = runTest {
+        val originalDescriptor = SavedConnectionDescriptor(
+            baseUrl = "https://old-hermes.example.net",
+            authMode = SavedAuthMode.ProviderSession,
+            provider = "password",
+            username = "celeste",
+            expectsSecret = true,
+        )
+        val store = RetryingClearConnectionStore(
+            StoredConnection(originalDescriptor, ReusableSecret("old-session-cookies")),
+        )
+        val dashboard = AutoLoginDashboard(passwordProbe)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+
+        viewModel.signOut()
+        advanceUntilIdle()
+        assertEquals(UiNoticeCategory.Persistence, viewModel.state.value.localCleanupNotice?.category)
+
+        viewModel.useAnotherConnection()
+        viewModel.updateDashboardUrl("https://new-hermes.example.net")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.updateUsername("celeste")
+        viewModel.updatePassword("synthetic-password")
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals("https://new-hermes.example.net", store.load()?.descriptor?.baseUrl)
+        assertEquals("synthetic-session-cookies", store.load()?.secret?.value)
+
+        viewModel.retrySavedConnection()
+        advanceUntilIdle()
+
+        assertEquals("https://new-hermes.example.net", store.load()?.descriptor?.baseUrl)
+        assertEquals("synthetic-session-cookies", store.load()?.secret?.value)
+    }
+
+    @Test
     fun signOutRetainsSafePrefillWhileForgetRemovesEverything() = runTest {
         val descriptor = SavedConnectionDescriptor(
             baseUrl = "https://hermes.example.net",
@@ -332,6 +494,69 @@ class CelesteViewModelAutoLoginTest {
         assertEquals(1, forgetDashboard.logoutCalls)
     }
 
+    private class BackgroundCleanupStore(
+        private var saved: StoredConnection?,
+        private val clearGate: CompletableDeferred<Unit>? = null,
+    ) : ConnectionStore {
+        var clearCalls = 0
+        val clearEntered = CompletableDeferred<Unit>()
+
+        override suspend fun load(): StoredConnection? = saved
+
+        override suspend fun replace(
+            descriptor: SavedConnectionDescriptor,
+            secret: ReusableSecret?,
+        ) {
+            saved = StoredConnection(descriptor, secret)
+        }
+
+        override suspend fun clearSecret() {
+            clearCalls += 1
+            if (clearCalls == 1) {
+                clearEntered.complete(Unit)
+                clearGate?.await()
+            }
+            saved = saved?.copy(
+                descriptor = saved!!.descriptor.copy(autoLoginEnabled = false),
+                secret = null,
+            )
+        }
+
+        override suspend fun forget() {
+            saved = null
+        }
+    }
+
+    private class RetryingClearConnectionStore(
+        private var saved: StoredConnection?,
+    ) : ConnectionStore {
+        private var failuresRemaining = 1
+
+        override suspend fun load(): StoredConnection? = saved
+
+        override suspend fun replace(
+            descriptor: SavedConnectionDescriptor,
+            secret: ReusableSecret?,
+        ) {
+            saved = StoredConnection(descriptor, secret)
+        }
+
+        override suspend fun clearSecret() {
+            if (failuresRemaining > 0) {
+                failuresRemaining -= 1
+                throw IllegalStateException("synthetic local cleanup failure")
+            }
+            saved = saved?.copy(
+                descriptor = saved!!.descriptor.copy(autoLoginEnabled = false),
+                secret = null,
+            )
+        }
+
+        override suspend fun forget() {
+            saved = null
+        }
+    }
+
     private class AutoLoginDashboard(
         private val probeResult: DashboardProbeResult,
     ) : DashboardService {
@@ -345,6 +570,8 @@ class CelesteViewModelAutoLoginTest {
         var restoreAuthenticationCalls = 0
         var logoutCalls = 0
         var clearAuthenticationCalls = 0
+        var logoutGate: CompletableDeferred<Unit>? = null
+        var logoutEntered: CompletableDeferred<Unit>? = null
         var onLogout: (suspend () -> Unit)? = null
 
         override suspend fun probe(rawBaseUrl: String): DashboardProbeResult {
@@ -398,8 +625,10 @@ class CelesteViewModelAutoLoginTest {
         }
 
         override suspend fun logout(baseUrl: String) {
-            onLogout?.invoke()
             logoutCalls += 1
+            logoutEntered?.complete(Unit)
+            logoutGate?.await()
+            onLogout?.invoke()
         }
 
         override fun clearAuthentication() {

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -3,6 +3,10 @@ package dev.hazydreams.hermesceleste
 import java.io.IOException
 
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
+import dev.hazydreams.hermesceleste.connection.ReusableSecret
+import dev.hazydreams.hermesceleste.connection.SavedAuthMode
+import dev.hazydreams.hermesceleste.connection.SavedConnectionDescriptor
+import dev.hazydreams.hermesceleste.connection.StoredConnection
 import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.AuthProvider
@@ -200,6 +204,71 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun jsonRpcAuthenticationFailuresDuringLoadRequireSignInAndClearReusableAuth() = runTest {
+        listOf(401, 403).forEach { code ->
+            val descriptor = SavedConnectionDescriptor(
+                baseUrl = "http://hermes.test:9119",
+                authMode = SavedAuthMode.StaticToken,
+                expectsSecret = true,
+            )
+            val store = InMemoryConnectionStore(
+                StoredConnection(descriptor, ReusableSecret("synthetic-session-token")),
+            )
+            val dashboard = FakeDashboard(FakeGateway()).apply {
+                sessionFailure = GatewayRpcException(
+                    code = code,
+                    message = "raw JSON-RPC auth failure at https://private.example/path",
+                )
+            }
+            val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+            viewModel.updateDashboardUrl("http://hermes.test:9119")
+            viewModel.findDashboard()
+            advanceUntilIdle()
+            viewModel.loadSessions()
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            val notice = requireNotNull(state.notice)
+            assertEquals(ConnectionPhase.AuthenticationRequired, state.connectionPhase)
+            assertEquals(UiNoticeCategory.AuthenticationRequired, notice.category)
+            assertEquals(UiRecoveryAction.SignIn, notice.recovery)
+            assertEquals("Your Hermes sign-in has expired. Sign in again.", notice.message)
+            assertEquals("http://hermes.test:9119", state.dashboardUrl)
+            assertEquals("", state.sessionToken)
+            assertNull(store.load()?.secret)
+            assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
+            assertFalse(notice.message.contains("private.example"))
+        }
+    }
+
+    @Test
+    fun jsonRpcAuthenticationFailureDuringProfileReloadRequiresSignIn() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val store = InMemoryConnectionStore()
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        dashboard.profileFailure = GatewayRpcException(
+            code = 403,
+            message = "raw JSON-RPC auth failure at https://private.example/path",
+        )
+        viewModel.selectProfile("work")
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val notice = requireNotNull(state.notice)
+        assertEquals(ConnectionPhase.AuthenticationRequired, state.connectionPhase)
+        assertEquals(UiNoticeCategory.AuthenticationRequired, notice.category)
+        assertEquals(UiRecoveryAction.SignIn, notice.recovery)
+        assertEquals("Your Hermes sign-in has expired. Sign in again.", notice.message)
+        assertNull(state.sessions)
+        assertFalse(notice.message.contains("private.example"))
+    }
+
+    @Test
     fun foregroundHealthCheckReplacesAStaleSocketAndResumes() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
@@ -261,6 +330,48 @@ class CelesteViewModelTest {
         assertTrue(gateway.methods.count { it == "session.resume" } >= 3)
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         assertNull(viewModel.state.value.notice)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun newerReconciliationEpochWinsWhenAnOlderSnapshotReturnsLate() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        val olderResumeGate = CompletableDeferred<Unit>()
+        val newerResumeGate = CompletableDeferred<Unit>()
+        val olderResumeEntered = CompletableDeferred<Unit>()
+        val newerResumeEntered = CompletableDeferred<Unit>()
+        gateway.promptFailure = IOException("prompt delivery became uncertain")
+        gateway.resumePayloads += resumePayload(
+            messages = listOf(ConversationMessage(role = "user", text = "stale snapshot")),
+            running = false,
+        )
+        gateway.resumePayloads += resumePayload(
+            messages = listOf(ConversationMessage(role = "user", text = "fresh snapshot")),
+            running = false,
+        )
+        gateway.resumeGates += olderResumeGate
+        gateway.resumeGates += newerResumeGate
+        gateway.resumeEnteredSignals += olderResumeEntered
+        gateway.resumeEnteredSignals += newerResumeEntered
+
+        viewModel.updateDraft("uncertain prompt")
+        viewModel.sendMessage()
+        olderResumeEntered.await()
+
+        gateway.disconnect("reconnect while the first reconciliation is pending")
+        runCurrent()
+        newerResumeEntered.await()
+
+        newerResumeGate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("fresh snapshot", viewModel.state.value.messages.single().text)
+
+        olderResumeGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("fresh snapshot", viewModel.state.value.messages.single().text)
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
         viewModel.leaveConversation()
     }
 
@@ -487,6 +598,7 @@ class CelesteViewModelTest {
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
+        var sessionFailure: Throwable? = null
         var profileCatalog = listOf(
             DashboardProfile(name = "default", isDefault = true),
             DashboardProfile(name = "work"),
@@ -524,7 +636,10 @@ class CelesteViewModelTest {
             baseUrl: String,
             credential: GatewayCredential,
             limit: Int,
-        ): List<StoredSession> = listOf(session)
+        ): List<StoredSession> {
+            sessionFailure?.let { throw it }
+            return listOf(session)
+        }
 
         override suspend fun listProfiles(
             baseUrl: String,
@@ -555,7 +670,11 @@ class CelesteViewModelTest {
         var createCount = 0
         var failHealthCheck = false
         var connectFailure: Throwable? = null
+        var promptFailure: Throwable? = null
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
+        val resumePayloads = mutableListOf<JsonObject>()
+        val resumeGates = mutableListOf<CompletableDeferred<Unit>>()
+        val resumeEnteredSignals = mutableListOf<CompletableDeferred<Unit>>()
         var resumeFailure: Throwable? = null
         var resumeGate: CompletableDeferred<Unit>? = null
         var resumeEntered: CompletableDeferred<Unit>? = null
@@ -577,9 +696,23 @@ class CelesteViewModelTest {
             return when (method) {
                 "session.resume" -> {
                     resumeEntered?.complete(Unit)
-                    resumeGate?.await()
+                    resumeEnteredSignals.firstOrNull()?.let { entered ->
+                        entered.complete(Unit)
+                        resumeEnteredSignals.removeAt(0)
+                    }
+                    val gate = if (resumeGates.isNotEmpty()) {
+                        resumeGates.removeAt(0)
+                    } else {
+                        resumeGate
+                    }
+                    val payload = if (resumePayloads.isNotEmpty()) {
+                        resumePayloads.removeAt(0)
+                    } else {
+                        resumePayload
+                    }
+                    gate?.await()
                     resumeFailure?.let { throw it }
-                    resumePayload
+                    payload
                 }
                 "session.create" -> {
                     createCount += 1
@@ -596,7 +729,13 @@ class CelesteViewModelTest {
                     }
                     buildJsonObject { put("sessions", "healthy") }
                 }
-                "prompt.submit" -> buildJsonObject { put("status", "streaming") }
+                "prompt.submit" -> {
+                    promptFailure?.let { failure ->
+                        promptFailure = null
+                        throw failure
+                    }
+                    buildJsonObject { put("status", "streaming") }
+                }
                 "session.interrupt" -> buildJsonObject { put("status", "interrupting") }
                 else -> buildJsonObject {}
             }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -128,13 +128,37 @@ class CelesteViewModelTest {
         gateway.emit("message.delta", """{"text":"streamed prefix"}""")
         gateway.emit(
             "message.complete",
-            """{"content":"authoritative partial response","status":"error"}""",
+            """{"content":"authoritative partial response","status":"error","partial":true,"error":"synthetic provider failure"}""",
         )
         advanceUntilIdle()
 
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         assertEquals("authoritative partial response", viewModel.state.value.messages.last().text)
         assertEquals(UiNoticeCategory.ServerTurnFailure, viewModel.state.value.notice?.category)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun nonPartialErrorCompletionNeverBecomesAssistantContent() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+
+        viewModel.updateDraft("Do not render the failure payload")
+        viewModel.sendMessage()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"discarded streamed text"}""")
+        gateway.emit(
+            "message.complete",
+            """{"text":"raw error payload","content":"raw error payload","status":"error","partial":false,"error":"raw error payload"}""",
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(TurnState.Idle, state.turnState)
+        assertEquals("", state.streamingText)
+        assertEquals(listOf("user"), state.messages.map { it.role })
+        assertTrue(state.messages.none { it.text.contains("raw error payload") })
+        assertEquals(UiNoticeCategory.ServerTurnFailure, state.notice?.category)
         viewModel.leaveConversation()
     }
 
@@ -609,6 +633,53 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun runningFalseSessionEventsSettlePartialOutputWithoutMessageComplete() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"settled by busy=false"}""")
+        gateway.emit("session.busy", """{"busy":false}""")
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"settled by running=false"}""")
+        gateway.emit("session.info", """{"running":false}""")
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(TurnState.Idle, state.turnState)
+        assertEquals("", state.streamingText)
+        assertEquals(
+            listOf("settled by busy=false", "settled by running=false"),
+            state.messages.map { it.text },
+        )
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun runningFalseResumeSettlesAuthoritativeInflightOutputWithoutCompletion() = runTest {
+        val gateway = FakeGateway()
+        gateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "user", text = "Recover this turn", id = "user-1"),
+                ConversationMessage(role = "assistant", text = "Stored prefix", id = "assistant-1"),
+            ),
+            running = false,
+            inflightText = "Stored prefix and recovered suffix",
+        )
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(TurnState.Idle, state.turnState)
+        assertEquals("", state.streamingText)
+        assertEquals(
+            listOf("Recover this turn", "Stored prefix and recovered suffix"),
+            state.messages.map { it.text },
+        )
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun profileAndOriginChangesClearGatewayBoundStateAndOldEvents() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
@@ -1011,12 +1082,16 @@ class CelesteViewModelTest {
         private fun resumePayload(
             messages: List<ConversationMessage>,
             running: Boolean,
+            inflightText: String? = null,
         ): JsonObject {
             val encodedMessages = messages.joinToString(",") { message ->
                 """{"id":${Json.encodeToString(message.id ?: "")},"role":${Json.encodeToString(message.role)},"text":${Json.encodeToString(message.text)}}"""
             }
+            val encodedInflight = inflightText?.let { text ->
+                """{"text":${Json.encodeToString(text)}}"""
+            } ?: "null"
             return Json.parseToJsonElement(
-                """{"session_id":"runtime-7","resumed":"stored-42","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":null,"messages":[$encodedMessages]}""",
+                """{"session_id":"runtime-7","resumed":"stored-42","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":$encodedInflight,"messages":[$encodedMessages]}""",
             ) as JsonObject
         }
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -2,6 +2,7 @@ package dev.hazydreams.hermesceleste
 
 import java.io.IOException
 
+import dev.hazydreams.hermesceleste.connection.ConnectionStore
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
 import dev.hazydreams.hermesceleste.connection.ReusableSecret
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
@@ -23,6 +24,7 @@ import dev.hazydreams.hermesceleste.network.StoredSession
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -33,6 +35,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -111,6 +114,56 @@ class CelesteViewModelTest {
         assertTrue(gateway.methods.contains("session.interrupt"))
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         assertEquals("Partial work", viewModel.state.value.messages.last().text)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun errorCompletionRetainsAuthoritativePartialAssistantContent() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+
+        viewModel.updateDraft("Keep the partial response")
+        viewModel.sendMessage()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"streamed prefix"}""")
+        gateway.emit(
+            "message.complete",
+            """{"content":"authoritative partial response","status":"error"}""",
+        )
+        advanceUntilIdle()
+
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertEquals("authoritative partial response", viewModel.state.value.messages.last().text)
+        assertEquals(UiNoticeCategory.ServerTurnFailure, viewModel.state.value.notice?.category)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun interruptFailureStillReconcilesBeforeProjectingRecovery() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        viewModel.updateDraft("Stop this turn")
+        viewModel.sendMessage()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"safe partial"}""")
+        advanceUntilIdle()
+
+        gateway.interruptFailure = IOException("interrupt delivery failed")
+        gateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "user", text = "Stop this turn", id = "server-user"),
+                ConversationMessage(role = "assistant", text = "authoritative partial", id = "server-assistant"),
+            ),
+            running = false,
+        )
+        viewModel.interrupt()
+        advanceUntilIdle()
+
+        assertEquals(1, gateway.methods.count { it == "session.interrupt" })
+        assertEquals(2, gateway.methods.count { it == "session.resume" })
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertEquals("authoritative partial", viewModel.state.value.messages.last().text)
+        assertNull(viewModel.state.value.notice)
         viewModel.leaveConversation()
     }
 
@@ -269,6 +322,30 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun staleAuthenticationCannotPublishAfterBackgroundStoreWait() = runTest {
+        val clearGate = CompletableDeferred<Unit>()
+        val store = BlockingClearConnectionStore(clearGate)
+        val dashboard = FakeDashboard(FakeGateway()).apply {
+            sessionFailure = AuthenticationRejected("synthetic auth rejection")
+        }
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        advanceUntilIdle()
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.loadSessions()
+        store.clearEntered.await()
+
+        viewModel.onBackground()
+        clearGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.connectionPhase != ConnectionPhase.AuthenticationRequired)
+        assertNull(viewModel.state.value.notice)
+    }
+
+
+    @Test
     fun foregroundHealthCheckReplacesAStaleSocketAndResumes() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
@@ -307,6 +384,129 @@ class CelesteViewModelTest {
         assertEquals("after foreground", viewModel.state.value.streamingText)
         viewModel.leaveConversation()
     }
+
+    @Test
+    fun backgroundDuringRestoreIsCanceledAndForegroundRetriesWithNoGateway() = runTest {
+        val descriptor = SavedConnectionDescriptor(
+            baseUrl = "http://hermes.test:9119",
+            authMode = SavedAuthMode.Open,
+            expectsSecret = false,
+        )
+        val probeGate = CompletableDeferred<Unit>()
+        val dashboard = FakeDashboard(FakeGateway()).apply {
+            this.probeGate = probeGate
+            probeEntered = CompletableDeferred()
+        }
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            connectionStore = InMemoryConnectionStore(StoredConnection(descriptor, null)),
+        )
+        dashboard.probeEntered?.await()
+
+        viewModel.onBackground()
+        runCurrent()
+        viewModel.onForeground()
+        runCurrent()
+
+        assertTrue(dashboard.probeCalls >= 2)
+        probeGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.Connected, viewModel.state.value.connectionPhase)
+        assertNull(viewModel.state.value.activeSummary)
+    }
+
+    @Test
+    fun backgroundDuringProbeIsCanceledAndForegroundRetriesTheProbe() = runTest {
+        val probeGate = CompletableDeferred<Unit>()
+        val dashboard = FakeDashboard(FakeGateway()).apply {
+            this.probeGate = probeGate
+            probeEntered = CompletableDeferred()
+        }
+        val viewModel = CelesteViewModel(dashboard = dashboard)
+        advanceUntilIdle()
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        dashboard.probeEntered?.await()
+
+        viewModel.onBackground()
+        runCurrent()
+        viewModel.onForeground()
+        runCurrent()
+
+        assertTrue(dashboard.probeCalls >= 2)
+        probeGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
+        assertNotNull(viewModel.state.value.probe)
+        assertNull(viewModel.state.value.loadingMessage)
+    }
+
+    @Test
+    fun backgroundDuringSessionListIsCanceledAndForegroundReloadsSessions() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = CelesteViewModel(dashboard = dashboard)
+        advanceUntilIdle()
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+
+        val sessionsGate = CompletableDeferred<Unit>()
+        dashboard.sessionsGate = sessionsGate
+        dashboard.sessionsEntered = CompletableDeferred()
+        viewModel.loadSessions()
+        dashboard.sessionsEntered?.await()
+
+        viewModel.onBackground()
+        runCurrent()
+        viewModel.onForeground()
+        runCurrent()
+
+        assertTrue(dashboard.sessionCalls >= 2)
+        sessionsGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.Connected, viewModel.state.value.connectionPhase)
+        assertNotNull(viewModel.state.value.sessions)
+        assertNull(viewModel.state.value.loadingMessage)
+    }
+
+    @Test
+    fun backgroundDuringCreateBeforeSessionClosesGatewayAndForegroundCreatesAgain() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(dashboard = dashboard)
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        val createGate = CompletableDeferred<Unit>()
+        gateway.createGate = createGate
+        gateway.createEntered = CompletableDeferred()
+        viewModel.createNewConversation()
+        gateway.createEntered?.await()
+
+        viewModel.onBackground()
+        runCurrent()
+        assertTrue(gateway.closeCount > 0)
+
+        val secondCreateEntered = CompletableDeferred<Unit>()
+        gateway.createEntered = secondCreateEntered
+        viewModel.onForeground()
+        runCurrent()
+        secondCreateEntered.await()
+        createGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(2, gateway.methods.count { it == "session.create" })
+        assertNotNull(viewModel.state.value.activeSummary)
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertNull(viewModel.state.value.notice)
+        viewModel.leaveConversation()
+    }
+
 
     @Test
     fun cancelledReconciliationReleasesItsGlobalGateForForegroundRecovery() = runTest {
@@ -593,12 +793,40 @@ class CelesteViewModelTest {
         return viewModel
     }
 
+    private class BlockingClearConnectionStore(
+        private val clearGate: CompletableDeferred<Unit>,
+    ) : ConnectionStore {
+        val clearEntered = CompletableDeferred<Unit>()
+
+        override suspend fun load(): StoredConnection? = null
+
+        override suspend fun replace(
+            descriptor: SavedConnectionDescriptor,
+            secret: ReusableSecret?,
+        ) = Unit
+
+        override suspend fun clearSecret() {
+            withContext(NonCancellable) {
+                clearEntered.complete(Unit)
+                clearGate.await()
+            }
+        }
+
+        override suspend fun forget() = Unit
+    }
+
     private class FakeDashboard(
         private val gateway: FakeGateway,
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
         var sessionFailure: Throwable? = null
+        var probeGate: CompletableDeferred<Unit>? = null
+        var probeEntered: CompletableDeferred<Unit>? = null
+        var sessionsGate: CompletableDeferred<Unit>? = null
+        var sessionsEntered: CompletableDeferred<Unit>? = null
+        var probeCalls = 0
+        var sessionCalls = 0
         var profileCatalog = listOf(
             DashboardProfile(name = "default", isDefault = true),
             DashboardProfile(name = "work"),
@@ -613,8 +841,11 @@ class CelesteViewModelTest {
             source = "desktop",
         )
 
-        override suspend fun probe(rawBaseUrl: String): DashboardProbeResult =
-            DashboardProbeResult(
+        override suspend fun probe(rawBaseUrl: String): DashboardProbeResult {
+            probeCalls += 1
+            probeEntered?.complete(Unit)
+            probeGate?.await()
+            return DashboardProbeResult(
                 baseUrl = rawBaseUrl,
                 authRequired = authRequired,
                 providers = if (authRequired) {
@@ -624,6 +855,7 @@ class CelesteViewModelTest {
                 },
                 version = "test",
             )
+        }
 
         override suspend fun passwordLogin(
             baseUrl: String,
@@ -637,6 +869,9 @@ class CelesteViewModelTest {
             credential: GatewayCredential,
             limit: Int,
         ): List<StoredSession> {
+            sessionCalls += 1
+            sessionsEntered?.complete(Unit)
+            sessionsGate?.await()
             sessionFailure?.let { throw it }
             return listOf(session)
         }
@@ -671,6 +906,9 @@ class CelesteViewModelTest {
         var failHealthCheck = false
         var connectFailure: Throwable? = null
         var promptFailure: Throwable? = null
+        var interruptFailure: Throwable? = null
+        var createGate: CompletableDeferred<Unit>? = null
+        var createEntered: CompletableDeferred<Unit>? = null
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
         val resumePayloads = mutableListOf<JsonObject>()
         val resumeGates = mutableListOf<CompletableDeferred<Unit>>()
@@ -716,6 +954,8 @@ class CelesteViewModelTest {
                 }
                 "session.create" -> {
                     createCount += 1
+                    createEntered?.complete(Unit)
+                    createGate?.await()
                     buildJsonObject {
                         put("session_id", "runtime-new-$createCount")
                         put("stored_session_id", "stored-new-$createCount")
@@ -736,7 +976,13 @@ class CelesteViewModelTest {
                     }
                     buildJsonObject { put("status", "streaming") }
                 }
-                "session.interrupt" -> buildJsonObject { put("status", "interrupting") }
+                "session.interrupt" -> {
+                    interruptFailure?.let { failure ->
+                        interruptFailure = null
+                        throw failure
+                    }
+                    buildJsonObject { put("status", "interrupting") }
+                }
                 else -> buildJsonObject {}
             }
         }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -14,7 +14,9 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
 import dev.hazydreams.hermesceleste.network.StoredSession
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -24,6 +26,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.Json
@@ -35,6 +38,7 @@ import kotlinx.serialization.json.put
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -212,6 +216,197 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun foregroundReattachesGatewayCollectorsAfterBackgrounding() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+
+        viewModel.onBackground()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"stale background event"}""")
+        runCurrent()
+
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertEquals("", viewModel.state.value.streamingText)
+
+        viewModel.onForeground()
+        advanceUntilIdle()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"after foreground"}""")
+        advanceUntilIdle()
+
+        assertEquals(TurnState.Running, viewModel.state.value.turnState)
+        assertEquals("after foreground", viewModel.state.value.streamingText)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun cancelledReconciliationReleasesItsGlobalGateForForegroundRecovery() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        val resumeGate = CompletableDeferred<Unit>()
+        val resumeEntered = CompletableDeferred<Unit>()
+        gateway.resumeGate = resumeGate
+        gateway.resumeEntered = resumeEntered
+
+        gateway.disconnect("reconnect for cancellation test")
+        resumeEntered.await()
+
+        viewModel.onBackground()
+        runCurrent()
+        resumeGate.complete(Unit)
+
+        viewModel.onForeground()
+        advanceUntilIdle()
+
+        assertTrue(gateway.methods.count { it == "session.resume" } >= 3)
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertNull(viewModel.state.value.notice)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun staleStoppedTurnEventsCannotRearmTheConversation() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        viewModel.updateDraft("Stop this turn")
+        viewModel.sendMessage()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"safe partial"}""")
+        advanceUntilIdle()
+
+        gateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "user", text = "Stop this turn", id = "server-user"),
+                ConversationMessage(role = "assistant", text = "safe partial", id = "server-assistant"),
+            ),
+            running = false,
+        )
+        viewModel.interrupt()
+        advanceUntilIdle()
+
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"stale response"}""")
+        gateway.emit("session.busy", """{"busy":true}""")
+        gateway.emit("session.info", """{"running":true}""")
+        advanceUntilIdle()
+
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertEquals("", viewModel.state.value.streamingText)
+        assertEquals(listOf("user", "assistant"), viewModel.state.value.messages.map { it.role })
+        assertEquals("safe partial", viewModel.state.value.messages.last().text)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun profileAndOriginChangesClearGatewayBoundStateAndOldEvents() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://first.hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+
+        viewModel.selectProfile("work")
+        advanceUntilIdle()
+
+        assertEquals("work", viewModel.state.value.selectedProfile)
+        assertNotNull(viewModel.state.value.sessions)
+        assertNull(viewModel.state.value.activeSummary)
+        assertTrue(gateway.closeCount > 0)
+
+        gateway.emit("message.error", """{"message":"old profile failure"}""")
+        runCurrent()
+        assertNull(viewModel.state.value.notice)
+
+        dashboard.profileCatalog = listOf(DashboardProfile(name = "default", isDefault = true))
+        viewModel.updateDashboardUrl("http://second.hermes.test:9119")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+
+        assertEquals("http://second.hermes.test:9119", viewModel.state.value.dashboardUrl)
+        assertNull(viewModel.state.value.sessions)
+        assertNull(viewModel.state.value.activeSummary)
+        assertNull(viewModel.state.value.notice)
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.Connected, viewModel.state.value.connectionPhase)
+        assertEquals("default", viewModel.state.value.selectedProfile)
+        assertEquals("http://second.hermes.test:9119", viewModel.state.value.probe?.baseUrl)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun authRpcFailureKeepsAExplicitSignInRecoveryAction() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        gateway.connectFailure = GatewayRpcException(
+            code = 401,
+            message = "raw auth failure at https://private.example/path",
+        )
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+
+        val notice = requireNotNull(viewModel.state.value.notice)
+        assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
+        assertEquals(UiNoticeCategory.AuthenticationRequired, notice.category)
+        assertEquals(UiRecoveryAction.SignIn, notice.recovery)
+        assertEquals("Your Hermes sign-in has expired. Sign in again.", notice.message)
+        assertNull(viewModel.state.value.activeSummary)
+    }
+
+    @Test
+    fun protocolRpcFailureKeepsTypedRetryCopyAndRedactsRawErrorText() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val diagnostics = mutableListOf<SanitizedDiagnostic>()
+        val rawError = "StandaloneCoroutine was cancelled at https://private.example/path /srv/private prompt"
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 60_000L },
+            diagnosticsSink = DiagnosticsSink { diagnostics += it },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        gateway.resumeFailure = GatewayRpcException(code = -32602, message = rawError)
+        viewModel.openSession(dashboard.session)
+        runCurrent()
+
+        val state = viewModel.state.value
+        val notice = requireNotNull(state.notice)
+        assertEquals(UiNoticeCategory.InvalidResponse, notice.category)
+        assertEquals(UiRecoveryAction.Retry, notice.recovery)
+        assertEquals("Hermes returned an unexpected response. Try again.", notice.message)
+        assertFalse(state.toString().contains(rawError))
+        assertFalse(state.toString().contains("StandaloneCoroutine"))
+        assertTrue(diagnostics.isNotEmpty())
+        assertTrue(diagnostics.none { it.toString().contains(rawError) })
+        assertTrue(diagnostics.none { it.toString().contains("private.example") })
+        assertTrue(diagnostics.none { it.toString().contains("/srv/private") })
+        assertTrue(diagnostics.none { it.toString().contains("prompt") })
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun createsInTheSelectedProfileAndRecreatesOnlyAnUntouchedDraftSession() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
@@ -241,6 +436,8 @@ class CelesteViewModelTest {
         assertEquals(2, gateway.methods.count { it == "session.create" })
         assertEquals(0, gateway.methods.count { it == "session.resume" })
         assertEquals("stored-new-2", viewModel.state.value.activeSummary?.id)
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertNull(viewModel.state.value.notice)
 
         viewModel.updateDraft("Persist this conversation")
         viewModel.sendMessage()
@@ -257,6 +454,8 @@ class CelesteViewModelTest {
         assertEquals(2, gateway.methods.count { it == "session.create" })
         assertEquals(1, gateway.methods.count { it == "session.resume" })
         assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertNull(viewModel.state.value.notice)
         viewModel.leaveConversation()
     }
 
@@ -288,6 +487,10 @@ class CelesteViewModelTest {
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
+        var profileCatalog = listOf(
+            DashboardProfile(name = "default", isDefault = true),
+            DashboardProfile(name = "work"),
+        )
 
         val session = StoredSession(
             id = "stored-42",
@@ -328,10 +531,7 @@ class CelesteViewModelTest {
             credential: GatewayCredential,
         ): List<DashboardProfile> {
             profileFailure?.let { throw it }
-            return listOf(
-                DashboardProfile(name = "default", isDefault = true),
-                DashboardProfile(name = "work"),
-            )
+            return profileCatalog
         }
 
         override fun exportAuthentication(baseUrl: String): AuthenticationMaterial? =
@@ -356,6 +556,10 @@ class CelesteViewModelTest {
         var failHealthCheck = false
         var connectFailure: Throwable? = null
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
+        var resumeFailure: Throwable? = null
+        var resumeGate: CompletableDeferred<Unit>? = null
+        var resumeEntered: CompletableDeferred<Unit>? = null
+        var closeCount = 0
 
         override suspend fun connect() {
             connectCount += 1
@@ -371,7 +575,12 @@ class CelesteViewModelTest {
             methods += method
             requests += method to params
             return when (method) {
-                "session.resume" -> resumePayload
+                "session.resume" -> {
+                    resumeEntered?.complete(Unit)
+                    resumeGate?.await()
+                    resumeFailure?.let { throw it }
+                    resumePayload
+                }
                 "session.create" -> {
                     createCount += 1
                     buildJsonObject {
@@ -394,6 +603,7 @@ class CelesteViewModelTest {
         }
 
         override fun close() {
+            closeCount += 1
             mutableState.value = GatewayConnectionState.Closed
         }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -189,7 +189,10 @@ class CelesteViewModelTest {
 
         assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
         assertNull(viewModel.state.value.sessions)
-        assertEquals("Hermes rejected profile access.", viewModel.state.value.errorMessage)
+        val notice = requireNotNull(viewModel.state.value.notice)
+        assertEquals(UiNoticeCategory.AuthenticationRequired, notice.category)
+        assertEquals(UiRecoveryAction.SignIn, notice.recovery)
+        assertEquals("Your Hermes sign-in has expired. Sign in again.", notice.message)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/UiProjectionTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/UiProjectionTest.kt
@@ -1,0 +1,70 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.network.AuthenticationRejected
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
+import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
+import dev.hazydreams.hermesceleste.network.RateLimited
+import dev.hazydreams.hermesceleste.network.TransportUnavailable
+import java.util.concurrent.CancellationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UiProjectionTest {
+    @Test
+    fun mapsCurrentFailuresToStableCopyAndRecoveryWithoutCauseText() {
+        val forbiddenText = "StandaloneCoroutine was cancelled at https://private.example/path /srv/private prompt"
+        val cases = listOf(
+            AuthenticationRejected(forbiddenText) to UiNoticeCategory.AuthenticationRequired,
+            RateLimited(forbiddenText) to UiNoticeCategory.RateLimited,
+            TransportUnavailable(forbiddenText) to UiNoticeCategory.TransportUnavailable,
+            InvalidDashboardResponse(forbiddenText) to UiNoticeCategory.InvalidResponse,
+            GatewayRpcException(500, forbiddenText) to UiNoticeCategory.GenericTurnFailure,
+        )
+
+        cases.forEach { (error, category) ->
+            val notice = requireNotNull(projectUiNotice(error, UiNoticeScope.Turn))
+            assertEquals(category, notice.category)
+            assertFalse(notice.message.contains(forbiddenText))
+            assertFalse(notice.message.contains("StandaloneCoroutine"))
+            assertFalse(notice.message.contains("private.example"))
+            assertFalse(notice.message.contains("/srv/private"))
+            assertFalse(notice.message.contains("prompt"))
+        }
+    }
+
+    @Test
+    fun cancellationAndWrappedCancellationAreSilentControlFlow() {
+        val direct = CancellationException("StandaloneCoroutine was cancelled")
+        val wrapped = IllegalStateException("legacy boundary", direct)
+
+        assertNull(projectUiNotice(direct, UiNoticeScope.Turn))
+        assertNull(projectUiNotice(wrapped, UiNoticeScope.Connection))
+        assertEquals("cancelled", diagnosticReason(direct))
+    }
+
+    @Test
+    fun diagnosticsSerializationIsContentFree() {
+        val diagnostic = SanitizedDiagnostic(
+            category = "TransportUnavailable",
+            reasonCode = "transport_unavailable",
+            operation = "open_session",
+            exceptionClass = "IOException",
+            operationGeneration = 7,
+            gatewayGeneration = 3,
+            lifecycleGeneration = 2,
+            retryCount = 1,
+        )
+        val serialized = Json.encodeToString(diagnostic)
+
+        assertTrue(serialized.contains("TransportUnavailable"))
+        assertTrue(serialized.contains("open_session"))
+        assertFalse(serialized.contains("https://private.example"))
+        assertFalse(serialized.contains("prompt"))
+        assertFalse(serialized.contains("StandaloneCoroutine"))
+    }
+}


### PR DESCRIPTION
## Summary
- DF-07 scope: sanitize cancellation and operation failures.
- Paired DF-07 specs and the temporary tracker are included in this candidate.

## Approvals
- Final Luna spec: PASS.
- Quality: APPROVED.

## Validation
- Focused host tests: `CelesteViewModelAutoLoginTest` 15/15 passed.
- Not run locally: other Gradle gates, lint, screenshot validation, Android/device checks, and APK gates.

## Review status
- Opened as an honest draft; no merge requested.