### PR TITLE
feat: present agent activity safely

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCardsSemanticsTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCardsSemanticsTest.kt
@@ -1,0 +1,164 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.assertIsSelectable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
+import dev.hazydreams.hermesceleste.network.ActivityItem
+import dev.hazydreams.hermesceleste.network.ActivityPresentationState
+import dev.hazydreams.hermesceleste.network.ActivitySource
+import dev.hazydreams.hermesceleste.network.AgentActivityProjection
+import dev.hazydreams.hermesceleste.network.CorrelationQuality
+import dev.hazydreams.hermesceleste.network.DisplayedDetail
+import dev.hazydreams.hermesceleste.network.ReasoningPhase
+import dev.hazydreams.hermesceleste.network.ReasoningSource
+import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
+import dev.hazydreams.hermesceleste.network.ToolActivity
+import dev.hazydreams.hermesceleste.network.ToolPhase
+import dev.hazydreams.hermesceleste.network.initialActivityProjection
+import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AgentActivityCardsSemanticsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun mountedActivityUsesButtonRolesLabelsAndVisibleExpandedState() {
+        setActivityContent()
+
+        val activity = composeRule.onNodeWithContentDescription("Agent activity, Available")
+        activity.assert(hasRole(Role.Button))
+        activity.assert(hasStateDescription("Collapsed"))
+        activity.performClick()
+        activity.assert(hasStateDescription("Expanded"))
+
+        val tool = composeRule.onNodeWithContentDescription(
+            "Tool terminal, Completed",
+            useUnmergedTree = true,
+        )
+        tool.assert(hasRole(Role.Button))
+        tool.assert(hasStateDescription("Collapsed"))
+        tool.performClick()
+        tool.assert(hasStateDescription("Expanded"))
+
+        composeRule.onNodeWithContentDescription(
+            "Server-provided reasoning, Complete",
+            useUnmergedTree = true,
+        ).assert(hasRole(Role.Button))
+        composeRule.onNodeWithText("Tool", useUnmergedTree = true).assertExists()
+        composeRule.onNodeWithText("Server-provided reasoning", useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun mountedActivityMarksPhaseChangesAsPoliteLiveRegions() {
+        setActivityContent()
+        composeRule.onNodeWithContentDescription("Agent activity, Available").performClick()
+
+        composeRule.onNodeWithContentDescription(
+            "Tool, completed",
+            useUnmergedTree = true,
+        ).assert(hasLiveRegion(LiveRegionMode.Polite))
+        composeRule.onNodeWithContentDescription(
+            "Server-provided reasoning, complete",
+            useUnmergedTree = true,
+        ).assert(hasLiveRegion(LiveRegionMode.Polite))
+    }
+
+    @Test
+    fun mountedActivityDetailIsSelectableAndContainsOnlySanitizedText() {
+        setActivityContent()
+        composeRule.onNodeWithContentDescription("Agent activity, Available").performClick()
+        composeRule.onNodeWithContentDescription(
+            "Tool terminal, Completed",
+            useUnmergedTree = true,
+        ).performClick()
+
+        composeRule.onNodeWithText("[redacted]", useUnmergedTree = true).assertIsSelectable()
+        composeRule.onNodeWithContentDescription(
+            "Displayed output, selectable displayed detail",
+            useUnmergedTree = true,
+        ).assertIsSelectable()
+        composeRule.onNodeWithText("synthetic-raw-output", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    private fun setActivityContent() {
+        composeRule.setContent {
+            HermesCelesteTheme {
+                AgentActivityPanel(
+                    projection = projection(),
+                    reasoningDisclosureEnabled = true,
+                    onReasoningDisclosureChange = {},
+                )
+            }
+        }
+    }
+
+    private fun projection(): AgentActivityProjection {
+        val safeOutput = DisplayedDetail(
+            text = "[redacted]",
+            originalLength = 20,
+            wasTruncated = false,
+            wasRedacted = true,
+            canRestore = false,
+        )
+        val tool = ToolActivity(
+            uiKey = "activity:stored-42:tool-id:call-1:occurrence:1",
+            callId = "call-1",
+            name = "terminal",
+            phase = ToolPhase.Completed,
+            input = null,
+            output = safeOutput,
+            startedAt = null,
+            finishedAt = null,
+            correlation = CorrelationQuality.ExactId,
+        )
+        val reasoning = ServerReasoningActivity(
+            uiKey = "activity:stored-42:reasoning:server:occurrence:1",
+            source = ReasoningSource.ServerSummary,
+            phase = ReasoningPhase.Complete,
+            text = DisplayedDetail(
+                text = "Displayed server summary",
+                originalLength = 24,
+                wasTruncated = false,
+                wasRedacted = false,
+                canRestore = false,
+            ),
+            serverLabel = "Server-provided reasoning",
+        )
+        return initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        ).copy(
+            items = listOf<ActivityItem>(tool, reasoning),
+            source = ActivitySource.Live,
+            capability = ActivityCapabilityState.ToolAndServerReasoning,
+            presentation = ActivityPresentationState.Available,
+            serverReasoningAllowed = true,
+        )
+    }
+
+    private fun hasRole(expected: Role): SemanticsMatcher =
+        SemanticsMatcher.expectValue(SemanticsProperties.Role, expected)
+
+    private fun hasStateDescription(expected: String): SemanticsMatcher =
+        SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, expected)
+
+    private fun hasLiveRegion(expected: LiveRegionMode): SemanticsMatcher =
+        SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, expected)
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -17,6 +17,7 @@ import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardService
 import dev.hazydreams.hermesceleste.network.DashboardUrlPolicy
+import dev.hazydreams.hermesceleste.network.DisplayedDetail
 import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
@@ -1317,16 +1318,25 @@ internal class CelesteViewModel(
         }
         val currentMessages = mutableState.value.messages
         val previous = currentMessages.lastOrNull()
+        val previousTextForMerge = previous
+            ?.takeIf { it.role == "assistant" && it.interim }
+            ?.let { deduplicateReasoningFromFinalContent(it.text) }
+            ?: previous?.text
         val continuesInterim = !interim &&
             previous?.role == "assistant" &&
             previous.interim &&
             finalText.isNotBlank() &&
-            (finalText.startsWith(previous.text) || previous.text.startsWith(finalText))
+            (finalText.startsWith(previousTextForMerge.orEmpty()) ||
+                previousTextForMerge.orEmpty().startsWith(finalText))
         val messages = when {
             !interim && previous?.let(::isReasoningOnlyInterim) == true && finalText.isBlank() ->
                 currentMessages.dropLast(1)
             continuesInterim -> currentMessages.dropLast(1) + previous.copy(
-                text = if (finalText.length >= previous.text.length) finalText else previous.text,
+                text = if (finalText.length >= previousTextForMerge.orEmpty().length) {
+                    finalText
+                } else {
+                    previousTextForMerge.orEmpty()
+                },
                 interim = false,
             )
             finalText.isNotBlank() && previous?.let { it.role == "assistant" && it.text == finalText } != true ->
@@ -1348,29 +1358,68 @@ internal class CelesteViewModel(
         var content = raw
         val reasoningDetails = mutableState.value.agentActivity?.items
             .filterIsInstance<ServerReasoningActivity>()
-            .map { it.text.text.trim() }
-            .filter(String::isNotBlank)
-            .distinct()
-            .sortedByDescending { it.length }
-        reasoningDetails.forEach { reasoning ->
-            val normalized = content.trim()
-            content = when {
-                normalized == reasoning -> ""
-                normalized.startsWith(reasoning) -> normalized.removePrefix(reasoning).trimStart()
-                normalized.endsWith(reasoning) -> normalized.removeSuffix(reasoning).trimEnd()
-                else -> content
-            }
+            .map(ServerReasoningActivity::text)
+            .filter { it.text.isNotBlank() }
+            .distinctBy { it.text }
+            .sortedByDescending { it.text.length }
+        reasoningDetails.forEach { detail ->
+            content = removeDisclosedReasoning(content, detail)
         }
-        return content
+        return content.trimEnd()
+    }
+
+    private fun removeDisclosedReasoning(content: String, detail: DisplayedDetail): String {
+        var result = removeExactReasoningOccurrences(content, detail.text.trim())
+        if (!detail.wasTruncated) return result
+
+        // The projection intentionally retains only a bounded prefix. If the
+        // final assistant field repeats the full disclosed body, use the safe
+        // prefix plus its original code-point count to remove that occurrence
+        // without retaining the undisplayed tail locally.
+        val marker = " … truncated (original length: ${detail.originalLength} chars)"
+        val prefix = detail.text.removeSuffix(marker)
+        if (prefix.isBlank()) return result
+        var start = result.indexOf(prefix)
+        while (start >= 0) {
+            val end = runCatching {
+                result.offsetByCodePoints(start, detail.originalLength)
+            }.getOrNull()
+            if (end == null) break
+            result = joinAfterReasoningRemoval(result, start, end)
+            start = result.indexOf(prefix)
+        }
+        return result
+    }
+
+    private fun removeExactReasoningOccurrences(content: String, reasoning: String): String {
+        if (reasoning.isBlank()) return content
+        var result = content
+        var start = result.indexOf(reasoning)
+        while (start >= 0) {
+            result = joinAfterReasoningRemoval(result, start, start + reasoning.length)
+            start = result.indexOf(reasoning)
+        }
+        return result
+    }
+
+    private fun joinAfterReasoningRemoval(content: String, start: Int, end: Int): String {
+        val before = content.substring(0, start)
+        val after = content.substring(end)
+        val hasLineBreak = before.takeLastWhile(Char::isWhitespace).any { it == '\n' || it == '\r' } ||
+            after.takeWhile(Char::isWhitespace).any { it == '\n' || it == '\r' }
+        val cleanBefore = before.trimEnd()
+        val cleanAfter = after.trimStart()
+        val separator = if (cleanBefore.isNotEmpty() && cleanAfter.isNotEmpty()) {
+            if (hasLineBreak) "\n" else " "
+        } else {
+            ""
+        }
+        return cleanBefore + separator + cleanAfter
     }
 
     private fun isReasoningOnlyInterim(message: ConversationMessage): Boolean {
         if (message.role != "assistant" || !message.interim) return false
-        val text = message.text.trim()
-        return mutableState.value.agentActivity?.items
-            ?.filterIsInstance<ServerReasoningActivity>()
-            ?.any { it.text.text.trim() == text && text.isNotBlank() }
-            == true
+        return deduplicateReasoningFromFinalContent(message.text).isBlank()
     }
 
     private suspend fun recreateBlankSession(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -45,6 +45,7 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -94,7 +95,7 @@ internal data class CelesteUiState(
     val draft: String = "",
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
-    val errorMessage: String? = null,
+    val notice: UiNotice? = null,
 ) {
     /** Compatibility alias for callers that name the projection explicitly. */
     val activityProjection: AgentActivityProjection? get() = agentActivity
@@ -136,6 +137,21 @@ private data class PendingReasoningDelta(
     val reconciliationGuard: ReconciliationGuard?,
 )
 
+private enum class SessionOperation {
+    Open,
+    Create,
+    Send,
+    Interrupt,
+}
+
+private class SessionOperationToken(
+    val operation: SessionOperation,
+    val generation: Long,
+    var context: SessionContextGuard,
+)
+
+private class SupersededSessionOperationCancellation : CancellationException()
+
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
@@ -161,6 +177,8 @@ internal class CelesteViewModel(
     private var activityDiscoveryJob: Job? = null
     private var reasoningCoalescingJob: Job? = null
     private var pendingReasoningDeltas = mutableListOf<PendingReasoningDelta>()
+    private val sessionOperationJobs = mutableMapOf<SessionOperation, Pair<Long, Job>>()
+    private var sessionOperationGeneration = 0L
     private var connectionAttempt = 0L
     private val connectionStoreMutex = Mutex()
     private val reconciliationMutex = Mutex()
@@ -187,7 +205,7 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             dashboardUrl = value,
             probe = null,
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -213,20 +231,49 @@ internal class CelesteViewModel(
      * private text to preferences or a local transcript.
      */
     fun setActivityReasoningDisclosureEnabled(enabled: Boolean) {
-        activityReasoningDisclosureEnabled = enabled
-        runCatching {
-            activityDisclosureScope?.let { scope ->
-                activityDisclosurePreferences.setServerReasoningDisclosureEnabled(scope, enabled)
-            } ?: activityDisclosurePreferences.setServerReasoningDisclosureEnabled(enabled)
+        val previousEnabled = activityReasoningDisclosureEnabled
+        val previousActivity = mutableState.value.agentActivity
+        val scope = activityDisclosureScope
+        val writePreference: (Boolean) -> Boolean = { value ->
+            if (scope == null) {
+                activityDisclosurePreferences.setServerReasoningDisclosureEnabled(value)
+            } else {
+                activityDisclosurePreferences.setServerReasoningDisclosureEnabled(scope, value)
+            }
         }
-        val activity = mutableState.value.agentActivity
+        val readPreference: () -> Boolean = {
+            if (scope == null) {
+                activityDisclosurePreferences.isServerReasoningDisclosureEnabled()
+            } else {
+                activityDisclosurePreferences.isServerReasoningDisclosureEnabled(scope)
+            }
+        }
+        val writeSucceeded = runCatching { writePreference(enabled) }.getOrDefault(false)
+        if (!writeSucceeded) {
+            // A failed commit must not make the UI claim a value that will be
+            // lost on the next process. Verify the best-effort rollback even
+            // when the backend reported failure after partially applying it.
+            runCatching {
+                writePreference(previousEnabled)
+                readPreference() == previousEnabled
+            }
+            activityReasoningDisclosureEnabled = previousEnabled
+            mutableState.value = mutableState.value.copy(
+                agentActivityReasoningDisclosureEnabled = previousEnabled,
+                notice = UiNotice.preferencePersistence(),
+            )
+            return
+        }
+
+        activityReasoningDisclosureEnabled = enabled
         mutableState.value = mutableState.value.copy(
             agentActivityReasoningDisclosureEnabled = enabled,
-            agentActivity = if (enabled || activity == null) {
-                activity
+            agentActivity = if (enabled || previousActivity == null) {
+                previousActivity
             } else {
-                AgentActivityReducer.withoutServerReasoning(activity)
+                AgentActivityReducer.withoutServerReasoning(previousActivity)
             },
+            notice = null,
         )
     }
 
@@ -253,7 +300,7 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             loadingMessage = "Finding Hermes…",
-            errorMessage = null,
+            notice = null,
         )
         connectionJob = viewModelScope.launch {
             runCatching { dashboard.probe(rawUrl) }
@@ -267,7 +314,7 @@ internal class CelesteViewModel(
                 .onFailure { error ->
                     if (!isCurrentConnectionAttempt(attempt)) return@onFailure
                     mutableState.value = mutableState.value.copy(
-                        errorMessage = error.message ?: "Could not reach the Hermes dashboard.",
+                        notice = projectUiNotice(error, UiNoticeScope.Connection),
                     )
                 }
             if (!isCurrentConnectionAttempt(attempt)) return@launch
@@ -283,7 +330,7 @@ internal class CelesteViewModel(
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             loadingMessage = "Loading your conversations…",
-            errorMessage = null,
+            notice = null,
         )
         connectionJob = viewModelScope.launch {
             runCatching {
@@ -345,17 +392,17 @@ internal class CelesteViewModel(
                     loaded = remembered.loaded,
                     password = "",
                     sessionToken = "",
-                    errorMessage = if (remembered.persistenceError == null) {
+                    notice = if (remembered.persistenceError == null) {
                         null
                     } else {
-                        "Connected, but Celeste could not remember this connection."
+                        UiNotice.persistence()
                     },
                 )
             }.onFailure { error ->
                 if (!isCurrentConnectionAttempt(attempt)) return@onFailure
                 dashboard.clearAuthentication()
                 mutableState.value = mutableState.value.copy(
-                    errorMessage = error.message ?: "Could not load Hermes conversations.",
+                    notice = projectUiNotice(error, UiNoticeScope.Connection),
                     password = "",
                     sessionToken = "",
                 )
@@ -378,7 +425,7 @@ internal class CelesteViewModel(
             agentActivity = null,
             streamingText = "",
             draft = "",
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -418,7 +465,7 @@ internal class CelesteViewModel(
             password = "",
             sessionToken = "",
             loadingMessage = "Signing out…",
-            errorMessage = null,
+            notice = null,
         )
         connectionJob = viewModelScope.launch {
             val (error, saved) = connectionStoreMutex.withLock {
@@ -433,9 +480,7 @@ internal class CelesteViewModel(
             currentDescriptor = saved?.descriptor
             mutableState.value = manualState(
                 descriptor = saved?.descriptor,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved sign-in. Try Forget connection."
-                },
+                notice = if (error == null) null else UiNotice.persistence(),
             )
         }
     }
@@ -465,9 +510,7 @@ internal class CelesteViewModel(
             mutableState.value = CelesteUiState(
                 connectionPhase = ConnectionPhase.ManualSetup,
                 agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved connection. Try again."
-                },
+                notice = if (error == null) null else UiNotice.persistence(),
             )
         }
     }
@@ -490,7 +533,7 @@ internal class CelesteViewModel(
             val saved = savedResult.getOrElse {
                 mutableState.value = manualState(
                     descriptor = null,
-                    errorMessage = "Celeste could not read the saved connection. Sign in again.",
+                    notice = UiNotice.persistence(),
                 )
                 return@launch
             }
@@ -578,9 +621,7 @@ internal class CelesteViewModel(
             )
             publishConnectedDashboard(
                 loaded,
-                errorMessage = if (persistenceError == null) null else {
-                    "Connected, but Celeste could not refresh the saved sign-in."
-                },
+                notice = if (persistenceError == null) null else UiNotice.persistence(),
             )
         }.onFailure { error ->
             if (!isCurrentConnectionAttempt(attempt)) return@onFailure
@@ -588,6 +629,7 @@ internal class CelesteViewModel(
                 invalidateReusableAuthentication(
                     descriptor = descriptor,
                     probe = restoredProbe,
+                    attempt = attempt,
                 )
             } else {
                 dashboard.clearAuthentication()
@@ -599,7 +641,7 @@ internal class CelesteViewModel(
                     dashboardUrl = descriptor.baseUrl,
                     savedAuthMode = descriptor.authMode,
                     username = descriptor.username.orEmpty(),
-                    errorMessage = error.message ?: "Could not reconnect to Hermes.",
+                    notice = projectUiNotice(error, UiNoticeScope.Connection),
                 )
             }
         }
@@ -617,18 +659,22 @@ internal class CelesteViewModel(
     private suspend fun invalidateReusableAuthentication(
         descriptor: SavedConnectionDescriptor?,
         probe: DashboardProbeResult? = null,
+        attempt: Long = connectionAttempt,
     ) {
+        if (!isCurrentConnectionAttempt(attempt)) return
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
         connectionStoreMutex.withLock {
+            if (!isCurrentConnectionAttempt(attempt)) return@withLock
             runCatching { connectionStore.clearSecret() }
         }
+        if (!isCurrentConnectionAttempt(attempt)) return
         mutableState.value = manualState(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
             probe = probe,
-            errorMessage = "Saved sign-in is no longer valid. Sign in again.",
+            notice = UiNotice.authentication(UiNoticeScope.Connection),
         )
     }
 
@@ -636,7 +682,7 @@ internal class CelesteViewModel(
         loaded: LoadedDashboard,
         password: String = "",
         sessionToken: String = "",
-        errorMessage: String? = null,
+        notice: UiNotice? = null,
     ) {
         val selectedProfile = mutableState.value.selectedProfile
             .takeIf { selected -> loaded.profiles.any { it.name == selected } }
@@ -655,7 +701,7 @@ internal class CelesteViewModel(
             password = password,
             sessionToken = sessionToken,
             loadingMessage = null,
-            errorMessage = errorMessage,
+            notice = notice,
         )
     }
 
@@ -663,7 +709,7 @@ internal class CelesteViewModel(
         descriptor: SavedConnectionDescriptor? = null,
         phase: ConnectionPhase = ConnectionPhase.ManualSetup,
         probe: DashboardProbeResult? = null,
-        errorMessage: String? = null,
+        notice: UiNotice? = null,
     ): CelesteUiState = CelesteUiState(
         connectionPhase = phase,
         agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
@@ -671,7 +717,7 @@ internal class CelesteViewModel(
         probe = probe,
         savedAuthMode = descriptor?.authMode,
         username = descriptor?.username.orEmpty(),
-        errorMessage = errorMessage,
+        notice = notice,
     )
 
     private fun useActivityDisclosureScope(scope: ActivityDisclosureScope?) {
@@ -740,6 +786,59 @@ internal class CelesteViewModel(
             gatewayGeneration == context.gatewayGeneration &&
             sessionGeneration == context.sessionGeneration &&
             currentStoredSessionId?.trim()?.takeIf(String::isNotBlank) == context.storedSessionId
+
+    private fun isCurrent(token: SessionOperationToken): Boolean =
+        sessionOperationJobs[token.operation]?.first == token.generation && isCurrent(token.context)
+
+    /** Rebind an owned operation after the server assigns a new session identity. */
+    private fun rebindSessionOperation(
+        token: SessionOperationToken,
+        context: SessionContextGuard,
+    ): Boolean {
+        if (sessionOperationJobs[token.operation]?.first != token.generation) return false
+        token.context = context
+        return true
+    }
+
+    private fun launchSessionOperation(
+        operation: SessionOperation,
+        context: SessionContextGuard,
+        block: suspend (SessionOperationToken) -> Unit,
+    ): Job {
+        sessionOperationJobs[operation]?.second?.cancel()
+        val token = SessionOperationToken(
+            operation = operation,
+            generation = ++sessionOperationGeneration,
+            context = context,
+        )
+        val job = viewModelScope.launch(start = CoroutineStart.LAZY) {
+            try {
+                block(token)
+            } finally {
+                if (sessionOperationJobs[operation]?.first == token.generation) {
+                    sessionOperationJobs.remove(operation)
+                }
+            }
+        }
+        sessionOperationJobs[operation] = token.generation to job
+        job.start()
+        return job
+    }
+
+    private fun cancelSessionOperations() {
+        sessionOperationGeneration += 1
+        sessionOperationJobs.values.forEach { (_, job) -> job.cancel() }
+        sessionOperationJobs.clear()
+    }
+
+    private suspend fun <T> awaitSessionOperation(
+        token: SessionOperationToken,
+        block: suspend () -> T,
+    ): T {
+        val result = block()
+        if (!isCurrent(token)) throw SupersededSessionOperationCancellation()
+        return result
+    }
 
     private fun isActiveSession(activeGateway: GatewayConnection, storedSessionId: String): Boolean =
         gateway === activeGateway &&
@@ -818,30 +917,37 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Synchronizing,
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
-            errorMessage = null,
+            notice = null,
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
         installGateway(newGateway)
         observeGateway(newGateway)
         val operationContext = currentSessionContext(newGateway, summary.id)
-        viewModelScope.launch {
-            runCatching {
-                newGateway.connect()
-                if (!isCurrent(operationContext)) return@runCatching
-                reconcile(newGateway, summary.id)
-            }.onSuccess {
-                if (!isCurrent(operationContext)) return@onSuccess
+        launchSessionOperation(SessionOperation.Open, operationContext) { token ->
+            try {
+                awaitSessionOperation(token) { newGateway.connect() }
+                awaitSessionOperation(token) { reconcile(newGateway, summary.id) }
+                if (!isCurrent(token)) return@launchSessionOperation
                 reconnectAttempts = 0
                 mutableState.value = mutableState.value.copy(loadingMessage = null)
-            }.onFailure { error ->
-                if (!isCurrent(operationContext)) return@onFailure
+            } catch (error: CancellationException) {
+                if (isExpectedCancellation(error)) throw error
+                if (!isCurrent(token)) return@launchSessionOperation
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
-                    errorMessage = error.message ?: "Could not open that Hermes conversation.",
+                    notice = projectUiNotice(error, UiNoticeScope.Session),
                     turnState = TurnState.Reconnecting,
                 )
-                scheduleReconnect(wasRunning = false)
+                if (isCurrent(token)) scheduleReconnect(wasRunning = false)
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchSessionOperation
+                mutableState.value = mutableState.value.copy(
+                    loadingMessage = null,
+                    notice = projectUiNotice(error, UiNoticeScope.Session),
+                    turnState = TurnState.Reconnecting,
+                )
+                if (isCurrent(token)) scheduleReconnect(wasRunning = false)
             }
         }
     }
@@ -860,80 +966,95 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Synchronizing,
             loadingMessage = "Starting a new $selectedProfile conversation…",
-            errorMessage = null,
+            notice = null,
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
         installGateway(newGateway)
         observeGateway(newGateway)
         val operationContext = currentSessionContext(newGateway, null)
-        var createdStoredSessionId: String? = null
-        viewModelScope.launch {
-            runCatching {
-                newGateway.connect()
-                if (!isCurrent(operationContext)) return@runCatching
-                withReconciliationBatch(newGateway, null) { batch ->
-                    val created = newGateway.createSession(selectedProfile)
-                    if (!isCurrent(batch.guard)) return@withReconciliationBatch
-                    val returnedProfile = created.profile?.takeIf(String::isNotBlank)
-                    if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
-                        throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
-                    }
-                    val activityProfile = returnedProfile ?: selectedProfile
-                    currentRuntimeSessionId = created.runtimeSessionId
-                    currentStoredSessionId = created.storedSessionId
-                    currentSessionCanResume = false
-                    sessionGeneration += 1
-                    reconciliationEpoch += 1
-                    batch.guard = ReconciliationGuard(
-                        epoch = reconciliationEpoch,
-                        context = currentSessionContext(newGateway, created.storedSessionId),
-                    )
-                    createdStoredSessionId = created.storedSessionId
-                    val summary = StoredSession(
-                        id = created.storedSessionId,
-                        title = "New conversation",
-                        preview = "",
-                        startedAt = 0.0,
-                        messageCount = 0,
-                        source = "android",
-                        profile = activityProfile,
-                    )
-                    useActivityDisclosureScope(
-                        activityDisclosureScope(connection.baseUrl, activityProfile, created.storedSessionId),
-                    )
-                    mutableState.value = mutableState.value.copy(
-                        sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
-                            .filterNot { it.id == summary.id },
-                        activeSummary = summary,
-                        agentActivity = initialActivityProjection(
-                            originKey = connection.baseUrl,
+        launchSessionOperation(SessionOperation.Create, operationContext) { token ->
+            try {
+                awaitSessionOperation(token) { newGateway.connect() }
+                awaitSessionOperation(token) {
+                    withReconciliationBatch(newGateway, null) { batch ->
+                        val created = awaitSessionOperation(token) {
+                            newGateway.createSession(selectedProfile)
+                        }
+                        if (!isCurrent(token) || !isCurrent(batch.guard)) {
+                            return@withReconciliationBatch
+                        }
+                        val returnedProfile = created.profile?.takeIf(String::isNotBlank)
+                        if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
+                            throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
+                        }
+                        val activityProfile = returnedProfile ?: selectedProfile
+                        currentRuntimeSessionId = created.runtimeSessionId
+                        currentStoredSessionId = created.storedSessionId
+                        currentSessionCanResume = false
+                        sessionGeneration += 1
+                        reconciliationEpoch += 1
+                        val createdContext = currentSessionContext(newGateway, created.storedSessionId)
+                        if (!rebindSessionOperation(token, createdContext)) {
+                            return@withReconciliationBatch
+                        }
+                        batch.guard = ReconciliationGuard(
+                            epoch = reconciliationEpoch,
+                            context = createdContext,
+                        )
+                        val summary = StoredSession(
+                            id = created.storedSessionId,
+                            title = "New conversation",
+                            preview = "",
+                            startedAt = 0.0,
+                            messageCount = 0,
+                            source = "android",
                             profile = activityProfile,
-                            storedSessionId = created.storedSessionId,
-                            runtimeSessionId = created.runtimeSessionId,
-                            capability = connection.activityCapability,
-                        ),
-                        turnState = TurnState.Idle,
-                        loadingMessage = null,
-                        errorMessage = null,
-                    )
-                    replayBufferedEvents(batch)
-                    if (isCurrent(batch.guard)) {
-                        scheduleActivityDiscoveryFallback()
+                        )
+                        useActivityDisclosureScope(
+                            activityDisclosureScope(connection.baseUrl, activityProfile, created.storedSessionId),
+                        )
+                        if (!isCurrent(token)) return@withReconciliationBatch
+                        mutableState.value = mutableState.value.copy(
+                            sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
+                                .filterNot { it.id == summary.id },
+                            activeSummary = summary,
+                            agentActivity = initialActivityProjection(
+                                originKey = connection.baseUrl,
+                                profile = activityProfile,
+                                storedSessionId = created.storedSessionId,
+                                runtimeSessionId = created.runtimeSessionId,
+                                capability = connection.activityCapability,
+                            ),
+                            turnState = TurnState.Idle,
+                            loadingMessage = null,
+                            notice = null,
+                        )
+                        replayBufferedEvents(batch)
+                        if (isCurrent(token) && isCurrent(batch.guard)) {
+                            scheduleActivityDiscoveryFallback()
+                        }
                     }
                 }
-            }.onSuccess {
-                if (gateway === newGateway && currentStoredSessionId == createdStoredSessionId) {
-                    reconnectAttempts = 0
-                }
-            }.onFailure { error ->
-                if (gateway !== newGateway || !isCurrent(operationContext)) return@onFailure
-                closeGateway()
+                if (!isCurrent(token)) return@launchSessionOperation
+                reconnectAttempts = 0
+            } catch (error: CancellationException) {
+                if (isExpectedCancellation(error)) throw error
+                if (!isCurrent(token)) return@launchSessionOperation
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
                     loadingMessage = null,
-                    errorMessage = error.message ?: "Could not create a Hermes conversation.",
+                    notice = projectUiNotice(error, UiNoticeScope.Session),
                 )
+                closeGateway()
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchSessionOperation
+                mutableState.value = mutableState.value.copy(
+                    turnState = TurnState.Idle,
+                    loadingMessage = null,
+                    notice = projectUiNotice(error, UiNoticeScope.Session),
+                )
+                closeGateway()
             }
         }
     }
@@ -949,7 +1070,7 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Idle,
             loadingMessage = null,
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -973,31 +1094,48 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Running,
-            errorMessage = null,
+            notice = null,
         )
         // prompt.submit creates the durable row before work begins. From this point on,
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
-        viewModelScope.launch {
-            runCatching {
-                if (!isCurrent(operationContext)) return@runCatching
-                activeGateway.submitPrompt(runtimeId, text)
+        launchSessionOperation(SessionOperation.Send, operationContext) { token ->
+            try {
+                awaitSessionOperation(token) {
+                    activeGateway.submitPrompt(runtimeId, text)
+                }
+                if (!isCurrent(token)) return@launchSessionOperation
+                mutableState.value = mutableState.value.copy(
+                    messages = mutableState.value.messages.map { message ->
+                        if (message.id == localId) message.copy(pending = false) else message
+                    },
+                )
+            } catch (error: CancellationException) {
+                if (isExpectedCancellation(error)) throw error
+                if (!isCurrent(token)) return@launchSessionOperation
+                mutableState.value = mutableState.value.copy(
+                    notice = projectUiNotice(error, UiNoticeScope.Turn),
+                )
+                runCatching {
+                    awaitSessionOperation(token) {
+                        reconcile(activeGateway, storedSessionId)
+                    }
+                }.onFailure { recoveryError ->
+                    if (isExpectedCancellation(recoveryError)) throw recoveryError
+                }
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchSessionOperation
+                mutableState.value = mutableState.value.copy(
+                    notice = projectUiNotice(error, UiNoticeScope.Turn),
+                )
+                runCatching {
+                    awaitSessionOperation(token) {
+                        reconcile(activeGateway, storedSessionId)
+                    }
+                }.onFailure { recoveryError ->
+                    if (isExpectedCancellation(recoveryError)) throw recoveryError
+                }
             }
-                .onSuccess {
-                    if (!isCurrent(operationContext)) return@onSuccess
-                    mutableState.value = mutableState.value.copy(
-                        messages = mutableState.value.messages.map { message ->
-                            if (message.id == localId) message.copy(pending = false) else message
-                        },
-                    )
-                }
-                .onFailure { error ->
-                    if (!isCurrent(operationContext)) return@onFailure
-                    mutableState.value = mutableState.value.copy(
-                        errorMessage = error.message ?: "Hermes could not send that message.",
-                    )
-                    runCatching { reconcile(activeGateway, storedSessionId) }
-                }
         }
     }
 
@@ -1009,17 +1147,26 @@ internal class CelesteViewModel(
         if (mutableState.value.turnState != TurnState.Running) return
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Synchronizing,
-            errorMessage = null,
+            notice = null,
         )
-        viewModelScope.launch {
-            runCatching {
-                if (!isCurrent(operationContext)) return@runCatching
-                activeGateway.interruptSession(runtimeId)
-                reconcile(activeGateway, storedSessionId)
-            }.onFailure { error ->
-                if (!isCurrent(operationContext)) return@onFailure
+        launchSessionOperation(SessionOperation.Interrupt, operationContext) { token ->
+            try {
+                awaitSessionOperation(token) {
+                    activeGateway.interruptSession(runtimeId)
+                }
+                awaitSessionOperation(token) {
+                    reconcile(activeGateway, storedSessionId)
+                }
+            } catch (error: CancellationException) {
+                if (isExpectedCancellation(error)) throw error
+                if (!isCurrent(token)) return@launchSessionOperation
                 mutableState.value = mutableState.value.copy(
-                    errorMessage = error.message ?: "Hermes could not stop that turn.",
+                    notice = projectUiNotice(error, UiNoticeScope.Turn),
+                )
+            } catch (error: Throwable) {
+                if (!isCurrent(token)) return@launchSessionOperation
+                mutableState.value = mutableState.value.copy(
+                    notice = projectUiNotice(error, UiNoticeScope.Turn),
                 )
             }
         }
@@ -1078,7 +1225,7 @@ internal class CelesteViewModel(
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
                     agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
-                    errorMessage = health.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
+                    notice = UiNotice.reconnecting(),
                 )
                 scheduleReconnect(wasRunning = wasRunning, immediate = true)
             }
@@ -1113,7 +1260,7 @@ internal class CelesteViewModel(
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
                         agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
-                        errorMessage = connectionState.reason,
+                        notice = UiNotice.reconnecting(),
                     )
                     scheduleReconnect(wasRunning)
                 }
@@ -1233,7 +1380,7 @@ internal class CelesteViewModel(
             } else {
                 TurnState.Idle
             },
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -1328,7 +1475,7 @@ internal class CelesteViewModel(
                 mutableState.value = mutableState.value.copy(
                     streamingText = "",
                     turnState = TurnState.Running,
-                    errorMessage = null,
+                    notice = null,
                 )
             }
 
@@ -1372,13 +1519,8 @@ internal class CelesteViewModel(
                 finalizeAssistant(content, keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = if (failed) {
-                        sanitizeActivityText(
-                            failureReason ?: explicitError ?: "Hermes could not finish that response.",
-                            240,
-                        )
-                    } else {
-                        mutableState.value.errorMessage
+                    notice = if (failed) UiNotice.serverTurnFailure() else {
+                        mutableState.value.notice
                     },
                 )
             }
@@ -1387,12 +1529,7 @@ internal class CelesteViewModel(
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = (
-                        event.payload.string("failure_reason")
-                            ?: event.payload.string("error")
-                            ?: event.payload.string("message")
-                    )?.let { sanitizeActivityText(it, 240) }
-                        ?: "Hermes reported an error.",
+                    notice = UiNotice.genericTurnFailure(),
                 )
             }
 
@@ -1666,7 +1803,7 @@ internal class CelesteViewModel(
                         if (session.id == previousStoredId) updatedSummary else session
                     },
                     turnState = TurnState.Idle,
-                    errorMessage = null,
+                    notice = null,
                 )
                 replayBufferedEvents(batch)
                 if (isCurrent(batch.guard)) {
@@ -1739,7 +1876,7 @@ internal class CelesteViewModel(
                 reconnectAttempts += 1
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
-                    errorMessage = failure?.message ?: "Reconnecting to Hermes…",
+                    notice = UiNotice.reconnecting(),
                 )
             }
             reconnectJob = null
@@ -1748,6 +1885,7 @@ internal class CelesteViewModel(
 
     private fun closeGateway() {
         val activeGateway = gateway
+        cancelSessionOperations()
         invalidateReconciliationEpoch()
         gatewayGeneration += 1
         sessionGeneration += 1

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -1422,7 +1422,11 @@ internal class CelesteViewModel(
     ) {
         val context = reconciliationGuard?.context ?: currentSessionContext() ?: return
         if (reconciliationGuard != null && !isCurrent(reconciliationGuard)) return
-        if (event.type == "reasoning.delta" && event.payload.boolean("verbose") == true) {
+        if (
+            event.type == "reasoning.delta" &&
+            event.payload.boolean("show_reasoning") != false &&
+            event.payload.boolean("verbose") == true
+        ) {
             pendingReasoningDeltas += PendingReasoningDelta(
                 event = event,
                 context = context,
@@ -1693,7 +1697,7 @@ internal class CelesteViewModel(
 
     private fun deduplicateReasoningFromFinalContent(raw: String): String {
         var content = raw
-        val reasoningDetails = mutableState.value.agentActivity?.items
+        val reasoningDetails = mutableState.value.agentActivity?.items.orEmpty()
             .filterIsInstance<ServerReasoningActivity>()
             .map(ServerReasoningActivity::text)
             .filter { it.text.isNotBlank() }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -112,6 +112,30 @@ private data class RememberedDashboard(
     val persistenceError: Throwable?,
 )
 
+private data class SessionContextGuard(
+    val gateway: GatewayConnection,
+    val gatewayGeneration: Long,
+    val sessionGeneration: Long,
+    val storedSessionId: String?,
+)
+
+private data class ReconciliationGuard(
+    val epoch: Long,
+    val context: SessionContextGuard,
+)
+
+private class ReconciliationBatch(
+    var guard: ReconciliationGuard,
+) {
+    val events = mutableListOf<GatewayEvent>()
+}
+
+private data class PendingReasoningDelta(
+    val event: GatewayEvent,
+    val context: SessionContextGuard,
+    val reconciliationGuard: ReconciliationGuard?,
+)
+
 internal class CelesteViewModel(
     private val dashboard: DashboardService = DashboardClient(),
     private val connectionStore: ConnectionStore = InMemoryConnectionStore(),
@@ -136,18 +160,21 @@ internal class CelesteViewModel(
     private var connectionJob: Job? = null
     private var activityDiscoveryJob: Job? = null
     private var reasoningCoalescingJob: Job? = null
-    private val pendingReasoningDeltas = mutableListOf<GatewayEvent>()
+    private var pendingReasoningDeltas = mutableListOf<PendingReasoningDelta>()
     private var connectionAttempt = 0L
     private val connectionStoreMutex = Mutex()
+    private val reconciliationMutex = Mutex()
+    private var reconciliationEpoch = 0L
+    private var gatewayGeneration = 0L
+    private var sessionGeneration = 0L
+    private var activeReconciliationBatch: ReconciliationBatch? = null
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
-    private var reconciling = false
     private var currentSessionCanResume = true
     private var activityReasoningDisclosureEnabled = runCatching {
         activityDisclosurePreferences.isServerReasoningDisclosureEnabled()
     }.getOrDefault(true)
     private var activityDisclosureScope: ActivityDisclosureScope? = null
-    private val bufferedEvents = mutableListOf<GatewayEvent>()
 
     init {
         mutableState.value = mutableState.value.copy(
@@ -681,6 +708,91 @@ internal class CelesteViewModel(
 
     private fun isCurrentConnectionAttempt(attempt: Long): Boolean = connectionAttempt == attempt
 
+    private fun installGateway(activeGateway: GatewayConnection) {
+        invalidateReconciliationEpoch()
+        gatewayGeneration += 1
+        sessionGeneration += 1
+        gateway = activeGateway
+    }
+
+    private fun currentSessionContext(): SessionContextGuard? {
+        val activeGateway = gateway ?: return null
+        return SessionContextGuard(
+            gateway = activeGateway,
+            gatewayGeneration = gatewayGeneration,
+            sessionGeneration = sessionGeneration,
+            storedSessionId = currentStoredSessionId?.trim()?.takeIf(String::isNotBlank),
+        )
+    }
+
+    private fun currentSessionContext(
+        activeGateway: GatewayConnection,
+        storedSessionId: String?,
+    ): SessionContextGuard = SessionContextGuard(
+        gateway = activeGateway,
+        gatewayGeneration = gatewayGeneration,
+        sessionGeneration = sessionGeneration,
+        storedSessionId = storedSessionId?.trim()?.takeIf(String::isNotBlank),
+    )
+
+    private fun isCurrent(context: SessionContextGuard): Boolean =
+        gateway === context.gateway &&
+            gatewayGeneration == context.gatewayGeneration &&
+            sessionGeneration == context.sessionGeneration &&
+            currentStoredSessionId?.trim()?.takeIf(String::isNotBlank) == context.storedSessionId
+
+    private fun isActiveSession(activeGateway: GatewayConnection, storedSessionId: String): Boolean =
+        gateway === activeGateway &&
+            currentStoredSessionId?.trim() == storedSessionId.trim()
+
+    private fun beginReconciliationGuard(
+        activeGateway: GatewayConnection,
+        storedSessionId: String?,
+    ): ReconciliationGuard? {
+        val normalizedStoredId = storedSessionId?.trim()?.takeIf(String::isNotBlank)
+        val currentStoredId = currentStoredSessionId?.trim()?.takeIf(String::isNotBlank)
+        if (gateway !== activeGateway || currentStoredId != normalizedStoredId) return null
+        val context = currentSessionContext(activeGateway, normalizedStoredId)
+        return ReconciliationGuard(
+            epoch = ++reconciliationEpoch,
+            context = context,
+        )
+    }
+
+    private fun isCurrent(guard: ReconciliationGuard): Boolean =
+        reconciliationEpoch == guard.epoch && isCurrent(guard.context)
+
+    private suspend fun <T> withReconciliationBatch(
+        activeGateway: GatewayConnection,
+        storedSessionId: String?,
+        block: suspend (ReconciliationBatch) -> T,
+    ): T? = reconciliationMutex.withLock {
+        val guard = beginReconciliationGuard(activeGateway, storedSessionId)
+            ?: return@withLock null
+        reasoningCoalescingJob?.cancel()
+        reasoningCoalescingJob = null
+        pendingReasoningDeltas.clear()
+        activityDiscoveryJob?.cancel()
+        activityDiscoveryJob = null
+        val batch = ReconciliationBatch(guard)
+        activeReconciliationBatch = batch
+        try {
+            block(batch)
+        } finally {
+            if (activeReconciliationBatch === batch) {
+                activeReconciliationBatch = null
+            }
+        }
+    }
+
+    private fun invalidateReconciliationEpoch() {
+        reconciliationEpoch += 1
+        activeReconciliationBatch = null
+        reasoningCoalescingJob?.cancel()
+        reasoningCoalescingJob = null
+        pendingReasoningDeltas.clear()
+    }
+
     fun openSession(summary: StoredSession) {
         val connection = mutableState.value.probe ?: return
         val activeCredential = credential ?: return
@@ -710,16 +822,20 @@ internal class CelesteViewModel(
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
-        gateway = newGateway
+        installGateway(newGateway)
         observeGateway(newGateway)
+        val operationContext = currentSessionContext(newGateway, summary.id)
         viewModelScope.launch {
             runCatching {
                 newGateway.connect()
+                if (!isCurrent(operationContext)) return@runCatching
                 reconcile(newGateway, summary.id)
             }.onSuccess {
+                if (!isCurrent(operationContext)) return@onSuccess
                 reconnectAttempts = 0
                 mutableState.value = mutableState.value.copy(loadingMessage = null)
             }.onFailure { error ->
+                if (!isCurrent(operationContext)) return@onFailure
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
                     errorMessage = error.message ?: "Could not open that Hermes conversation.",
@@ -748,59 +864,71 @@ internal class CelesteViewModel(
         )
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
-        gateway = newGateway
+        installGateway(newGateway)
         observeGateway(newGateway)
+        val operationContext = currentSessionContext(newGateway, null)
+        var createdStoredSessionId: String? = null
         viewModelScope.launch {
             runCatching {
                 newGateway.connect()
-                reconciling = true
-                bufferedEvents.clear()
-                val created = newGateway.createSession(selectedProfile)
-                if (gateway !== newGateway) throw IOException("The Hermes connection changed while creating the conversation.")
-                val returnedProfile = created.profile?.takeIf(String::isNotBlank)
-                if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
-                    throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
-                }
-                val activityProfile = returnedProfile ?: selectedProfile
-                currentRuntimeSessionId = created.runtimeSessionId
-                currentStoredSessionId = created.storedSessionId
-                currentSessionCanResume = false
-                val summary = StoredSession(
-                    id = created.storedSessionId,
-                    title = "New conversation",
-                    preview = "",
-                    startedAt = 0.0,
-                    messageCount = 0,
-                    source = "android",
-                    profile = activityProfile,
-                )
-                val events = bufferedEvents.toList()
-                bufferedEvents.clear()
-                reconciling = false
-                useActivityDisclosureScope(
-                    activityDisclosureScope(connection.baseUrl, activityProfile, created.storedSessionId),
-                )
-                mutableState.value = mutableState.value.copy(
-                    sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
-                        .filterNot { it.id == summary.id },
-                    activeSummary = summary,
-                    agentActivity = initialActivityProjection(
-                        originKey = connection.baseUrl,
+                if (!isCurrent(operationContext)) return@runCatching
+                withReconciliationBatch(newGateway, null) { batch ->
+                    val created = newGateway.createSession(selectedProfile)
+                    if (!isCurrent(batch.guard)) return@withReconciliationBatch
+                    val returnedProfile = created.profile?.takeIf(String::isNotBlank)
+                    if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
+                        throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
+                    }
+                    val activityProfile = returnedProfile ?: selectedProfile
+                    currentRuntimeSessionId = created.runtimeSessionId
+                    currentStoredSessionId = created.storedSessionId
+                    currentSessionCanResume = false
+                    sessionGeneration += 1
+                    reconciliationEpoch += 1
+                    batch.guard = ReconciliationGuard(
+                        epoch = reconciliationEpoch,
+                        context = currentSessionContext(newGateway, created.storedSessionId),
+                    )
+                    createdStoredSessionId = created.storedSessionId
+                    val summary = StoredSession(
+                        id = created.storedSessionId,
+                        title = "New conversation",
+                        preview = "",
+                        startedAt = 0.0,
+                        messageCount = 0,
+                        source = "android",
                         profile = activityProfile,
-                        storedSessionId = created.storedSessionId,
-                        runtimeSessionId = created.runtimeSessionId,
-                        capability = connection.activityCapability,
-                    ),
-                    turnState = TurnState.Idle,
-                    loadingMessage = null,
-                    errorMessage = null,
-                )
-                events.forEach { applyEvent(it) }
-                scheduleActivityDiscoveryFallback()
+                    )
+                    useActivityDisclosureScope(
+                        activityDisclosureScope(connection.baseUrl, activityProfile, created.storedSessionId),
+                    )
+                    mutableState.value = mutableState.value.copy(
+                        sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
+                            .filterNot { it.id == summary.id },
+                        activeSummary = summary,
+                        agentActivity = initialActivityProjection(
+                            originKey = connection.baseUrl,
+                            profile = activityProfile,
+                            storedSessionId = created.storedSessionId,
+                            runtimeSessionId = created.runtimeSessionId,
+                            capability = connection.activityCapability,
+                        ),
+                        turnState = TurnState.Idle,
+                        loadingMessage = null,
+                        errorMessage = null,
+                    )
+                    replayBufferedEvents(batch)
+                    if (isCurrent(batch.guard)) {
+                        scheduleActivityDiscoveryFallback()
+                    }
+                }
             }.onSuccess {
-                reconnectAttempts = 0
+                if (gateway === newGateway && currentStoredSessionId == createdStoredSessionId) {
+                    reconnectAttempts = 0
+                }
             }.onFailure { error ->
-                if (gateway === newGateway) closeGateway()
+                if (gateway !== newGateway || !isCurrent(operationContext)) return@onFailure
+                closeGateway()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
                     loadingMessage = null,
@@ -829,6 +957,8 @@ internal class CelesteViewModel(
         val activeGateway = gateway ?: return
         val snapshot = mutableState.value
         val runtimeId = currentRuntimeSessionId ?: return
+        val storedSessionId = currentStoredSessionId ?: return
+        val operationContext = currentSessionContext(activeGateway, storedSessionId)
         val text = snapshot.draft.trim()
         if (text.isBlank() || snapshot.turnState != TurnState.Idle) return
 
@@ -849,8 +979,12 @@ internal class CelesteViewModel(
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
         viewModelScope.launch {
-            runCatching { activeGateway.submitPrompt(runtimeId, text) }
+            runCatching {
+                if (!isCurrent(operationContext)) return@runCatching
+                activeGateway.submitPrompt(runtimeId, text)
+            }
                 .onSuccess {
+                    if (!isCurrent(operationContext)) return@onSuccess
                     mutableState.value = mutableState.value.copy(
                         messages = mutableState.value.messages.map { message ->
                             if (message.id == localId) message.copy(pending = false) else message
@@ -858,12 +992,11 @@ internal class CelesteViewModel(
                     )
                 }
                 .onFailure { error ->
+                    if (!isCurrent(operationContext)) return@onFailure
                     mutableState.value = mutableState.value.copy(
                         errorMessage = error.message ?: "Hermes could not send that message.",
                     )
-                    if (gateway === activeGateway) {
-                        runCatching { reconcile(activeGateway, currentStoredSessionId ?: return@launch) }
-                    }
+                    runCatching { reconcile(activeGateway, storedSessionId) }
                 }
         }
     }
@@ -871,6 +1004,8 @@ internal class CelesteViewModel(
     fun interrupt() {
         val activeGateway = gateway ?: return
         val runtimeId = currentRuntimeSessionId ?: return
+        val storedSessionId = currentStoredSessionId ?: return
+        val operationContext = currentSessionContext(activeGateway, storedSessionId)
         if (mutableState.value.turnState != TurnState.Running) return
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Synchronizing,
@@ -878,9 +1013,11 @@ internal class CelesteViewModel(
         )
         viewModelScope.launch {
             runCatching {
+                if (!isCurrent(operationContext)) return@runCatching
                 activeGateway.interruptSession(runtimeId)
-                reconcile(activeGateway, currentStoredSessionId ?: return@launch)
+                reconcile(activeGateway, storedSessionId)
             }.onFailure { error ->
+                if (!isCurrent(operationContext)) return@onFailure
                 mutableState.value = mutableState.value.copy(
                     errorMessage = error.message ?: "Hermes could not stop that turn.",
                 )
@@ -916,22 +1053,27 @@ internal class CelesteViewModel(
     fun onForeground() {
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: return
-        if (foregroundCheckJob?.isActive == true || reconciling) return
+        val operationContext = currentSessionContext(activeGateway, storedSessionId)
+        if (foregroundCheckJob?.isActive == true) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
             reconnectNow()
             return
         }
         foregroundCheckJob = viewModelScope.launch {
             val health = runCatching {
+                if (!isCurrent(operationContext)) return@runCatching
                 activeGateway.request(
                     method = "session.list",
                     params = buildJsonObject { put("limit", 1) },
                     timeoutMillis = 8_000,
                 )
-                if (currentSessionCanResume) reconcile(activeGateway, storedSessionId)
+                if (currentSessionCanResume && isCurrent(operationContext)) {
+                    reconcile(activeGateway, storedSessionId)
+                }
             }
-            if (health.isFailure && gateway === activeGateway) {
+            if (health.isFailure && isCurrent(operationContext)) {
                 val wasRunning = mutableState.value.turnState == TurnState.Running
+                invalidateReconciliationEpoch()
                 activeGateway.close()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
@@ -948,20 +1090,25 @@ internal class CelesteViewModel(
     private var currentStoredSessionId: String? = null
 
     private fun observeGateway(activeGateway: GatewayConnection) {
+        val observedGatewayGeneration = gatewayGeneration
         gatewayEventsJob = viewModelScope.launch {
             activeGateway.events.collect { event ->
-                if (gateway !== activeGateway) return@collect
-                if (reconciling) {
-                    bufferedEvents += event
-                } else {
-                    applyEvent(event)
+                if (gateway !== activeGateway || gatewayGeneration != observedGatewayGeneration) return@collect
+                val batch = activeReconciliationBatch
+                if (batch != null) {
+                    if (isCurrent(batch.guard)) {
+                        batch.events += event
+                    }
+                    return@collect
                 }
+                applyEvent(event)
             }
         }
         gatewayStateJob = viewModelScope.launch {
             activeGateway.state.collect { connectionState ->
-                if (gateway !== activeGateway) return@collect
+                if (gateway !== activeGateway || gatewayGeneration != observedGatewayGeneration) return@collect
                 if (connectionState is GatewayConnectionState.Disconnected) {
+                    invalidateReconciliationEpoch()
                     val wasRunning = mutableState.value.turnState == TurnState.Running
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
@@ -975,35 +1122,53 @@ internal class CelesteViewModel(
     }
 
     private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
-        reconciling = true
-        bufferedEvents.clear()
-        mutableState.value = mutableState.value.copy(
-            agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markRestoring),
-        )
+        var guard: ReconciliationGuard? = null
         try {
-            val activity = mutableState.value.agentActivity
-            val resumed = activeGateway.resumeStoredSession(
-                storedSessionId = storedSessionId,
-                profile = activity?.profile
-                    ?: mutableState.value.activeSummary?.profile
-                    ?: mutableState.value.selectedProfile,
-                originKey = activity?.originKey
-                    ?: mutableState.value.probe?.baseUrl,
-            )
-            if (gateway !== activeGateway) return
-            applyResumedSession(resumed)
-            val events = bufferedEvents.toList()
-            bufferedEvents.clear()
-            reconciling = false
-            events.forEach { applyEvent(it) }
-            scheduleActivityDiscoveryFallback()
-        } catch (error: Throwable) {
-            bufferedEvents.clear()
-            reconciling = false
-            mutableState.value = mutableState.value.copy(
-                agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
-            )
+            withReconciliationBatch(activeGateway, storedSessionId) { batch ->
+                guard = batch.guard
+                if (!isCurrent(batch.guard)) return@withReconciliationBatch
+                mutableState.value = mutableState.value.copy(
+                    agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markRestoring),
+                )
+                val activity = mutableState.value.agentActivity
+                val resumed = activeGateway.resumeStoredSession(
+                    storedSessionId = storedSessionId,
+                    profile = activity?.profile
+                        ?: mutableState.value.activeSummary?.profile
+                        ?: mutableState.value.selectedProfile,
+                    originKey = activity?.originKey
+                        ?: mutableState.value.probe?.baseUrl,
+                )
+                if (!isCurrent(batch.guard)) return@withReconciliationBatch
+                applyResumedSession(resumed)
+                if (!isCurrent(batch.guard)) return@withReconciliationBatch
+                replayBufferedEvents(batch)
+                if (!isCurrent(batch.guard)) return@withReconciliationBatch
+                scheduleActivityDiscoveryFallback()
+            }
+        } catch (error: CancellationException) {
+            if (guard?.let(::isCurrent) == true) {
+                mutableState.value = mutableState.value.copy(
+                    agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
+                )
+            }
             throw error
+        } catch (error: Throwable) {
+            if (guard?.let(::isCurrent) == true) {
+                mutableState.value = mutableState.value.copy(
+                    agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
+                )
+            }
+            throw error
+        }
+    }
+
+    private suspend fun replayBufferedEvents(batch: ReconciliationBatch) {
+        var index = 0
+        while (index < batch.events.size) {
+            if (!isCurrent(batch.guard)) return
+            applyEvent(batch.events[index], batch.guard)
+            index += 1
         }
     }
 
@@ -1082,10 +1247,12 @@ internal class CelesteViewModel(
         val expectedProfile = activity.profile
         val expectedStoredSession = activity.storedSessionId
         val expectedRuntime = activity.runtimeSessionId
+        val expectedContext = currentSessionContext() ?: return
         activityDiscoveryJob = viewModelScope.launch {
             delay(activityDiscoveryTimeoutMillis.coerceAtLeast(0L))
             val current = mutableState.value.agentActivity
             if (
+                isCurrent(expectedContext) &&
                 current != null &&
                 current.presentation == dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering &&
                 current.originKey == expectedOrigin &&
@@ -1102,9 +1269,18 @@ internal class CelesteViewModel(
         }
     }
 
-    private suspend fun applyEvent(event: GatewayEvent) {
+    private suspend fun applyEvent(
+        event: GatewayEvent,
+        reconciliationGuard: ReconciliationGuard? = null,
+    ) {
+        val context = reconciliationGuard?.context ?: currentSessionContext() ?: return
+        if (reconciliationGuard != null && !isCurrent(reconciliationGuard)) return
         if (event.type == "reasoning.delta" && event.payload.boolean("verbose") == true) {
-            pendingReasoningDeltas += event
+            pendingReasoningDeltas += PendingReasoningDelta(
+                event = event,
+                context = context,
+                reconciliationGuard = reconciliationGuard,
+            )
             if (reasoningCoalescingJob?.isActive != true) {
                 reasoningCoalescingJob = viewModelScope.launch {
                     delay(reasoningCoalescingWindowMillis.coerceAtLeast(0L))
@@ -1114,10 +1290,16 @@ internal class CelesteViewModel(
             return
         }
         flushReasoningDeltas()
-        applyEventNow(event)
+        applyEventNow(event, context, reconciliationGuard)
     }
 
-    private suspend fun applyEventNow(event: GatewayEvent) {
+    private suspend fun applyEventNow(
+        event: GatewayEvent,
+        context: SessionContextGuard,
+        reconciliationGuard: ReconciliationGuard?,
+    ) {
+        if (!isCurrent(context)) return
+        if (reconciliationGuard != null && !isCurrent(reconciliationGuard)) return
         val runtimeId = currentRuntimeSessionId?.trim()?.takeIf(String::isNotBlank) ?: return
         val eventSessionId = event.sessionId.trim()
         if (eventSessionId.isNotBlank() && eventSessionId != runtimeId) return
@@ -1130,6 +1312,8 @@ internal class CelesteViewModel(
                     reasoningEnabled = activityReasoningDisclosureEnabled,
                 )
             }
+            if (!isCurrent(context)) return
+            if (reconciliationGuard != null && !isCurrent(reconciliationGuard)) return
             if (updated !== projection) {
                 mutableState.value = mutableState.value.copy(agentActivity = updated)
                 if (updated.presentation != dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering) {
@@ -1247,37 +1431,53 @@ internal class CelesteViewModel(
 
     private suspend fun flushReasoningDeltas() {
         reasoningCoalescingJob = null
-        val events = pendingReasoningDeltas.toList()
+        val pending = pendingReasoningDeltas.toList()
         pendingReasoningDeltas.clear()
+        val events = pending.filter { item ->
+            isCurrent(item.context) &&
+                (item.reconciliationGuard == null || isCurrent(item.reconciliationGuard))
+        }
         if (events.isEmpty()) return
 
         val first = events.first()
-        val sameBinding = events.all { event ->
-            event.sessionId == first.sessionId &&
-                event.originKey == first.originKey &&
-                event.profile == first.profile &&
-                event.storedSessionId == first.storedSessionId
+        val sameContext = events.all { item ->
+            item.context == first.context && item.reconciliationGuard == first.reconciliationGuard
         }
-        val hasExplicitReplayIdentity = events.any { event ->
+        val sameBinding = events.all { item ->
+            val event = item.event
+            val firstEvent = first.event
+            event.sessionId == firstEvent.sessionId &&
+                event.originKey == firstEvent.originKey &&
+                event.profile == firstEvent.profile &&
+                event.storedSessionId == firstEvent.storedSessionId
+        }
+        val hasExplicitReplayIdentity = events.any { item ->
+            val event = item.event
             event.eventId?.isNotBlank() == true ||
                 event.payload.keys.any {
                     it == "event_id" || it == "eventId" || it == "event_seq" || it == "seq"
                 }
         }
-        if (events.size == 1 || !sameBinding || hasExplicitReplayIdentity) {
-            events.forEach { applyEventNow(it) }
+        if (events.size == 1 || !sameContext || !sameBinding || hasExplicitReplayIdentity) {
+            events.forEach { item ->
+                applyEventNow(item.event, item.context, item.reconciliationGuard)
+            }
             return
         }
 
-        val mergedText = mergeReasoningDeltaText(events)
+        val mergedText = mergeReasoningDeltaText(events.map(PendingReasoningDelta::event))
         if (mergedText.isBlank()) return
         val representative = events.last()
         val combinedPayload = buildJsonObject {
-            representative.payload.forEach { (key, value) -> put(key, value) }
+            representative.event.payload.forEach { (key, value) -> put(key, value) }
             put("text", mergedText)
             put("verbose", true)
         }
-        applyEventNow(representative.copy(payload = combinedPayload, eventId = null))
+        applyEventNow(
+            representative.event.copy(payload = combinedPayload, eventId = null),
+            representative.context,
+            representative.reconciliationGuard,
+        )
     }
 
     private fun mergeReasoningDeltaText(events: List<GatewayEvent>): String {
@@ -1427,48 +1627,56 @@ internal class CelesteViewModel(
         profile: String,
     ) {
         val previousStoredId = currentStoredSessionId
-        reconciling = true
-        bufferedEvents.clear()
+        var guard: ReconciliationGuard? = null
         try {
-            val created = activeGateway.createSession(profile)
-            if (gateway !== activeGateway) return
-            currentRuntimeSessionId = created.runtimeSessionId
-            currentStoredSessionId = created.storedSessionId
-            currentSessionCanResume = false
-            val previousSummary = mutableState.value.activeSummary
-                ?: throw IOException("No draft conversation is open.")
-            val previousActivity = mutableState.value.agentActivity
-                ?: throw IOException("No activity projection is open.")
-            val activityProfile = created.profile?.takeIf(String::isNotBlank) ?: profile
-            val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = activityProfile)
-            useActivityDisclosureScope(
-                activityDisclosureScope(previousActivity.originKey, activityProfile, created.storedSessionId),
-            )
-            val updatedActivity = initialActivityProjection(
-                originKey = previousActivity.originKey,
-                profile = activityProfile,
-                storedSessionId = created.storedSessionId,
-                runtimeSessionId = created.runtimeSessionId,
-                capability = mutableState.value.probe?.activityCapability
-                    ?: ActivityCapabilityState.Unknown,
-            )
-            mutableState.value = mutableState.value.copy(
-                activeSummary = updatedSummary,
-                agentActivity = updatedActivity,
-                sessions = mutableState.value.sessions?.map { session ->
-                    if (session.id == previousStoredId) updatedSummary else session
-                },
-                turnState = TurnState.Idle,
-                errorMessage = null,
-            )
-            val events = bufferedEvents.toList()
-            bufferedEvents.clear()
-            reconciling = false
-            events.forEach { applyEvent(it) }
-            scheduleActivityDiscoveryFallback()
+            withReconciliationBatch(activeGateway, previousStoredId) { batch ->
+                guard = batch.guard
+                val created = activeGateway.createSession(profile)
+                if (!isCurrent(batch.guard)) return@withReconciliationBatch
+                val previousSummary = mutableState.value.activeSummary
+                    ?: throw IOException("No draft conversation is open.")
+                val previousActivity = mutableState.value.agentActivity
+                    ?: throw IOException("No activity projection is open.")
+                val activityProfile = created.profile?.takeIf(String::isNotBlank) ?: profile
+                currentRuntimeSessionId = created.runtimeSessionId
+                currentStoredSessionId = created.storedSessionId
+                currentSessionCanResume = false
+                sessionGeneration += 1
+                reconciliationEpoch += 1
+                batch.guard = ReconciliationGuard(
+                    epoch = reconciliationEpoch,
+                    context = currentSessionContext(activeGateway, created.storedSessionId),
+                )
+                val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = activityProfile)
+                useActivityDisclosureScope(
+                    activityDisclosureScope(previousActivity.originKey, activityProfile, created.storedSessionId),
+                )
+                val updatedActivity = initialActivityProjection(
+                    originKey = previousActivity.originKey,
+                    profile = activityProfile,
+                    storedSessionId = created.storedSessionId,
+                    runtimeSessionId = created.runtimeSessionId,
+                    capability = mutableState.value.probe?.activityCapability
+                        ?: ActivityCapabilityState.Unknown,
+                )
+                mutableState.value = mutableState.value.copy(
+                    activeSummary = updatedSummary,
+                    agentActivity = updatedActivity,
+                    sessions = mutableState.value.sessions?.map { session ->
+                        if (session.id == previousStoredId) updatedSummary else session
+                    },
+                    turnState = TurnState.Idle,
+                    errorMessage = null,
+                )
+                replayBufferedEvents(batch)
+                if (isCurrent(batch.guard)) {
+                    scheduleActivityDiscoveryFallback()
+                }
+            }
+        } catch (error: CancellationException) {
+            if (guard?.let(::isCurrent) == true) throw error
+            throw error
         } catch (error: Throwable) {
-            bufferedEvents.clear()
-            reconciling = false
             throw error
         }
     }
@@ -1476,18 +1684,34 @@ internal class CelesteViewModel(
     private fun scheduleReconnect(wasRunning: Boolean, immediate: Boolean = false) {
         val activeGateway = gateway ?: return
         val storedSessionId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
+        val reconnectGatewayGeneration = gatewayGeneration
+        val reconnectSessionGeneration = sessionGeneration
         if (reconnectJob?.isActive == true) return
         mutableState.value = mutableState.value.copy(turnState = TurnState.Reconnecting)
         reconnectJob = viewModelScope.launch {
-            while (gateway === activeGateway) {
+            while (
+                isActiveSession(activeGateway, storedSessionId) &&
+                gatewayGeneration == reconnectGatewayGeneration &&
+                sessionGeneration == reconnectSessionGeneration
+            ) {
                 val delayMillis = if (immediate && reconnectAttempts == 0) {
                     0L
                 } else {
                     reconnectDelayMillis(reconnectAttempts, wasRunning)
                 }
                 if (delayMillis > 0) delay(delayMillis)
+                if (
+                    !isActiveSession(activeGateway, storedSessionId) ||
+                    gatewayGeneration != reconnectGatewayGeneration ||
+                    sessionGeneration != reconnectSessionGeneration
+                ) break
                 val result = runCatching {
                     activeGateway.connect()
+                    if (
+                        !isActiveSession(activeGateway, storedSessionId) ||
+                        gatewayGeneration != reconnectGatewayGeneration ||
+                        sessionGeneration != reconnectSessionGeneration
+                    ) return@runCatching
                     if (currentSessionCanResume) {
                         reconcile(activeGateway, storedSessionId)
                     } else {
@@ -1499,6 +1723,11 @@ internal class CelesteViewModel(
                     reconnectJob = null
                     return@launch
                 }
+                if (
+                    !isActiveSession(activeGateway, storedSessionId) ||
+                    gatewayGeneration != reconnectGatewayGeneration ||
+                    sessionGeneration != reconnectSessionGeneration
+                ) break
                 val failure = result.exceptionOrNull()
                 if (failure is AuthenticationRejected) {
                     val descriptor = currentDescriptor
@@ -1519,22 +1748,20 @@ internal class CelesteViewModel(
 
     private fun closeGateway() {
         val activeGateway = gateway
+        invalidateReconciliationEpoch()
+        gatewayGeneration += 1
+        sessionGeneration += 1
         gateway = null
         reconnectJob?.cancel()
         reconnectJob = null
         activityDiscoveryJob?.cancel()
         activityDiscoveryJob = null
-        reasoningCoalescingJob?.cancel()
-        reasoningCoalescingJob = null
-        pendingReasoningDeltas.clear()
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         gatewayEventsJob?.cancel()
         gatewayEventsJob = null
         gatewayStateJob?.cancel()
         gatewayStateJob = null
-        reconciling = false
-        bufferedEvents.clear()
         currentRuntimeSessionId = null
         currentStoredSessionId = null
         currentSessionCanResume = true

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -20,7 +20,16 @@ import dev.hazydreams.hermesceleste.network.DashboardUrlPolicy
 import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
+import dev.hazydreams.hermesceleste.network.ActivityBinding
+import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
+import dev.hazydreams.hermesceleste.network.ActivityDisclosurePreferenceStore
+import dev.hazydreams.hermesceleste.network.AgentActivityProjection
+import dev.hazydreams.hermesceleste.network.AgentActivityReducer
+import dev.hazydreams.hermesceleste.network.InMemoryActivityDisclosurePreferenceStore
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
+import dev.hazydreams.hermesceleste.network.initialActivityProjection
+import dev.hazydreams.hermesceleste.network.normalizeActivityOrigin
 import dev.hazydreams.hermesceleste.network.ResumedSession
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.boolean
@@ -74,12 +83,17 @@ internal data class CelesteUiState(
     val selectedProfile: String = "default",
     val activeSummary: StoredSession? = null,
     val messages: List<ConversationMessage> = emptyList(),
+    val agentActivity: AgentActivityProjection? = null,
+    val agentActivityReasoningDisclosureEnabled: Boolean = true,
     val streamingText: String = "",
     val draft: String = "",
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
     val errorMessage: String? = null,
-)
+) {
+    /** Compatibility alias for callers that name the projection explicitly. */
+    val activityProjection: AgentActivityProjection? get() = agentActivity
+}
 
 private data class LoadedDashboard(
     val credential: GatewayCredential,
@@ -99,6 +113,8 @@ internal class CelesteViewModel(
     private val reconnectDelayMillis: (attempt: Int, wasRunning: Boolean) -> Long = { attempt, wasRunning ->
         if (wasRunning && attempt == 0) 100L else min(5_000L, 1_000L shl attempt.coerceAtMost(2))
     },
+    private val activityDisclosurePreferences: ActivityDisclosurePreferenceStore =
+        InMemoryActivityDisclosurePreferenceStore(),
 ) : ViewModel() {
     private val mutableState = MutableStateFlow(CelesteUiState())
     val state: StateFlow<CelesteUiState> = mutableState.asStateFlow()
@@ -117,9 +133,15 @@ internal class CelesteViewModel(
     private var reconnectAttempts = 0
     private var reconciling = false
     private var currentSessionCanResume = true
+    private var activityReasoningDisclosureEnabled = runCatching {
+        activityDisclosurePreferences.isServerReasoningDisclosureEnabled()
+    }.getOrDefault(true)
     private val bufferedEvents = mutableListOf<GatewayEvent>()
 
     init {
+        mutableState.value = mutableState.value.copy(
+            agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
+        )
         restoreSavedConnection()
     }
 
@@ -147,6 +169,27 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(draft = value)
     }
 
+    /**
+     * Device-local disclosure only. It never requests a new server payload and
+     * disabling it drops the in-memory reasoning projection rather than writing
+     * private text to preferences or a local transcript.
+     */
+    fun setActivityReasoningDisclosureEnabled(enabled: Boolean) {
+        activityReasoningDisclosureEnabled = enabled
+        runCatching {
+            activityDisclosurePreferences.setServerReasoningDisclosureEnabled(enabled)
+        }
+        val activity = mutableState.value.agentActivity
+        mutableState.value = mutableState.value.copy(
+            agentActivityReasoningDisclosureEnabled = enabled,
+            agentActivity = if (enabled || activity == null) {
+                activity
+            } else {
+                AgentActivityReducer.withoutServerReasoning(activity)
+            },
+        )
+    }
+
     fun selectProfile(name: String) {
         if (mutableState.value.profiles.none { it.name == name }) return
         mutableState.value = mutableState.value.copy(selectedProfile = name)
@@ -165,6 +208,7 @@ internal class CelesteViewModel(
             sessions = null,
             activeSummary = null,
             messages = emptyList(),
+            agentActivity = null,
             streamingText = "",
             draft = "",
             loadingMessage = "Finding Hermes…",
@@ -289,6 +333,7 @@ internal class CelesteViewModel(
             sessions = null,
             activeSummary = null,
             messages = emptyList(),
+            agentActivity = null,
             streamingText = "",
             draft = "",
             errorMessage = null,
@@ -305,7 +350,10 @@ internal class CelesteViewModel(
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
-        mutableState.value = CelesteUiState(connectionPhase = ConnectionPhase.ManualSetup)
+        mutableState.value = CelesteUiState(
+            connectionPhase = ConnectionPhase.ManualSetup,
+            agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
+        )
     }
 
     fun signOut() {
@@ -320,6 +368,7 @@ internal class CelesteViewModel(
             sessions = null,
             activeSummary = null,
             messages = emptyList(),
+            agentActivity = null,
             streamingText = "",
             draft = "",
             password = "",
@@ -356,6 +405,7 @@ internal class CelesteViewModel(
         currentDescriptor = null
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.ManualSetup,
+            agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
             loadingMessage = "Forgetting this connection…",
         )
         connectionJob = viewModelScope.launch {
@@ -369,6 +419,7 @@ internal class CelesteViewModel(
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = CelesteUiState(
                 connectionPhase = ConnectionPhase.ManualSetup,
+                agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
                 errorMessage = if (error == null) null else {
                     "Celeste could not remove the saved connection. Try again."
                 },
@@ -382,6 +433,7 @@ internal class CelesteViewModel(
         credential = null
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.CheckingSavedConnection,
+            agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
             loadingMessage = "Checking this device…",
         )
         connectionJob = viewModelScope.launch {
@@ -418,6 +470,7 @@ internal class CelesteViewModel(
         var restoredProbe: DashboardProbeResult? = null
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.Restoring,
+            agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
             dashboardUrl = descriptor.baseUrl,
             savedAuthMode = descriptor.authMode,
             username = descriptor.username.orEmpty(),
@@ -496,6 +549,7 @@ internal class CelesteViewModel(
                 currentDescriptor = null
                 mutableState.value = CelesteUiState(
                     connectionPhase = ConnectionPhase.RestoreFailed,
+                    agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
                     dashboardUrl = descriptor.baseUrl,
                     savedAuthMode = descriptor.authMode,
                     username = descriptor.username.orEmpty(),
@@ -551,6 +605,7 @@ internal class CelesteViewModel(
             selectedProfile = selectedProfile,
             activeSummary = null,
             messages = emptyList(),
+            agentActivity = null,
             password = password,
             sessionToken = sessionToken,
             loadingMessage = null,
@@ -565,6 +620,7 @@ internal class CelesteViewModel(
         errorMessage: String? = null,
     ): CelesteUiState = CelesteUiState(
         connectionPhase = phase,
+        agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
         dashboardUrl = descriptor?.baseUrl.orEmpty(),
         probe = probe,
         savedAuthMode = descriptor?.authMode,
@@ -585,10 +641,19 @@ internal class CelesteViewModel(
         val connection = mutableState.value.probe ?: return
         val activeCredential = credential ?: return
         closeGateway()
+        currentRuntimeSessionId = null
+        currentStoredSessionId = summary.id
         currentSessionCanResume = true
+        val initialActivity = initialActivityProjection(
+            originKey = connection.baseUrl,
+            profile = summary.profile.ifBlank { mutableState.value.selectedProfile },
+            storedSessionId = summary.id,
+            capability = ActivityCapabilityState.Unknown,
+        )
         mutableState.value = mutableState.value.copy(
             activeSummary = summary,
             messages = emptyList(),
+            agentActivity = initialActivity,
             streamingText = "",
             draft = "",
             turnState = TurnState.Synchronizing,
@@ -626,6 +691,7 @@ internal class CelesteViewModel(
         mutableState.value = snapshot.copy(
             activeSummary = null,
             messages = emptyList(),
+            agentActivity = null,
             streamingText = "",
             draft = "",
             turnState = TurnState.Synchronizing,
@@ -666,6 +732,13 @@ internal class CelesteViewModel(
                     sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
                         .filterNot { it.id == summary.id },
                     activeSummary = summary,
+                    agentActivity = initialActivityProjection(
+                        originKey = connection.baseUrl,
+                        profile = selectedProfile,
+                        storedSessionId = created.storedSessionId,
+                        runtimeSessionId = created.runtimeSessionId,
+                        capability = ActivityCapabilityState.Unknown,
+                    ),
                     turnState = TurnState.Idle,
                     loadingMessage = null,
                     errorMessage = null,
@@ -689,6 +762,7 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             activeSummary = null,
             messages = emptyList(),
+            agentActivity = null,
             streamingText = "",
             draft = "",
             turnState = TurnState.Idle,
@@ -807,6 +881,7 @@ internal class CelesteViewModel(
                 activeGateway.close()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
+                    agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
                     errorMessage = health.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
                 )
                 scheduleReconnect(wasRunning = wasRunning, immediate = true)
@@ -836,6 +911,7 @@ internal class CelesteViewModel(
                     val wasRunning = mutableState.value.turnState == TurnState.Running
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
+                        agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
                         errorMessage = connectionState.reason,
                     )
                     scheduleReconnect(wasRunning)
@@ -847,6 +923,9 @@ internal class CelesteViewModel(
     private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
         reconciling = true
         bufferedEvents.clear()
+        mutableState.value = mutableState.value.copy(
+            agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markRestoring),
+        )
         try {
             val resumed = activeGateway.resumeStoredSession(storedSessionId)
             if (gateway !== activeGateway) return
@@ -858,11 +937,34 @@ internal class CelesteViewModel(
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false
+            mutableState.value = mutableState.value.copy(
+                agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markStale),
+            )
             throw error
         }
     }
 
     private fun applyResumedSession(resumed: ResumedSession) {
+        val currentActivity = mutableState.value.agentActivity
+        val expectedStoredId = currentStoredSessionId
+            ?: mutableState.value.activeSummary?.id
+            ?: resumed.storedSessionId
+        if (resumed.storedSessionId != expectedStoredId) {
+            throw IOException("Hermes returned activity for a different stored conversation.")
+        }
+        if (currentActivity != null) {
+            if (resumed.originKey != null &&
+                normalizeActivityOrigin(resumed.originKey) != currentActivity.originKey
+            ) {
+                throw IOException("Hermes returned activity for a different dashboard origin.")
+            }
+            if (resumed.profile != null &&
+                resumed.profile.isNotBlank() &&
+                resumed.profile != currentActivity.profile
+            ) {
+                throw IOException("Hermes returned activity for a different profile.")
+            }
+        }
         currentRuntimeSessionId = resumed.runtimeSessionId
         currentStoredSessionId = resumed.storedSessionId
         currentSessionCanResume = true
@@ -870,8 +972,27 @@ internal class CelesteViewModel(
             inflight = resumed.inflightAssistantText,
             messages = resumed.messages,
         )
+        val activity = currentActivity?.let { projection ->
+            val snapshotItems = resumed.activityItems.ifEmpty {
+                dev.hazydreams.hermesceleste.network.activityItemsFromMessages(resumed.messages)
+            }.filter { item ->
+                activityReasoningDisclosureEnabled || item !is ServerReasoningActivity
+            }
+            AgentActivityReducer.applySnapshot(
+                projection = projection,
+                items = snapshotItems,
+                binding = ActivityBinding(
+                    originKey = projection.originKey,
+                    profile = projection.profile,
+                    storedSessionId = resumed.storedSessionId,
+                    runtimeSessionId = resumed.runtimeSessionId,
+                ),
+                running = resumed.running == true || resumed.hasLiveProjection,
+            )
+        }
         mutableState.value = mutableState.value.copy(
             messages = resumed.messages,
+            agentActivity = activity,
             streamingText = streamingSuffix,
             turnState = if (resumed.running == true || resumed.hasLiveProjection) {
                 TurnState.Running
@@ -885,6 +1006,16 @@ internal class CelesteViewModel(
     private fun applyEvent(event: GatewayEvent) {
         val runtimeId = currentRuntimeSessionId ?: return
         if (event.sessionId.isNotBlank() && event.sessionId != runtimeId) return
+        mutableState.value.agentActivity?.let { projection ->
+            val updated = AgentActivityReducer.applyEvent(
+                projection = projection,
+                event = event,
+                reasoningEnabled = activityReasoningDisclosureEnabled,
+            )
+            if (updated !== projection) {
+                mutableState.value = mutableState.value.copy(agentActivity = updated)
+            }
+        }
         when (event.type) {
             "message.start" -> {
                 if (mutableState.value.streamingText.isNotBlank()) finalizeAssistant()
@@ -965,36 +1096,14 @@ internal class CelesteViewModel(
 
             "tool.start", "tool_call" -> {
                 if (mutableState.value.streamingText.isNotBlank()) finalizeAssistant(keepRunning = true)
-                val name = event.payload.string("name") ?: "Tool"
-                val input = event.payload.string("args_text")
-                    ?: event.payload.string("context")
-                    ?: event.payload["args"]?.toString().orEmpty()
-                mutableState.value = mutableState.value.copy(
-                    messages = mutableState.value.messages + ConversationMessage(
-                        role = "tool",
-                        text = input,
-                        toolName = name,
-                        id = "tool-${localMessageCounter.incrementAndGet()}",
-                        pending = true,
-                    ),
-                    turnState = TurnState.Running,
-                )
+                mutableState.value = mutableState.value.copy(turnState = TurnState.Running)
             }
 
             "tool.complete", "tool_result" -> {
-                val name = event.payload.string("name") ?: "Tool"
-                val output = event.payload.string("output")
-                    ?: event.payload["result"]?.toString().orEmpty()
-                val messages = mutableState.value.messages.toMutableList()
-                val index = messages.indexOfLast {
-                    it.role == "tool" && it.toolName == name && it.pending
-                }
-                if (index >= 0) {
-                    messages[index] = messages[index].copy(text = output, pending = false)
-                } else {
-                    messages += ConversationMessage(role = "tool", text = output, toolName = name)
-                }
-                mutableState.value = mutableState.value.copy(messages = messages)
+                // Tool completion is activity state, not an assistant transcript row.
+                // Keep the turn running because Hermes may execute another tool or
+                // continue streaming assistant content after this event.
+                mutableState.value = mutableState.value.copy(turnState = TurnState.Running)
             }
         }
     }
@@ -1053,9 +1162,20 @@ internal class CelesteViewModel(
             currentStoredSessionId = created.storedSessionId
             val previousSummary = mutableState.value.activeSummary
                 ?: throw IOException("No draft conversation is open.")
+            val previousActivity = mutableState.value.agentActivity
+                ?: throw IOException("No activity projection is open.")
             val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
+            val updatedActivity = initialActivityProjection(
+                originKey = previousActivity.originKey,
+                profile = profile,
+                storedSessionId = created.storedSessionId,
+                runtimeSessionId = created.runtimeSessionId,
+                capability = ActivityCapabilityState.Unknown,
+            )
+            currentSessionCanResume = false
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
+                agentActivity = updatedActivity,
                 sessions = mutableState.value.sessions?.map { session ->
                     if (session.id == previousStoredId) updatedSummary else session
                 },

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -119,6 +119,8 @@ internal class CelesteViewModel(
     },
     private val activityDisclosurePreferences: ActivityDisclosurePreferenceStore =
         InMemoryActivityDisclosurePreferenceStore(),
+    private val activityDiscoveryTimeoutMillis: Long = 1_000L,
+    private val reasoningCoalescingWindowMillis: Long = 75L,
 ) : ViewModel() {
     private val mutableState = MutableStateFlow(CelesteUiState())
     val state: StateFlow<CelesteUiState> = mutableState.asStateFlow()
@@ -131,6 +133,9 @@ internal class CelesteViewModel(
     private var reconnectJob: Job? = null
     private var foregroundCheckJob: Job? = null
     private var connectionJob: Job? = null
+    private var activityDiscoveryJob: Job? = null
+    private var reasoningCoalescingJob: Job? = null
+    private val pendingReasoningDeltas = mutableListOf<GatewayEvent>()
     private var connectionAttempt = 0L
     private val connectionStoreMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
@@ -790,6 +795,7 @@ internal class CelesteViewModel(
                     errorMessage = null,
                 )
                 events.forEach { applyEvent(it) }
+                scheduleActivityDiscoveryFallback()
             }.onSuccess {
                 reconnectAttempts = 0
             }.onFailure { error ->
@@ -989,6 +995,7 @@ internal class CelesteViewModel(
             bufferedEvents.clear()
             reconciling = false
             events.forEach { applyEvent(it) }
+            scheduleActivityDiscoveryFallback()
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false
@@ -1064,7 +1071,52 @@ internal class CelesteViewModel(
         )
     }
 
+    private fun scheduleActivityDiscoveryFallback() {
+        activityDiscoveryJob?.cancel()
+        val activity = mutableState.value.agentActivity ?: return
+        if (activity.presentation != dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering) {
+            return
+        }
+        val expectedOrigin = activity.originKey
+        val expectedProfile = activity.profile
+        val expectedStoredSession = activity.storedSessionId
+        val expectedRuntime = activity.runtimeSessionId
+        activityDiscoveryJob = viewModelScope.launch {
+            delay(activityDiscoveryTimeoutMillis.coerceAtLeast(0L))
+            val current = mutableState.value.agentActivity
+            if (
+                current != null &&
+                current.presentation == dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering &&
+                current.originKey == expectedOrigin &&
+                current.profile == expectedProfile &&
+                current.storedSessionId == expectedStoredSession &&
+                current.runtimeSessionId == expectedRuntime
+            ) {
+                val resolved = withContext(Dispatchers.Default) {
+                    AgentActivityReducer.markAbsent(current)
+                }
+                mutableState.value = mutableState.value.copy(agentActivity = resolved)
+            }
+            activityDiscoveryJob = null
+        }
+    }
+
     private suspend fun applyEvent(event: GatewayEvent) {
+        if (event.type == "reasoning.delta" && event.payload.boolean("verbose") == true) {
+            pendingReasoningDeltas += event
+            if (reasoningCoalescingJob?.isActive != true) {
+                reasoningCoalescingJob = viewModelScope.launch {
+                    delay(reasoningCoalescingWindowMillis.coerceAtLeast(0L))
+                    flushReasoningDeltas()
+                }
+            }
+            return
+        }
+        flushReasoningDeltas()
+        applyEventNow(event)
+    }
+
+    private suspend fun applyEventNow(event: GatewayEvent) {
         val runtimeId = currentRuntimeSessionId?.trim()?.takeIf(String::isNotBlank) ?: return
         val eventSessionId = event.sessionId.trim()
         if (eventSessionId.isNotBlank() && eventSessionId != runtimeId) return
@@ -1079,6 +1131,10 @@ internal class CelesteViewModel(
             }
             if (updated !== projection) {
                 mutableState.value = mutableState.value.copy(agentActivity = updated)
+                if (updated.presentation != dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering) {
+                    activityDiscoveryJob?.cancel()
+                    activityDiscoveryJob = null
+                }
             }
         }
         when (event.type) {
@@ -1117,6 +1173,13 @@ internal class CelesteViewModel(
 
             "message.complete" -> {
                 val status = event.payload.string("status")?.lowercase()
+                val failureReason = event.payload.string("failure_reason")
+                    ?.takeIf(String::isNotBlank)
+                val explicitError = event.payload.string("error")
+                    ?.takeIf(String::isNotBlank)
+                val failed = status in setOf("error", "failed", "failure") ||
+                    failureReason != null ||
+                    explicitError != null
                 val content = event.payload.string("text")
                     ?: event.payload.string("content")
                     ?: event.payload.string("rendered")
@@ -1124,9 +1187,11 @@ internal class CelesteViewModel(
                 finalizeAssistant(content, keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = if (status in setOf("error", "failed", "failure")) {
-                        event.payload.string("error")?.let { sanitizeActivityText(it, 240) }
-                            ?: "Hermes could not finish that response."
+                    errorMessage = if (failed) {
+                        sanitizeActivityText(
+                            failureReason ?: explicitError ?: "Hermes could not finish that response.",
+                            240,
+                        )
                     } else {
                         mutableState.value.errorMessage
                     },
@@ -1137,8 +1202,11 @@ internal class CelesteViewModel(
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = event.payload.string("message")
-                        ?.let { sanitizeActivityText(it, 240) }
+                    errorMessage = (
+                        event.payload.string("failure_reason")
+                            ?: event.payload.string("error")
+                            ?: event.payload.string("message")
+                    )?.let { sanitizeActivityText(it, 240) }
                         ?: "Hermes reported an error.",
                 )
             }
@@ -1174,6 +1242,56 @@ internal class CelesteViewModel(
                 mutableState.value = mutableState.value.copy(turnState = TurnState.Running)
             }
         }
+    }
+
+    private suspend fun flushReasoningDeltas() {
+        reasoningCoalescingJob = null
+        val events = pendingReasoningDeltas.toList()
+        pendingReasoningDeltas.clear()
+        if (events.isEmpty()) return
+
+        val first = events.first()
+        val sameBinding = events.all { event ->
+            event.sessionId == first.sessionId &&
+                event.originKey == first.originKey &&
+                event.profile == first.profile &&
+                event.storedSessionId == first.storedSessionId
+        }
+        val hasExplicitReplayIdentity = events.any { event ->
+            event.eventId?.isNotBlank() == true ||
+                event.payload.keys.any {
+                    it == "event_id" || it == "eventId" || it == "event_seq" || it == "seq"
+                }
+        }
+        if (events.size == 1 || !sameBinding || hasExplicitReplayIdentity) {
+            events.forEach { applyEventNow(it) }
+            return
+        }
+
+        val mergedText = mergeReasoningDeltaText(events)
+        if (mergedText.isBlank()) return
+        val representative = events.last()
+        val combinedPayload = buildJsonObject {
+            representative.payload.forEach { (key, value) -> put(key, value) }
+            put("text", mergedText)
+            put("verbose", true)
+        }
+        applyEventNow(representative.copy(payload = combinedPayload, eventId = null))
+    }
+
+    private fun mergeReasoningDeltaText(events: List<GatewayEvent>): String {
+        var merged = ""
+        events.forEach { event ->
+            val text = event.payload.string("text").orEmpty()
+            if (text.isBlank()) return@forEach
+            merged = when {
+                merged.isBlank() -> text
+                text.startsWith(merged) -> text
+                merged.startsWith(text) || merged.endsWith(text) -> merged
+                else -> merged + text
+            }
+        }
+        return merged
     }
 
     private fun finalizeAssistant(
@@ -1259,6 +1377,7 @@ internal class CelesteViewModel(
             bufferedEvents.clear()
             reconciling = false
             events.forEach { applyEvent(it) }
+            scheduleActivityDiscoveryFallback()
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false
@@ -1315,6 +1434,11 @@ internal class CelesteViewModel(
         gateway = null
         reconnectJob?.cancel()
         reconnectJob = null
+        activityDiscoveryJob?.cancel()
+        activityDiscoveryJob = null
+        reasoningCoalescingJob?.cancel()
+        reasoningCoalescingJob = null
+        pendingReasoningDeltas.clear()
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
         gatewayEventsJob?.cancel()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -1300,13 +1300,21 @@ internal class CelesteViewModel(
         interim: Boolean = false,
     ) {
         val streamed = mutableState.value.streamingText
-        val finalText = when {
+        val rawFinalText = when {
             suppliedContent.isBlank() -> streamed
             streamed.isBlank() -> suppliedContent
             suppliedContent.startsWith(streamed) -> suppliedContent
             streamed.startsWith(suppliedContent) -> streamed
             else -> suppliedContent
         }.trimEnd()
+        // Hermes can include the same explicitly disclosed reasoning summary in
+        // the assistant's final content. Keep the labelled activity item, but do
+        // not render that summary a second time as ordinary assistant text.
+        val finalText = if (interim) {
+            rawFinalText
+        } else {
+            deduplicateReasoningFromFinalContent(rawFinalText)
+        }
         val currentMessages = mutableState.value.messages
         val previous = currentMessages.lastOrNull()
         val continuesInterim = !interim &&
@@ -1315,6 +1323,8 @@ internal class CelesteViewModel(
             finalText.isNotBlank() &&
             (finalText.startsWith(previous.text) || previous.text.startsWith(finalText))
         val messages = when {
+            !interim && previous?.let(::isReasoningOnlyInterim) == true && finalText.isBlank() ->
+                currentMessages.dropLast(1)
             continuesInterim -> currentMessages.dropLast(1) + previous.copy(
                 text = if (finalText.length >= previous.text.length) finalText else previous.text,
                 interim = false,
@@ -1332,6 +1342,35 @@ internal class CelesteViewModel(
             streamingText = "",
             turnState = if (keepRunning) TurnState.Running else TurnState.Idle,
         )
+    }
+
+    private fun deduplicateReasoningFromFinalContent(raw: String): String {
+        var content = raw
+        val reasoningDetails = mutableState.value.agentActivity?.items
+            .filterIsInstance<ServerReasoningActivity>()
+            .map { it.text.text.trim() }
+            .filter(String::isNotBlank)
+            .distinct()
+            .sortedByDescending { it.length }
+        reasoningDetails.forEach { reasoning ->
+            val normalized = content.trim()
+            content = when {
+                normalized == reasoning -> ""
+                normalized.startsWith(reasoning) -> normalized.removePrefix(reasoning).trimStart()
+                normalized.endsWith(reasoning) -> normalized.removeSuffix(reasoning).trimEnd()
+                else -> content
+            }
+        }
+        return content
+    }
+
+    private fun isReasoningOnlyInterim(message: ConversationMessage): Boolean {
+        if (message.role != "assistant" || !message.interim) return false
+        val text = message.text.trim()
+        return mutableState.value.agentActivity?.items
+            ?.filterIsInstance<ServerReasoningActivity>()
+            ?.any { it.text.text.trim() == text && text.isNotBlank() }
+            == true
     }
 
     private suspend fun recreateBlankSession(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -23,6 +23,7 @@ import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.ActivityBinding
 import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
 import dev.hazydreams.hermesceleste.network.ActivityDisclosurePreferenceStore
+import dev.hazydreams.hermesceleste.network.ActivityDisclosureScope
 import dev.hazydreams.hermesceleste.network.AgentActivityProjection
 import dev.hazydreams.hermesceleste.network.AgentActivityReducer
 import dev.hazydreams.hermesceleste.network.InMemoryActivityDisclosurePreferenceStore
@@ -34,6 +35,7 @@ import dev.hazydreams.hermesceleste.network.ResumedSession
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.boolean
 import dev.hazydreams.hermesceleste.network.createSession
+import dev.hazydreams.hermesceleste.network.sanitizeActivityText
 import dev.hazydreams.hermesceleste.network.interruptSession
 import dev.hazydreams.hermesceleste.network.resumeStoredSession
 import dev.hazydreams.hermesceleste.network.string
@@ -42,6 +44,7 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,6 +53,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -136,6 +140,7 @@ internal class CelesteViewModel(
     private var activityReasoningDisclosureEnabled = runCatching {
         activityDisclosurePreferences.isServerReasoningDisclosureEnabled()
     }.getOrDefault(true)
+    private var activityDisclosureScope: ActivityDisclosureScope? = null
     private val bufferedEvents = mutableListOf<GatewayEvent>()
 
     init {
@@ -177,7 +182,9 @@ internal class CelesteViewModel(
     fun setActivityReasoningDisclosureEnabled(enabled: Boolean) {
         activityReasoningDisclosureEnabled = enabled
         runCatching {
-            activityDisclosurePreferences.setServerReasoningDisclosureEnabled(enabled)
+            activityDisclosureScope?.let { scope ->
+                activityDisclosurePreferences.setServerReasoningDisclosureEnabled(scope, enabled)
+            } ?: activityDisclosurePreferences.setServerReasoningDisclosureEnabled(enabled)
         }
         val activity = mutableState.value.agentActivity
         mutableState.value = mutableState.value.copy(
@@ -200,6 +207,7 @@ internal class CelesteViewModel(
         if (rawUrl.isBlank()) return
         val attempt = beginConnectionAttempt()
         closeGateway()
+        clearActivityDisclosureScope()
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
@@ -327,6 +335,7 @@ internal class CelesteViewModel(
     fun leaveSessionList() {
         beginConnectionAttempt()
         closeGateway()
+        clearActivityDisclosureScope()
         credential = null
         mutableState.value = mutableState.value.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
@@ -347,6 +356,7 @@ internal class CelesteViewModel(
     fun useAnotherConnection() {
         beginConnectionAttempt()
         closeGateway()
+        clearActivityDisclosureScope()
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
@@ -361,6 +371,7 @@ internal class CelesteViewModel(
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
         closeGateway()
+        clearActivityDisclosureScope()
         credential = null
         currentDescriptor = null
         mutableState.value = snapshot.copy(
@@ -401,6 +412,7 @@ internal class CelesteViewModel(
         val activeCredential = credential
         val attempt = beginConnectionAttempt()
         closeGateway()
+        clearActivityDisclosureScope()
         credential = null
         currentDescriptor = null
         mutableState.value = CelesteUiState(
@@ -430,6 +442,7 @@ internal class CelesteViewModel(
     private fun restoreSavedConnection() {
         val attempt = beginConnectionAttempt()
         closeGateway()
+        clearActivityDisclosureScope()
         credential = null
         mutableState.value = CelesteUiState(
             connectionPhase = ConnectionPhase.CheckingSavedConnection,
@@ -628,6 +641,31 @@ internal class CelesteViewModel(
         errorMessage = errorMessage,
     )
 
+    private fun useActivityDisclosureScope(scope: ActivityDisclosureScope?) {
+        activityDisclosureScope = scope
+        activityReasoningDisclosureEnabled = runCatching {
+            scope?.let { activityDisclosurePreferences.isServerReasoningDisclosureEnabled(it) }
+                ?: activityDisclosurePreferences.isServerReasoningDisclosureEnabled()
+        }.getOrDefault(true)
+        mutableState.value = mutableState.value.copy(
+            agentActivityReasoningDisclosureEnabled = activityReasoningDisclosureEnabled,
+        )
+    }
+
+    private fun clearActivityDisclosureScope() {
+        useActivityDisclosureScope(null)
+    }
+
+    private fun activityDisclosureScope(
+        originKey: String,
+        profile: String,
+        storedSessionId: String,
+    ): ActivityDisclosureScope = ActivityDisclosureScope(
+        originKey = normalizeActivityOrigin(originKey),
+        profile = profile,
+        storedSessionId = storedSessionId,
+    )
+
     private fun beginConnectionAttempt(): Long {
         connectionAttempt += 1
         connectionJob?.cancel()
@@ -644,11 +682,15 @@ internal class CelesteViewModel(
         currentRuntimeSessionId = null
         currentStoredSessionId = summary.id
         currentSessionCanResume = true
+        val profile = summary.profile.ifBlank { mutableState.value.selectedProfile }
+        useActivityDisclosureScope(
+            activityDisclosureScope(connection.baseUrl, profile, summary.id),
+        )
         val initialActivity = initialActivityProjection(
             originKey = connection.baseUrl,
-            profile = summary.profile.ifBlank { mutableState.value.selectedProfile },
+            profile = profile,
             storedSessionId = summary.id,
-            capability = ActivityCapabilityState.Unknown,
+            capability = connection.activityCapability,
         )
         mutableState.value = mutableState.value.copy(
             activeSummary = summary,
@@ -713,6 +755,7 @@ internal class CelesteViewModel(
                 if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
                     throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
                 }
+                val activityProfile = returnedProfile ?: selectedProfile
                 currentRuntimeSessionId = created.runtimeSessionId
                 currentStoredSessionId = created.storedSessionId
                 currentSessionCanResume = false
@@ -723,27 +766,30 @@ internal class CelesteViewModel(
                     startedAt = 0.0,
                     messageCount = 0,
                     source = "android",
-                    profile = selectedProfile,
+                    profile = activityProfile,
                 )
                 val events = bufferedEvents.toList()
                 bufferedEvents.clear()
                 reconciling = false
+                useActivityDisclosureScope(
+                    activityDisclosureScope(connection.baseUrl, activityProfile, created.storedSessionId),
+                )
                 mutableState.value = mutableState.value.copy(
                     sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
                         .filterNot { it.id == summary.id },
                     activeSummary = summary,
                     agentActivity = initialActivityProjection(
                         originKey = connection.baseUrl,
-                        profile = selectedProfile,
+                        profile = activityProfile,
                         storedSessionId = created.storedSessionId,
                         runtimeSessionId = created.runtimeSessionId,
-                        capability = ActivityCapabilityState.Unknown,
+                        capability = connection.activityCapability,
                     ),
                     turnState = TurnState.Idle,
                     loadingMessage = null,
                     errorMessage = null,
                 )
-                events.forEach(::applyEvent)
+                events.forEach { applyEvent(it) }
             }.onSuccess {
                 reconnectAttempts = 0
             }.onFailure { error ->
@@ -759,6 +805,7 @@ internal class CelesteViewModel(
 
     fun leaveConversation() {
         closeGateway()
+        clearActivityDisclosureScope()
         mutableState.value = mutableState.value.copy(
             activeSummary = null,
             messages = emptyList(),
@@ -927,13 +974,21 @@ internal class CelesteViewModel(
             agentActivity = mutableState.value.agentActivity?.let(AgentActivityReducer::markRestoring),
         )
         try {
-            val resumed = activeGateway.resumeStoredSession(storedSessionId)
+            val activity = mutableState.value.agentActivity
+            val resumed = activeGateway.resumeStoredSession(
+                storedSessionId = storedSessionId,
+                profile = activity?.profile
+                    ?: mutableState.value.activeSummary?.profile
+                    ?: mutableState.value.selectedProfile,
+                originKey = activity?.originKey
+                    ?: mutableState.value.probe?.baseUrl,
+            )
             if (gateway !== activeGateway) return
             applyResumedSession(resumed)
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false
-            events.forEach(::applyEvent)
+            events.forEach { applyEvent(it) }
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false
@@ -949,34 +1004,39 @@ internal class CelesteViewModel(
         val expectedStoredId = currentStoredSessionId
             ?: mutableState.value.activeSummary?.id
             ?: resumed.storedSessionId
-        if (resumed.storedSessionId != expectedStoredId) {
+        if (resumed.storedSessionId.trim() != expectedStoredId.trim()) {
             throw IOException("Hermes returned activity for a different stored conversation.")
         }
         if (currentActivity != null) {
-            if (resumed.originKey != null &&
+            if (
+                resumed.originKey != null &&
                 normalizeActivityOrigin(resumed.originKey) != currentActivity.originKey
             ) {
                 throw IOException("Hermes returned activity for a different dashboard origin.")
             }
-            if (resumed.profile != null &&
-                resumed.profile.isNotBlank() &&
-                resumed.profile != currentActivity.profile
+            if (
+                resumed.profile != null &&
+                resumed.profile.trim().isNotBlank() &&
+                resumed.profile.trim() != currentActivity.profile
             ) {
                 throw IOException("Hermes returned activity for a different profile.")
             }
         }
-        currentRuntimeSessionId = resumed.runtimeSessionId
-        currentStoredSessionId = resumed.storedSessionId
+        currentRuntimeSessionId = resumed.runtimeSessionId.trim()
+        currentStoredSessionId = resumed.storedSessionId.trim()
         currentSessionCanResume = true
         val streamingSuffix = unpersistedInflightText(
             inflight = resumed.inflightAssistantText,
             messages = resumed.messages,
         )
         val activity = currentActivity?.let { projection ->
+            val effectiveServerReasoningAllowed = resumed.serverReasoningAllowed
+                ?: projection.serverReasoningAllowed
             val snapshotItems = resumed.activityItems.ifEmpty {
                 dev.hazydreams.hermesceleste.network.activityItemsFromMessages(resumed.messages)
             }.filter { item ->
-                activityReasoningDisclosureEnabled || item !is ServerReasoningActivity
+                (activityReasoningDisclosureEnabled && effectiveServerReasoningAllowed != false) ||
+                    item !is ServerReasoningActivity
             }
             AgentActivityReducer.applySnapshot(
                 projection = projection,
@@ -988,6 +1048,7 @@ internal class CelesteViewModel(
                     runtimeSessionId = resumed.runtimeSessionId,
                 ),
                 running = resumed.running == true || resumed.hasLiveProjection,
+                serverReasoningAllowed = effectiveServerReasoningAllowed,
             )
         }
         mutableState.value = mutableState.value.copy(
@@ -1003,15 +1064,19 @@ internal class CelesteViewModel(
         )
     }
 
-    private fun applyEvent(event: GatewayEvent) {
-        val runtimeId = currentRuntimeSessionId ?: return
-        if (event.sessionId.isNotBlank() && event.sessionId != runtimeId) return
-        mutableState.value.agentActivity?.let { projection ->
-            val updated = AgentActivityReducer.applyEvent(
-                projection = projection,
-                event = event,
-                reasoningEnabled = activityReasoningDisclosureEnabled,
-            )
+    private suspend fun applyEvent(event: GatewayEvent) {
+        val runtimeId = currentRuntimeSessionId?.trim()?.takeIf(String::isNotBlank) ?: return
+        val eventSessionId = event.sessionId.trim()
+        if (eventSessionId.isNotBlank() && eventSessionId != runtimeId) return
+        val projection = mutableState.value.agentActivity
+        if (projection != null) {
+            val updated = withContext(Dispatchers.Default) {
+                AgentActivityReducer.applyEvent(
+                    projection = projection,
+                    event = event,
+                    reasoningEnabled = activityReasoningDisclosureEnabled,
+                )
+            }
             if (updated !== projection) {
                 mutableState.value = mutableState.value.copy(agentActivity = updated)
             }
@@ -1051,7 +1116,7 @@ internal class CelesteViewModel(
             }
 
             "message.complete" -> {
-                val status = event.payload.string("status")
+                val status = event.payload.string("status")?.lowercase()
                 val content = event.payload.string("text")
                     ?: event.payload.string("content")
                     ?: event.payload.string("rendered")
@@ -1059,8 +1124,9 @@ internal class CelesteViewModel(
                 finalizeAssistant(content, keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = if (status == "error") {
-                        event.payload.string("error") ?: "Hermes could not finish that response."
+                    errorMessage = if (status in setOf("error", "failed", "failure")) {
+                        event.payload.string("error")?.let { sanitizeActivityText(it, 240) }
+                            ?: "Hermes could not finish that response."
                     } else {
                         mutableState.value.errorMessage
                     },
@@ -1071,7 +1137,9 @@ internal class CelesteViewModel(
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = event.payload.string("message") ?: "Hermes reported an error.",
+                    errorMessage = event.payload.string("message")
+                        ?.let { sanitizeActivityText(it, 240) }
+                        ?: "Hermes reported an error.",
                 )
             }
 
@@ -1160,19 +1228,24 @@ internal class CelesteViewModel(
             if (gateway !== activeGateway) return
             currentRuntimeSessionId = created.runtimeSessionId
             currentStoredSessionId = created.storedSessionId
+            currentSessionCanResume = false
             val previousSummary = mutableState.value.activeSummary
                 ?: throw IOException("No draft conversation is open.")
             val previousActivity = mutableState.value.agentActivity
                 ?: throw IOException("No activity projection is open.")
-            val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
+            val activityProfile = created.profile?.takeIf(String::isNotBlank) ?: profile
+            val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = activityProfile)
+            useActivityDisclosureScope(
+                activityDisclosureScope(previousActivity.originKey, activityProfile, created.storedSessionId),
+            )
             val updatedActivity = initialActivityProjection(
                 originKey = previousActivity.originKey,
-                profile = profile,
+                profile = activityProfile,
                 storedSessionId = created.storedSessionId,
                 runtimeSessionId = created.runtimeSessionId,
-                capability = ActivityCapabilityState.Unknown,
+                capability = mutableState.value.probe?.activityCapability
+                    ?: ActivityCapabilityState.Unknown,
             )
-            currentSessionCanResume = false
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
                 agentActivity = updatedActivity,
@@ -1185,7 +1258,7 @@ internal class CelesteViewModel(
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false
-            events.forEach(::applyEvent)
+            events.forEach { applyEvent(it) }
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false

--- a/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.hazydreams.hermesceleste.connection.AndroidConnectionStore
+import dev.hazydreams.hermesceleste.network.AndroidActivityDisclosurePreferenceStore
 import dev.hazydreams.hermesceleste.ui.CelesteRoutes
 import dev.hazydreams.hermesceleste.ui.HermesCelesteTheme
 
@@ -45,7 +46,10 @@ private class CelesteViewModelFactory(
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass.isAssignableFrom(CelesteViewModel::class.java))
-        return CelesteViewModel(connectionStore = AndroidConnectionStore(context)) as T
+        return CelesteViewModel(
+            connectionStore = AndroidConnectionStore(context),
+            activityDisclosurePreferences = AndroidActivityDisclosurePreferenceStore(context),
+        ) as T
     }
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/UiProjection.kt
@@ -1,0 +1,172 @@
+package dev.hazydreams.hermesceleste
+
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+
+/**
+ * Product-facing recovery categories. Compose receives this typed projection,
+ * never exception or server-provided error text.
+ */
+internal enum class UiNoticeCategory {
+    AuthenticationRequired,
+    RateLimited,
+    Reconnecting,
+    TransportUnavailable,
+    InvalidResponse,
+    ServerTurnFailure,
+    GenericTurnFailure,
+    Persistence,
+    PreferencePersistence,
+}
+
+internal enum class UiNoticeScope {
+    Connection,
+    Session,
+    Turn,
+}
+
+internal enum class UiRecoveryAction {
+    None,
+    Retry,
+    SignIn,
+}
+
+internal data class UiNotice(
+    val category: UiNoticeCategory,
+    val recovery: UiRecoveryAction,
+    val scope: UiNoticeScope,
+) {
+    /** Stable, catalogued product copy. Raw server/exception text never enters here. */
+    val message: String
+        get() = when (category) {
+            UiNoticeCategory.AuthenticationRequired -> "Your Hermes sign-in has expired. Sign in again."
+            UiNoticeCategory.RateLimited -> "Hermes is busy right now. Try again shortly."
+            UiNoticeCategory.Reconnecting -> "Reconnecting to Hermes…"
+            UiNoticeCategory.TransportUnavailable -> "Hermes is unavailable right now. Try again."
+            UiNoticeCategory.InvalidResponse -> "Hermes returned an unexpected response. Try again."
+            UiNoticeCategory.ServerTurnFailure -> "Hermes couldn’t finish that response."
+            UiNoticeCategory.GenericTurnFailure -> "Hermes reported an error. Try again."
+            UiNoticeCategory.Persistence -> "Connected, but Celeste could not remember this connection."
+            UiNoticeCategory.PreferencePersistence -> "Couldn’t save this display preference. Try again."
+        }
+
+    val recoveryLabel: String?
+        get() = when (recovery) {
+            UiRecoveryAction.None -> null
+            UiRecoveryAction.Retry -> "Retry"
+            UiRecoveryAction.SignIn -> "Sign in"
+        }
+
+    companion object {
+        fun authentication(scope: UiNoticeScope = UiNoticeScope.Connection) = UiNotice(
+            category = UiNoticeCategory.AuthenticationRequired,
+            recovery = UiRecoveryAction.SignIn,
+            scope = scope,
+        )
+
+        fun rateLimited(scope: UiNoticeScope = UiNoticeScope.Connection) = UiNotice(
+            category = UiNoticeCategory.RateLimited,
+            recovery = UiRecoveryAction.Retry,
+            scope = scope,
+        )
+
+        fun reconnecting(scope: UiNoticeScope = UiNoticeScope.Session) = UiNotice(
+            category = UiNoticeCategory.Reconnecting,
+            recovery = UiRecoveryAction.None,
+            scope = scope,
+        )
+
+        fun unavailable(scope: UiNoticeScope = UiNoticeScope.Session) = UiNotice(
+            category = UiNoticeCategory.TransportUnavailable,
+            recovery = UiRecoveryAction.Retry,
+            scope = scope,
+        )
+
+        fun invalidResponse(scope: UiNoticeScope = UiNoticeScope.Connection) = UiNotice(
+            category = UiNoticeCategory.InvalidResponse,
+            recovery = UiRecoveryAction.Retry,
+            scope = scope,
+        )
+
+        fun serverTurnFailure() = UiNotice(
+            category = UiNoticeCategory.ServerTurnFailure,
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Turn,
+        )
+
+        fun genericTurnFailure() = UiNotice(
+            category = UiNoticeCategory.GenericTurnFailure,
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Turn,
+        )
+
+        fun persistence() = UiNotice(
+            category = UiNoticeCategory.Persistence,
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Connection,
+        )
+
+        fun preferencePersistence() = UiNotice(
+            category = UiNoticeCategory.PreferencePersistence,
+            recovery = UiRecoveryAction.Retry,
+            scope = UiNoticeScope.Connection,
+        )
+    }
+}
+
+/** Project any failure into fixed product copy and a bounded recovery action. */
+internal fun projectUiNotice(error: Throwable, scope: UiNoticeScope): UiNotice? {
+    if (isExpectedCancellation(error)) return null
+    if (containsTimeoutCancellation(error)) return UiNotice.unavailable(scope)
+
+    val typedError = findCause(error) {
+        it is dev.hazydreams.hermesceleste.network.AuthenticationRejected ||
+            it is dev.hazydreams.hermesceleste.network.RateLimited ||
+            it is dev.hazydreams.hermesceleste.network.InvalidDashboardResponse ||
+            it is dev.hazydreams.hermesceleste.network.TransportUnavailable ||
+            it is dev.hazydreams.hermesceleste.network.GatewayRpcException
+    }
+    return when (typedError) {
+        is dev.hazydreams.hermesceleste.network.AuthenticationRejected -> UiNotice.authentication(scope)
+        is dev.hazydreams.hermesceleste.network.RateLimited -> UiNotice.rateLimited(scope)
+        is dev.hazydreams.hermesceleste.network.InvalidDashboardResponse -> UiNotice.invalidResponse(scope)
+        is dev.hazydreams.hermesceleste.network.TransportUnavailable -> UiNotice.unavailable(scope)
+        is dev.hazydreams.hermesceleste.network.GatewayRpcException -> when (typedError.code) {
+            401, 403 -> UiNotice.authentication(scope)
+            429 -> UiNotice.rateLimited(scope)
+            -32600, -32601, -32602, -32603 -> UiNotice.invalidResponse(scope)
+            else -> if (scope == UiNoticeScope.Turn) {
+                UiNotice.genericTurnFailure()
+            } else {
+                UiNotice.invalidResponse(scope)
+            }
+        }
+        else -> if (scope == UiNoticeScope.Turn) {
+            UiNotice.genericTurnFailure()
+        } else {
+            UiNotice.unavailable(scope)
+        }
+    }
+}
+
+/** Cancellation is structural control flow and must remain silent at the UI boundary. */
+internal fun isExpectedCancellation(error: Throwable): Boolean {
+    if (containsTimeoutCancellation(error)) return false
+    return findCause(error) { it is CancellationException } != null
+}
+
+private fun containsTimeoutCancellation(error: Throwable): Boolean =
+    findCause(error) { it is TimeoutCancellationException } != null
+
+private fun findCause(error: Throwable, predicate: (Throwable) -> Boolean): Throwable? {
+    val seen: MutableSet<Throwable> =
+        Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
+    var current: Throwable? = error
+    while (current != null && seen.add(current)) {
+        if (predicate(current)) return current
+        current = current.cause
+    }
+    return null
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
@@ -1,6 +1,7 @@
 package dev.hazydreams.hermesceleste.network
 
 import android.content.Context
+import android.content.SharedPreferences
 import java.security.MessageDigest
 
 /**
@@ -62,12 +63,14 @@ class InMemoryActivityDisclosurePreferenceStore(
     }
 }
 
-class AndroidActivityDisclosurePreferenceStore(
-    context: Context,
+class AndroidActivityDisclosurePreferenceStore private constructor(
+    private val preferences: SharedPreferences,
 ) : ActivityDisclosurePreferenceStore {
-    private val preferences = context.applicationContext.getSharedPreferences(
-        PREFERENCES_NAME,
-        Context.MODE_PRIVATE,
+    constructor(context: Context) : this(
+        context.applicationContext.getSharedPreferences(
+            PREFERENCES_NAME,
+            Context.MODE_PRIVATE,
+        ),
     )
 
     override fun isServerReasoningDisclosureEnabled(): Boolean =
@@ -93,9 +96,15 @@ class AndroidActivityDisclosurePreferenceStore(
     private fun scopedKey(scope: ActivityDisclosureScope): String =
         "$SCOPED_REASONING_DISCLOSURE_PREFIX${scope.stablePreferenceKey()}"
 
-    private companion object {
-        const val PREFERENCES_NAME = "celeste_activity_preferences"
-        const val GLOBAL_REASONING_DISCLOSURE_KEY = "server_reasoning_disclosure_enabled"
-        const val SCOPED_REASONING_DISCLOSURE_PREFIX = "server_reasoning_disclosure_enabled:"
+    companion object {
+        /** JVM tests use the real SharedPreferences contract with a fake backend. */
+        internal fun fromPreferences(
+            preferences: SharedPreferences,
+        ): AndroidActivityDisclosurePreferenceStore =
+            AndroidActivityDisclosurePreferenceStore(preferences)
+
+        private const val PREFERENCES_NAME = "celeste_activity_preferences"
+        private const val GLOBAL_REASONING_DISCLOSURE_KEY = "server_reasoning_disclosure_enabled"
+        private const val SCOPED_REASONING_DISCLOSURE_PREFIX = "server_reasoning_disclosure_enabled:"
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
@@ -1,15 +1,47 @@
 package dev.hazydreams.hermesceleste.network
 
 import android.content.Context
+import java.security.MessageDigest
 
-/** Stores only the device-local disclosure choice, never activity text or tool arguments. */
+/**
+ * The local reasoning disclosure choice is scoped to the same authority chain
+ * as the activity projection. It never stores activity text, tool arguments, or
+ * server credentials.
+ */
+data class ActivityDisclosureScope(
+    val originKey: NormalizedDashboardOrigin,
+    val profile: String,
+    val storedSessionId: String,
+) {
+    internal val normalizedOrigin: String get() = normalizeActivityOrigin(originKey)
+    internal val normalizedProfile: String get() = profile.trim().ifBlank { "default" }
+    internal val normalizedStoredSessionId: String get() = storedSessionId.trim()
+
+    internal fun stablePreferenceKey(): String =
+        sha256("$normalizedOrigin\u0000$normalizedProfile\u0000$normalizedStoredSessionId")
+
+    private companion object {
+        fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    }
+}
+
 interface ActivityDisclosurePreferenceStore {
     fun isServerReasoningDisclosureEnabled(): Boolean
     fun setServerReasoningDisclosureEnabled(enabled: Boolean)
+
+    /** Scoped overloads keep older callers source-compatible during migration. */
+    fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
+        isServerReasoningDisclosureEnabled()
+
+    fun setServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope, enabled: Boolean) =
+        setServerReasoningDisclosureEnabled(enabled)
 }
 
 class InMemoryActivityDisclosurePreferenceStore(
     initialEnabled: Boolean = true,
+    private val scopedValues: MutableMap<String, Boolean> = mutableMapOf(),
 ) : ActivityDisclosurePreferenceStore {
     private var enabled = initialEnabled
 
@@ -17,6 +49,16 @@ class InMemoryActivityDisclosurePreferenceStore(
 
     override fun setServerReasoningDisclosureEnabled(enabled: Boolean) {
         this.enabled = enabled
+    }
+
+    override fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
+        scopedValues[scope.stablePreferenceKey()] ?: enabled
+
+    override fun setServerReasoningDisclosureEnabled(
+        scope: ActivityDisclosureScope,
+        enabled: Boolean,
+    ) {
+        scopedValues[scope.stablePreferenceKey()] = enabled
     }
 }
 
@@ -29,14 +71,31 @@ class AndroidActivityDisclosurePreferenceStore(
     )
 
     override fun isServerReasoningDisclosureEnabled(): Boolean =
-        preferences.getBoolean(REASONING_DISCLOSURE_KEY, true)
+        preferences.getBoolean(GLOBAL_REASONING_DISCLOSURE_KEY, true)
 
     override fun setServerReasoningDisclosureEnabled(enabled: Boolean) {
-        preferences.edit().putBoolean(REASONING_DISCLOSURE_KEY, enabled).apply()
+        preferences.edit().putBoolean(GLOBAL_REASONING_DISCLOSURE_KEY, enabled).apply()
     }
+
+    override fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
+        preferences.getBoolean(
+            scopedKey(scope),
+            preferences.getBoolean(GLOBAL_REASONING_DISCLOSURE_KEY, true),
+        )
+
+    override fun setServerReasoningDisclosureEnabled(
+        scope: ActivityDisclosureScope,
+        enabled: Boolean,
+    ) {
+        preferences.edit().putBoolean(scopedKey(scope), enabled).apply()
+    }
+
+    private fun scopedKey(scope: ActivityDisclosureScope): String =
+        "$SCOPED_REASONING_DISCLOSURE_PREFIX${scope.stablePreferenceKey()}"
 
     private companion object {
         const val PREFERENCES_NAME = "celeste_activity_preferences"
-        const val REASONING_DISCLOSURE_KEY = "server_reasoning_disclosure_enabled"
+        const val GLOBAL_REASONING_DISCLOSURE_KEY = "server_reasoning_disclosure_enabled"
+        const val SCOPED_REASONING_DISCLOSURE_PREFIX = "server_reasoning_disclosure_enabled:"
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
@@ -1,0 +1,42 @@
+package dev.hazydreams.hermesceleste.network
+
+import android.content.Context
+
+/** Stores only the device-local disclosure choice, never activity text or tool arguments. */
+interface ActivityDisclosurePreferenceStore {
+    fun isServerReasoningDisclosureEnabled(): Boolean
+    fun setServerReasoningDisclosureEnabled(enabled: Boolean)
+}
+
+class InMemoryActivityDisclosurePreferenceStore(
+    initialEnabled: Boolean = true,
+) : ActivityDisclosurePreferenceStore {
+    private var enabled = initialEnabled
+
+    override fun isServerReasoningDisclosureEnabled(): Boolean = enabled
+
+    override fun setServerReasoningDisclosureEnabled(enabled: Boolean) {
+        this.enabled = enabled
+    }
+}
+
+class AndroidActivityDisclosurePreferenceStore(
+    context: Context,
+) : ActivityDisclosurePreferenceStore {
+    private val preferences = context.applicationContext.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+
+    override fun isServerReasoningDisclosureEnabled(): Boolean =
+        preferences.getBoolean(REASONING_DISCLOSURE_KEY, true)
+
+    override fun setServerReasoningDisclosureEnabled(enabled: Boolean) {
+        preferences.edit().putBoolean(REASONING_DISCLOSURE_KEY, enabled).apply()
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "celeste_activity_preferences"
+        const val REASONING_DISCLOSURE_KEY = "server_reasoning_disclosure_enabled"
+    }
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStore.kt
@@ -30,14 +30,21 @@ data class ActivityDisclosureScope(
 
 interface ActivityDisclosurePreferenceStore {
     fun isServerReasoningDisclosureEnabled(): Boolean
-    fun setServerReasoningDisclosureEnabled(enabled: Boolean)
+
+    /**
+     * Returns true only after the write has been synchronously accepted and
+     * verified by reading the stored value back.
+     */
+    fun setServerReasoningDisclosureEnabled(enabled: Boolean): Boolean
 
     /** Scoped overloads keep older callers source-compatible during migration. */
     fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
         isServerReasoningDisclosureEnabled()
 
-    fun setServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope, enabled: Boolean) =
-        setServerReasoningDisclosureEnabled(enabled)
+    fun setServerReasoningDisclosureEnabled(
+        scope: ActivityDisclosureScope,
+        enabled: Boolean,
+    ): Boolean = setServerReasoningDisclosureEnabled(enabled)
 }
 
 class InMemoryActivityDisclosurePreferenceStore(
@@ -48,8 +55,9 @@ class InMemoryActivityDisclosurePreferenceStore(
 
     override fun isServerReasoningDisclosureEnabled(): Boolean = enabled
 
-    override fun setServerReasoningDisclosureEnabled(enabled: Boolean) {
+    override fun setServerReasoningDisclosureEnabled(enabled: Boolean): Boolean {
         this.enabled = enabled
+        return true
     }
 
     override fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
@@ -58,8 +66,9 @@ class InMemoryActivityDisclosurePreferenceStore(
     override fun setServerReasoningDisclosureEnabled(
         scope: ActivityDisclosureScope,
         enabled: Boolean,
-    ) {
+    ): Boolean {
         scopedValues[scope.stablePreferenceKey()] = enabled
+        return true
     }
 }
 
@@ -76,9 +85,8 @@ class AndroidActivityDisclosurePreferenceStore private constructor(
     override fun isServerReasoningDisclosureEnabled(): Boolean =
         preferences.getBoolean(GLOBAL_REASONING_DISCLOSURE_KEY, true)
 
-    override fun setServerReasoningDisclosureEnabled(enabled: Boolean) {
-        preferences.edit().putBoolean(GLOBAL_REASONING_DISCLOSURE_KEY, enabled).apply()
-    }
+    override fun setServerReasoningDisclosureEnabled(enabled: Boolean): Boolean =
+        commitAndVerify(GLOBAL_REASONING_DISCLOSURE_KEY, enabled)
 
     override fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
         preferences.getBoolean(
@@ -89,8 +97,15 @@ class AndroidActivityDisclosurePreferenceStore private constructor(
     override fun setServerReasoningDisclosureEnabled(
         scope: ActivityDisclosureScope,
         enabled: Boolean,
-    ) {
-        preferences.edit().putBoolean(scopedKey(scope), enabled).apply()
+    ): Boolean = commitAndVerify(scopedKey(scope), enabled)
+
+    private fun commitAndVerify(key: String, enabled: Boolean): Boolean {
+        val committed = runCatching {
+            preferences.edit().putBoolean(key, enabled).commit()
+        }.getOrDefault(false)
+        return committed && runCatching {
+            preferences.getBoolean(key, !enabled) == enabled
+        }.getOrDefault(false)
     }
 
     private fun scopedKey(scope: ActivityDisclosureScope): String =

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
@@ -1,0 +1,819 @@
+package dev.hazydreams.hermesceleste.network
+
+import java.time.Instant
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/** The origin/profile/session chain that authorizes an activity projection. */
+typealias NormalizedDashboardOrigin = String
+
+enum class ActivitySource {
+    Live,
+    Resumed,
+    Legacy,
+    Unavailable,
+}
+
+enum class ActivityCapabilityState {
+    Unknown,
+    ToolOnly,
+    ToolAndServerReasoning,
+    LegacyToolOnly,
+    Unsupported,
+    Stale,
+}
+
+enum class ActivityPresentationState {
+    Unknown,
+    Discovering,
+    Available,
+    Running,
+    Stale,
+    Restoring,
+    Unavailable,
+}
+
+enum class ToolPhase {
+    Started,
+    Running,
+    Completed,
+    Failed,
+    Interrupted,
+}
+
+enum class CorrelationQuality {
+    ExactId,
+    LegacyName,
+    Uncorrelated,
+}
+
+enum class ReasoningSource {
+    ServerSummary,
+    ServerFull,
+}
+
+enum class ReasoningPhase {
+    Streaming,
+    Complete,
+    Unavailable,
+}
+
+data class DisplayedDetail(
+    val text: String,
+    val originalLength: Int,
+    val wasTruncated: Boolean,
+    val wasRedacted: Boolean,
+    val canRestore: Boolean,
+)
+
+sealed interface ActivityItem {
+    val uiKey: String
+}
+
+data class ToolActivity(
+    override val uiKey: String,
+    val callId: String?,
+    val name: String,
+    val phase: ToolPhase,
+    val input: DisplayedDetail?,
+    val output: DisplayedDetail?,
+    val startedAt: Instant?,
+    val finishedAt: Instant?,
+    val correlation: CorrelationQuality,
+) : ActivityItem
+
+data class ServerReasoningActivity(
+    override val uiKey: String,
+    val source: ReasoningSource,
+    val phase: ReasoningPhase,
+    val text: DisplayedDetail,
+    val serverLabel: String?,
+) : ActivityItem
+
+data class ActivityBinding(
+    val originKey: NormalizedDashboardOrigin,
+    val profile: String,
+    val storedSessionId: String,
+    val runtimeSessionId: String? = null,
+)
+
+data class AgentActivityProjection(
+    val originKey: NormalizedDashboardOrigin,
+    val profile: String,
+    val storedSessionId: String,
+    val runtimeSessionId: String?,
+    val items: List<ActivityItem>,
+    val source: ActivitySource,
+    val capability: ActivityCapabilityState,
+    val lastAuthoritativeSnapshot: Instant?,
+    val presentation: ActivityPresentationState = ActivityPresentationState.Unknown,
+    val malformedEventCount: Int = 0,
+    val ambiguousCorrelationCount: Int = 0,
+) {
+    /** Count-only diagnostics; raw event payloads are deliberately absent. */
+    val diagnosticCount: Int get() = malformedEventCount + ambiguousCorrelationCount
+
+    companion object {
+        fun forSession(
+            originKey: NormalizedDashboardOrigin,
+            profile: String,
+            storedSessionId: String,
+            runtimeSessionId: String? = null,
+            capability: ActivityCapabilityState = ActivityCapabilityState.Unknown,
+        ): AgentActivityProjection = AgentActivityProjection(
+            originKey = normalizeActivityOrigin(originKey),
+            profile = profile.ifBlank { "default" },
+            storedSessionId = storedSessionId,
+            runtimeSessionId = runtimeSessionId,
+            items = emptyList(),
+            source = ActivitySource.Unavailable,
+            capability = capability,
+            lastAuthoritativeSnapshot = null,
+            presentation = if (capability == ActivityCapabilityState.Unsupported) {
+                ActivityPresentationState.Unavailable
+            } else {
+                ActivityPresentationState.Discovering
+            },
+        )
+    }
+}
+
+internal const val TOOL_ACTIVITY_DETAIL_LIMIT = 8_000
+internal const val REASONING_ACTIVITY_DETAIL_LIMIT = 12_000
+internal const val MAX_ACTIVITY_ITEMS = 100
+
+/**
+ * A pure redaction/truncation boundary for anything that can reach Compose or
+ * clipboard. It intentionally keeps only the safe display prefix.
+ */
+fun sanitizeActivityDetail(
+    raw: String,
+    maxCodePoints: Int,
+): DisplayedDetail {
+    require(maxCodePoints > 0) { "Activity detail limit must be positive." }
+
+    val originalLength = raw.codePointCount(0, raw.length)
+    val redacted = redactActivitySecrets(raw)
+    val wasRedacted = redacted != raw
+    val redactedLength = redacted.codePointCount(0, redacted.length)
+    if (redactedLength <= maxCodePoints) {
+        return DisplayedDetail(
+            text = redacted,
+            originalLength = originalLength,
+            wasTruncated = false,
+            wasRedacted = wasRedacted,
+            canRestore = false,
+        )
+    }
+
+    val suffix = " … truncated (original length: $originalLength chars)"
+    val suffixLength = suffix.codePointCount(0, suffix.length)
+    val truncatedText = if (suffixLength >= maxCodePoints) {
+        takeCodePoints(suffix, maxCodePoints)
+    } else {
+        takeCodePoints(redacted, maxCodePoints - suffixLength) + suffix
+    }
+    return DisplayedDetail(
+        text = truncatedText,
+        originalLength = originalLength,
+        wasTruncated = true,
+        wasRedacted = wasRedacted,
+        canRestore = false,
+    )
+}
+
+fun sanitizeActivityText(raw: String, maxCodePoints: Int): String =
+    sanitizeActivityDetail(raw, maxCodePoints).text
+
+private val privateKeyPattern = Regex(
+    "-----BEGIN [^-\\n]*PRIVATE KEY-----.*?-----END [^-\\n]*PRIVATE KEY-----",
+    setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+)
+private val authorizationHeaderPattern = Regex(
+    "(?im)(\\bauthorization\\s*[:=]\\s*(?:bearer|basic)\\s+)[^\\s,;]+",
+)
+private val bearerPattern = Regex("(?i)\\bbearer\\s+[A-Za-z0-9._~+/=-]{8,}")
+private val cookieHeaderPattern = Regex("(?im)(\\b(?:cookie|set-cookie)\\s*[:=]\\s*)[^\\r\\n]+")
+private val credentialAssignmentPattern = Regex(
+    "(?i)(\\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\\s*[:=]\\s*[\\\"']?)[^\\\"'\\s,}&]+",
+)
+private val credentialQueryPattern = Regex(
+    "(?i)([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|password|secret|key)=)[^&#\\s]+",
+)
+private val knownTokenPattern = Regex(
+    "(?i)\\b(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,})\\b",
+)
+
+private fun redactActivitySecrets(raw: String): String {
+    var safe = privateKeyPattern.replace(raw, "[redacted]")
+    safe = authorizationHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    safe = bearerPattern.replace(safe, "Bearer [redacted]")
+    safe = cookieHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    safe = credentialAssignmentPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    safe = credentialQueryPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    return knownTokenPattern.replace(safe, "[redacted]")
+}
+
+private fun takeCodePoints(value: String, count: Int): String {
+    if (count <= 0 || value.isEmpty()) return ""
+    if (value.codePointCount(0, value.length) <= count) return value
+    return value.substring(0, value.offsetByCodePoints(0, count))
+}
+
+internal fun normalizeActivityOrigin(origin: String): NormalizedDashboardOrigin =
+    origin.trim().trimEnd('/')
+
+internal fun initialActivityProjection(
+    originKey: String,
+    profile: String,
+    storedSessionId: String,
+    runtimeSessionId: String? = null,
+    capability: ActivityCapabilityState = ActivityCapabilityState.Unknown,
+): AgentActivityProjection = AgentActivityProjection.forSession(
+    originKey = normalizeActivityOrigin(originKey),
+    profile = profile,
+    storedSessionId = storedSessionId,
+    runtimeSessionId = runtimeSessionId,
+    capability = capability,
+)
+
+/**
+ * Pure reducer for source-audited Hermes activity events.
+ *
+ * The event names below are verified against the installed Hermes gateway at
+ * `tui_gateway/server.py`: tool lifecycle uses `tool.start`/`tool.complete`,
+ * the explicit server summary uses `reasoning.available`, and the configured
+ * server reasoning stream uses `reasoning.delta`. `thinking.delta` is an
+ * internal compatibility signal and is intentionally not presented here.
+ */
+internal object AgentActivityReducer {
+    private const val REASONING_SUMMARY_EVENT = "reasoning.available"
+    private const val REASONING_DELTA_EVENT = "reasoning.delta"
+
+    fun applyEvent(
+        projection: AgentActivityProjection,
+        event: GatewayEvent,
+        reasoningEnabled: Boolean = true,
+        now: Instant = Instant.now(),
+    ): AgentActivityProjection {
+        if (!accepts(projection, event)) return projection
+        return when (event.type) {
+            "tool.start" -> applyToolStart(projection, event.payload, legacy = false, now)
+            "tool_call" -> applyToolStart(projection, event.payload, legacy = true, now)
+            "tool.complete" -> applyToolComplete(projection, event.payload, legacy = false, now)
+            "tool_result" -> applyToolComplete(projection, event.payload, legacy = true, now)
+            REASONING_SUMMARY_EVENT -> {
+                if (reasoningEnabled) applyReasoningSummary(projection, event.payload) else projection
+            }
+            REASONING_DELTA_EVENT -> {
+                if (reasoningEnabled) applyReasoningDelta(projection, event.payload) else projection
+            }
+            "message.complete" -> settleReasoning(projection)
+            "message.interrupted", "session.interrupted" -> markInterrupted(projection, now)
+            else -> projection
+        }
+    }
+
+    fun applySnapshot(
+        projection: AgentActivityProjection,
+        items: List<ActivityItem>,
+        binding: ActivityBinding,
+        running: Boolean,
+        now: Instant = Instant.now(),
+    ): AgentActivityProjection {
+        if (!sameBinding(projection, binding)) {
+            return projection.copy(
+                malformedEventCount = (projection.malformedEventCount + 1).coerceAtMost(1_000),
+            )
+        }
+        val rekeyed = items
+            .takeLast(MAX_ACTIVITY_ITEMS)
+            .mapIndexed { index, item ->
+                normalizeSnapshotItem(item, projection.storedSessionId, index)
+            }
+        val capability = if (
+            projection.capability == ActivityCapabilityState.ToolAndServerReasoning &&
+                rekeyed.none { it is ServerReasoningActivity }
+        ) {
+            // A local disclosure choice may hide the already-proven reasoning
+            // stream. Keep the capability fact so the control can be restored
+            // without retaining the hidden body in memory.
+            ActivityCapabilityState.ToolAndServerReasoning
+        } else {
+            capabilityForItems(rekeyed)
+        }
+        return projection.copy(
+            originKey = normalizeActivityOrigin(binding.originKey),
+            profile = binding.profile.ifBlank { "default" },
+            storedSessionId = binding.storedSessionId,
+            runtimeSessionId = binding.runtimeSessionId,
+            items = rekeyed,
+            source = ActivitySource.Resumed,
+            capability = capability,
+            lastAuthoritativeSnapshot = now,
+            presentation = when {
+                capability == ActivityCapabilityState.Unsupported -> ActivityPresentationState.Unavailable
+                running || rekeyed.any(ActivityItem::isInFlight) -> ActivityPresentationState.Running
+                rekeyed.isNotEmpty() -> ActivityPresentationState.Available
+                capability == ActivityCapabilityState.ToolAndServerReasoning -> ActivityPresentationState.Available
+                else -> ActivityPresentationState.Discovering
+            },
+        )
+    }
+
+    fun markRestoring(projection: AgentActivityProjection): AgentActivityProjection =
+        projection.copy(presentation = ActivityPresentationState.Restoring)
+
+    fun markStale(projection: AgentActivityProjection): AgentActivityProjection =
+        projection.copy(
+            capability = ActivityCapabilityState.Stale,
+            presentation = ActivityPresentationState.Stale,
+        )
+
+    fun markUnavailable(projection: AgentActivityProjection): AgentActivityProjection =
+        projection.copy(
+            source = ActivitySource.Unavailable,
+            capability = ActivityCapabilityState.Unsupported,
+            presentation = ActivityPresentationState.Unavailable,
+        )
+
+    fun withoutServerReasoning(projection: AgentActivityProjection): AgentActivityProjection {
+        val items = projection.items.filterNot { it is ServerReasoningActivity }
+        return projection.copy(
+            items = items,
+            capability = if (projection.capability == ActivityCapabilityState.ToolAndServerReasoning) {
+                ActivityCapabilityState.ToolAndServerReasoning
+            } else {
+                capabilityForItems(items)
+            },
+            presentation = when {
+                projection.presentation == ActivityPresentationState.Stale -> ActivityPresentationState.Stale
+                items.any(ActivityItem::isInFlight) -> ActivityPresentationState.Running
+                items.isNotEmpty() -> ActivityPresentationState.Available
+                projection.capability == ActivityCapabilityState.ToolAndServerReasoning ->
+                    ActivityPresentationState.Available
+                else -> ActivityPresentationState.Discovering
+            },
+        )
+    }
+
+    fun markInterrupted(
+        projection: AgentActivityProjection,
+        now: Instant = Instant.now(),
+    ): AgentActivityProjection {
+        val items = projection.items.map { item ->
+            when {
+                item is ToolActivity && item.phase.isInFlight() ->
+                    item.copy(phase = ToolPhase.Interrupted, finishedAt = now)
+                item is ServerReasoningActivity && item.phase == ReasoningPhase.Streaming ->
+                    item.copy(phase = ReasoningPhase.Unavailable)
+                else -> item
+            }
+        }
+        return projection.copy(
+            items = items,
+            presentation = if (items.any(ActivityItem::isInFlight)) {
+                ActivityPresentationState.Running
+            } else {
+                ActivityPresentationState.Available
+            },
+        )
+    }
+
+    private fun accepts(projection: AgentActivityProjection, event: GatewayEvent): Boolean {
+        val runtime = projection.runtimeSessionId
+        if (runtime == null && event.sessionId.isNotBlank()) return false
+        if (runtime != null && event.sessionId.isNotBlank() && event.sessionId != runtime) return false
+        if (event.originKey != null && normalizeActivityOrigin(event.originKey) != projection.originKey) return false
+        if (event.profile != null && event.profile!!.isNotBlank() && event.profile != projection.profile) return false
+        if (event.storedSessionId != null && event.storedSessionId != projection.storedSessionId) return false
+        return true
+    }
+
+    private fun applyToolStart(
+        projection: AgentActivityProjection,
+        payload: JsonObject,
+        legacy: Boolean,
+        now: Instant,
+    ): AgentActivityProjection {
+        val rawName = payload.firstString("name", "tool_name")?.trim().orEmpty()
+        if (rawName.isBlank()) return malformed(projection)
+        val name = safeToolName(rawName)
+        val callId = payload.activityCallId()
+        val input = payload.detailFrom(
+            keys = listOf("args_text", "context", "args"),
+            limit = TOOL_ACTIVITY_DETAIL_LIMIT,
+        )
+        val items = projection.items.toMutableList()
+        val activeIndex = callId?.let { id ->
+            items.indexOfFirst { item -> item is ToolActivity && item.callId == id && item.phase.isInFlight() }
+        } ?: -1
+        if (activeIndex >= 0) {
+            val existing = items[activeIndex] as ToolActivity
+            items[activeIndex] = existing.copy(
+                name = if (existing.name == "Tool activity") name else existing.name,
+                phase = if (existing.phase.isTerminal()) existing.phase else ToolPhase.Started,
+                input = input ?: existing.input,
+                startedAt = existing.startedAt ?: now,
+                correlation = if (legacy) CorrelationQuality.LegacyName else CorrelationQuality.ExactId,
+            )
+        } else if (callId != null && items.any { item -> item is ToolActivity && item.callId == callId }) {
+            // A repeated start for a terminal server call is an idempotent replay.
+            return projection
+        } else {
+            items += ToolActivity(
+                uiKey = nextActivityKey(projection, items),
+                callId = callId,
+                name = name,
+                phase = ToolPhase.Started,
+                input = input,
+                output = null,
+                startedAt = now,
+                finishedAt = null,
+                correlation = if (legacy || callId == null) {
+                    CorrelationQuality.LegacyName
+                } else {
+                    CorrelationQuality.ExactId
+                },
+            )
+        }
+        return projection.copy(
+            items = items.takeLast(MAX_ACTIVITY_ITEMS),
+            source = if (legacy) ActivitySource.Legacy else ActivitySource.Live,
+            capability = capabilityWithTool(projection.capability, legacy),
+            presentation = ActivityPresentationState.Running,
+        )
+    }
+
+    private fun applyToolComplete(
+        projection: AgentActivityProjection,
+        payload: JsonObject,
+        legacy: Boolean,
+        now: Instant,
+    ): AgentActivityProjection {
+        val rawName = payload.firstString("name", "tool_name")?.trim().orEmpty()
+        val name = safeToolName(rawName.ifBlank { "Tool activity" })
+        val callId = payload.activityCallId()
+        val output = payload.detailFrom(
+            keys = listOf("result_text", "summary", "output", "result", "error"),
+            limit = TOOL_ACTIVITY_DETAIL_LIMIT,
+        )
+        val input = payload.detailFrom(
+            keys = listOf("args_text", "context", "args"),
+            limit = TOOL_ACTIVITY_DETAIL_LIMIT,
+        )
+        val failed = payload.booleanLike("is_error", "failed") ||
+            payload.firstString("status")?.lowercase() in setOf("error", "failed", "failure") ||
+            payload.firstString("error")?.isNotBlank() == true
+        val phase = if (failed) ToolPhase.Failed else ToolPhase.Completed
+        val items = projection.items.toMutableList()
+        val matchIndex = when {
+            callId != null -> items.indexOfFirst { item ->
+                item is ToolActivity && item.callId == callId && item.phase.isInFlight()
+            }
+            rawName.isNotBlank() -> {
+                val candidates = items.withIndex().filter { (_, item) ->
+                    item is ToolActivity && item.name == name && item.phase.isInFlight()
+                }
+                if (candidates.size == 1) candidates.single().index else -1
+            }
+            else -> -1
+        }
+        val ambiguousLegacy = callId == null && rawName.isNotBlank() &&
+            items.count { item -> item is ToolActivity && item.name == name && item.phase.isInFlight() } > 1
+        if (callId != null && items.any { item -> item is ToolActivity && item.callId == callId && item.phase.isTerminal() }) {
+            // Retransmitted completion after a reconnect must not duplicate a card.
+            return projection
+        }
+        if (matchIndex >= 0 && !ambiguousLegacy) {
+            val existing = items[matchIndex] as ToolActivity
+            items[matchIndex] = existing.copy(
+                phase = phase,
+                input = input ?: existing.input,
+                output = output ?: existing.output,
+                finishedAt = now,
+                correlation = when {
+                    callId != null && !legacy -> CorrelationQuality.ExactId
+                    else -> CorrelationQuality.LegacyName
+                },
+            )
+        } else {
+            items += ToolActivity(
+                uiKey = nextActivityKey(projection, items),
+                callId = callId,
+                name = name,
+                phase = phase,
+                input = input,
+                output = output,
+                startedAt = null,
+                finishedAt = now,
+                correlation = CorrelationQuality.Uncorrelated,
+            )
+        }
+        return projection.copy(
+            items = items.takeLast(MAX_ACTIVITY_ITEMS),
+            source = if (legacy) ActivitySource.Legacy else ActivitySource.Live,
+            capability = capabilityWithTool(projection.capability, legacy),
+            presentation = if (items.any(ActivityItem::isInFlight)) {
+                ActivityPresentationState.Running
+            } else {
+                ActivityPresentationState.Available
+            },
+            ambiguousCorrelationCount = if (ambiguousLegacy) {
+                (projection.ambiguousCorrelationCount + 1).coerceAtMost(1_000)
+            } else {
+                projection.ambiguousCorrelationCount
+            },
+        )
+    }
+
+    private fun applyReasoningSummary(
+        projection: AgentActivityProjection,
+        payload: JsonObject,
+    ): AgentActivityProjection {
+        val detail = payload.detailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
+            ?: return malformed(projection)
+        val item = ServerReasoningActivity(
+            uiKey = nextActivityKey(projection, projection.items),
+            source = ReasoningSource.ServerSummary,
+            phase = ReasoningPhase.Complete,
+            text = detail.copy(text = stripReasoningTags(detail.text)),
+            serverLabel = safeServerLabel(payload.firstString("label")) ?: "Server-provided summary",
+        )
+        val items = projection.items.toMutableList()
+        val existingIndex = items.indexOfLast {
+            it is ServerReasoningActivity && it.source == ReasoningSource.ServerSummary
+        }
+        if (existingIndex >= 0) items[existingIndex] = item.copy(uiKey = items[existingIndex].uiKey) else items += item
+        return projection.copy(
+            items = items.takeLast(MAX_ACTIVITY_ITEMS),
+            source = ActivitySource.Live,
+            capability = ActivityCapabilityState.ToolAndServerReasoning,
+            presentation = ActivityPresentationState.Available,
+        )
+    }
+
+    private fun applyReasoningDelta(
+        projection: AgentActivityProjection,
+        payload: JsonObject,
+    ): AgentActivityProjection {
+        val detail = payload.detailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
+            ?: return malformed(projection)
+        val delta = detail.copy(text = stripReasoningTags(detail.text))
+        val items = projection.items.toMutableList()
+        val index = items.indexOfLast {
+            it is ServerReasoningActivity &&
+                it.source == ReasoningSource.ServerFull &&
+                it.phase == ReasoningPhase.Streaming
+        }
+        if (index >= 0) {
+            val existing = items[index] as ServerReasoningActivity
+            val combined = sanitizeActivityDetail(
+                existing.text.text + delta.text,
+                REASONING_ACTIVITY_DETAIL_LIMIT,
+            )
+            items[index] = existing.copy(
+                text = combined.copy(
+                    originalLength = existing.text.originalLength + delta.originalLength,
+                    wasRedacted = existing.text.wasRedacted || delta.wasRedacted,
+                ),
+            )
+        } else {
+            items += ServerReasoningActivity(
+                uiKey = nextActivityKey(projection, items),
+                source = ReasoningSource.ServerFull,
+                phase = ReasoningPhase.Streaming,
+                text = delta,
+                serverLabel = "Server-provided reasoning",
+            )
+        }
+        return projection.copy(
+            items = items.takeLast(MAX_ACTIVITY_ITEMS),
+            source = ActivitySource.Live,
+            capability = ActivityCapabilityState.ToolAndServerReasoning,
+            presentation = ActivityPresentationState.Running,
+        )
+    }
+
+    private fun settleReasoning(projection: AgentActivityProjection): AgentActivityProjection {
+        val items = projection.items.map { item ->
+            if (item is ServerReasoningActivity && item.phase == ReasoningPhase.Streaming) {
+                item.copy(phase = ReasoningPhase.Complete)
+            } else {
+                item
+            }
+        }
+        return projection.copy(
+            items = items,
+            presentation = if (items.any(ActivityItem::isInFlight)) {
+                ActivityPresentationState.Running
+            } else {
+                ActivityPresentationState.Available
+            },
+        )
+    }
+
+    private fun malformed(projection: AgentActivityProjection): AgentActivityProjection =
+        projection.copy(malformedEventCount = (projection.malformedEventCount + 1).coerceAtMost(1_000))
+
+    private fun sameBinding(projection: AgentActivityProjection, binding: ActivityBinding): Boolean =
+        normalizeActivityOrigin(binding.originKey) == projection.originKey &&
+            binding.profile.ifBlank { "default" } == projection.profile &&
+            binding.storedSessionId == projection.storedSessionId
+
+    private fun normalizeSnapshotItem(
+        item: ActivityItem,
+        storedSessionId: String,
+        index: Int,
+    ): ActivityItem = when (item) {
+        is ToolActivity -> item.copy(uiKey = "activity:$storedSessionId:snapshot:tool:$index")
+        is ServerReasoningActivity -> item.copy(uiKey = "activity:$storedSessionId:snapshot:reasoning:$index")
+    }
+
+    private fun capabilityForItems(items: List<ActivityItem>): ActivityCapabilityState {
+        val hasReasoning = items.any {
+            it is ServerReasoningActivity && it.phase != ReasoningPhase.Unavailable
+        }
+        val tools = items.filterIsInstance<ToolActivity>()
+        if (hasReasoning) return ActivityCapabilityState.ToolAndServerReasoning
+        if (tools.isEmpty()) return ActivityCapabilityState.Unknown
+        return if (tools.all { it.correlation != CorrelationQuality.ExactId }) {
+            ActivityCapabilityState.LegacyToolOnly
+        } else {
+            ActivityCapabilityState.ToolOnly
+        }
+    }
+
+    private fun capabilityWithTool(
+        current: ActivityCapabilityState,
+        legacy: Boolean,
+    ): ActivityCapabilityState = when {
+        current == ActivityCapabilityState.ToolAndServerReasoning -> current
+        legacy -> ActivityCapabilityState.LegacyToolOnly
+        else -> ActivityCapabilityState.ToolOnly
+    }
+
+    private fun nextActivityKey(
+        projection: AgentActivityProjection,
+        items: List<ActivityItem>,
+    ): String {
+        val prefix = "activity:${projection.storedSessionId.ifBlank { "session" }}:live:"
+        var occurrence = items.size + 1
+        var candidate = "$prefix$occurrence"
+        val keys = items.asSequence().map(ActivityItem::uiKey).toSet()
+        while (candidate in keys) {
+            occurrence += 1
+            candidate = "$prefix$occurrence"
+        }
+        return candidate
+    }
+}
+
+internal fun reduceActivityEvent(
+    projection: AgentActivityProjection,
+    event: GatewayEvent,
+    reasoningEnabled: Boolean = true,
+    now: Instant = Instant.now(),
+): AgentActivityProjection = AgentActivityReducer.applyEvent(projection, event, reasoningEnabled, now)
+
+internal fun activityItemsFromMessages(messages: List<ConversationMessage>): List<ActivityItem> =
+    messages.mapNotNull { message ->
+        if (message.role != "tool") return@mapNotNull null
+        val detail = message.text.takeIf(String::isNotBlank)?.let {
+            sanitizeActivityDetail(it, TOOL_ACTIVITY_DETAIL_LIMIT)
+        }
+        ToolActivity(
+            uiKey = "",
+            callId = null,
+            name = safeToolName(message.toolName ?: "Tool activity"),
+            phase = if (message.pending) ToolPhase.Running else ToolPhase.Completed,
+            input = if (message.pending) detail else null,
+            output = if (message.pending) null else detail,
+            startedAt = null,
+            finishedAt = null,
+            correlation = CorrelationQuality.LegacyName,
+        )
+    }
+
+/** Decode only the fields the current Hermes session projection actually emits. */
+internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityItem> =
+    elements.mapNotNull { element ->
+        val row = element as? JsonObject ?: return@mapNotNull null
+        when (row.stringValue("role")) {
+            "tool" -> {
+                val rawName = row.firstString("name", "tool_name") ?: return@mapNotNull null
+                val callId = row.activityCallId()
+                val failed = row.booleanLike("is_error", "failed") ||
+                    row.firstString("status")?.lowercase() in setOf("error", "failed", "failure")
+                ToolActivity(
+                    uiKey = "",
+                    callId = callId,
+                    name = safeToolName(rawName),
+                    phase = if (failed) ToolPhase.Failed else ToolPhase.Completed,
+                    input = row.detailFrom(listOf("args_text", "context", "args"), TOOL_ACTIVITY_DETAIL_LIMIT),
+                    output = row.detailFrom(
+                        listOf("result_text", "summary", "output", "result", "error"),
+                        TOOL_ACTIVITY_DETAIL_LIMIT,
+                    ),
+                    startedAt = null,
+                    finishedAt = null,
+                    correlation = if (callId == null) {
+                        CorrelationQuality.LegacyName
+                    } else {
+                        CorrelationQuality.ExactId
+                    },
+                )
+            }
+            "assistant" -> {
+                val summary = row.detailFrom(listOf("reasoning"), REASONING_ACTIVITY_DETAIL_LIMIT)
+                val full = row.detailFrom(listOf("reasoning_content"), REASONING_ACTIVITY_DETAIL_LIMIT)
+                val detail = summary ?: full ?: return@mapNotNull null
+                ServerReasoningActivity(
+                    uiKey = "",
+                    source = if (summary != null) ReasoningSource.ServerSummary else ReasoningSource.ServerFull,
+                    phase = ReasoningPhase.Complete,
+                    text = detail.copy(text = stripReasoningTags(detail.text)),
+                    serverLabel = if (summary != null) {
+                        "Server-provided summary"
+                    } else {
+                        "Server-provided reasoning"
+                    },
+                )
+            }
+            else -> null
+        }
+    }
+
+private fun JsonObject.firstString(vararg keys: String): String? =
+    keys.asSequence()
+        .mapNotNull { key -> this[key]?.stringValue() }
+        .firstOrNull { it.isNotBlank() }
+
+private fun JsonObject.stringValue(key: String): String? =
+    (this[key] as? JsonPrimitive)?.contentOrNull
+
+private fun JsonObject.activityCallId(): String? {
+    val direct = sequenceOf("tool_call_id", "call_id", "id", "tool_id")
+        .mapNotNull(::stringValue)
+        .firstOrNull(String::isNotBlank)
+    if (direct != null) return direct.trim()
+    return sequenceOf("tool_call", "tool")
+        .mapNotNull { key -> this[key] as? JsonObject }
+        .flatMap { nested -> sequenceOf("tool_call_id", "call_id", "id", "tool_id").mapNotNull(nested::stringValue) }
+        .firstOrNull(String::isNotBlank)
+        ?.trim()
+}
+
+private fun JsonObject.booleanLike(vararg keys: String): Boolean =
+    keys.any { key ->
+        when (stringValue(key)?.lowercase()) {
+            "true", "1", "yes", "failed", "error" -> true
+            else -> false
+        }
+    }
+
+private fun JsonObject.detailFrom(keys: List<String>, limit: Int): DisplayedDetail? {
+    for (key in keys) {
+        val value = this[key] ?: continue
+        val text = value.displayText() ?: continue
+        if (text.isBlank()) continue
+        return sanitizeActivityDetail(stripReasoningTags(text), limit)
+    }
+    return null
+}
+
+private fun JsonElement.displayText(): String? = when (this) {
+    JsonNull -> null
+    is JsonPrimitive -> contentOrNull
+    else -> toString()
+}
+
+private fun safeToolName(raw: String): String {
+    val candidate = raw.trim()
+    if (candidate.isBlank()) return "Tool activity"
+    if (candidate.length > 80 || !candidate.matches(Regex("[A-Za-z0-9_.:-]+"))) {
+        return "Tool activity"
+    }
+    return candidate.replace('_', ' ')
+}
+
+private fun safeServerLabel(raw: String?): String? {
+    val candidate = raw?.trim().orEmpty()
+    if (candidate.isBlank() || candidate.length > 80) return null
+    return if (candidate.matches(Regex("[A-Za-z0-9 ._:-]+"))) candidate else null
+}
+
+private fun stripReasoningTags(text: String): String =
+    text.replace(
+        Regex("</?(?:REASONING_SCRATCHPAD|think|reasoning)>", RegexOption.IGNORE_CASE),
+        "",
+    ).trim()
+
+private fun ToolPhase.isInFlight(): Boolean = this == ToolPhase.Started || this == ToolPhase.Running
+private fun ToolPhase.isTerminal(): Boolean = !isInFlight()
+private fun ActivityItem.isInFlight(): Boolean =
+    this is ToolActivity && phase.isInFlight() ||
+        this is ServerReasoningActivity && phase == ReasoningPhase.Streaming

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 
 /** The origin/profile/session chain that authorizes an activity projection. */
@@ -83,6 +84,8 @@ data class ToolActivity(
     val startedAt: Instant?,
     val finishedAt: Instant?,
     val correlation: CorrelationQuality,
+    /** The official `tool.progress` preview, kept separate from input/output. */
+    val progress: DisplayedDetail? = null,
 ) : ActivityItem
 
 data class ServerReasoningActivity(
@@ -112,6 +115,10 @@ data class AgentActivityProjection(
     val presentation: ActivityPresentationState = ActivityPresentationState.Unknown,
     val malformedEventCount: Int = 0,
     val ambiguousCorrelationCount: Int = 0,
+    /** Null means the server has not disclosed its reasoning display policy. */
+    val serverReasoningAllowed: Boolean? = null,
+    /** Event IDs/sequences only; never raw activity payloads. */
+    internal val seenEventKeys: Set<String> = emptySet(),
 ) {
     /** Count-only diagnostics; raw event payloads are deliberately absent. */
     val diagnosticCount: Int get() = malformedEventCount + ambiguousCorrelationCount
@@ -144,6 +151,7 @@ data class AgentActivityProjection(
 internal const val TOOL_ACTIVITY_DETAIL_LIMIT = 8_000
 internal const val REASONING_ACTIVITY_DETAIL_LIMIT = 12_000
 internal const val MAX_ACTIVITY_ITEMS = 100
+private const val MAX_SEEN_ACTIVITY_EVENT_KEYS = 512
 
 /**
  * A pure redaction/truncation boundary for anything that can reach Compose or
@@ -193,25 +201,37 @@ private val privateKeyPattern = Regex(
     setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
 )
 private val authorizationHeaderPattern = Regex(
-    "(?im)(\\bauthorization\\s*[:=]\\s*(?:bearer|basic)\\s+)[^\\s,;]+",
+    "(?im)(\\b(?:authorization|proxy-authorization)\\s*[:=]\\s*(?:bearer|basic|token)\\s+)[^\\s,;]+",
 )
-private val bearerPattern = Regex("(?i)\\bbearer\\s+[A-Za-z0-9._~+/=-]{8,}")
+private val authorizationValuePattern = Regex(
+    "(?im)(\\b(?:authorization|proxy-authorization)\\s*[:=]\\s*)[^\\r\\n,;]+",
+)
+private val bearerPattern = Regex("(?i)\\bbearer\\s+[A-Za-z0-9._~+/=-]+")
 private val cookieHeaderPattern = Regex("(?im)(\\b(?:cookie|set-cookie)\\s*[:=]\\s*)[^\\r\\n]+")
+private val sessionTokenHeaderPattern = Regex(
+    "(?im)(\\b(?:x[-_]?hermes[-_])?session[-_]?token\\s*[:=]\\s*)[^\\s,;]+",
+)
 private val credentialAssignmentPattern = Regex(
-    "(?i)(\\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\\s*[:=]\\s*[\\\"']?)[^\\\"'\\s,}&]+",
+    "(?i)(\\b(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token)\\s*[:=]\\s*[\\\"']?)[^\\\"'\\s,}&]+",
 )
 private val credentialQueryPattern = Regex(
-    "(?i)([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|password|secret|key)=)[^&#\\s]+",
+    "(?i)([?&](?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|secret|credential|token|key)=)[^&#\\s]+",
 )
 private val knownTokenPattern = Regex(
     "(?i)\\b(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,})\\b",
+)
+private val hiddenReasoningTagPattern = Regex(
+    "</?(?:think|thinking|reasoning|reasoning_scratchpad)\\b[^>]*>",
+    RegexOption.IGNORE_CASE,
 )
 
 private fun redactActivitySecrets(raw: String): String {
     var safe = privateKeyPattern.replace(raw, "[redacted]")
     safe = authorizationHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    safe = authorizationValuePattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = bearerPattern.replace(safe, "Bearer [redacted]")
     safe = cookieHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    safe = sessionTokenHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = credentialAssignmentPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = credentialQueryPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     return knownTokenPattern.replace(safe, "[redacted]")
@@ -260,20 +280,60 @@ internal object AgentActivityReducer {
         now: Instant = Instant.now(),
     ): AgentActivityProjection {
         if (!accepts(projection, event)) return projection
-        return when (event.type) {
+        val replayKey = activityReplayKey(event)
+        if (replayKey != null && replayKey in projection.seenEventKeys) return projection
+        val updated = when (event.type) {
             "tool.start" -> applyToolStart(projection, event.payload, legacy = false, now)
             "tool_call" -> applyToolStart(projection, event.payload, legacy = true, now)
+            "tool.progress" -> applyToolProgress(projection, event.payload, now)
             "tool.complete" -> applyToolComplete(projection, event.payload, legacy = false, now)
             "tool_result" -> applyToolComplete(projection, event.payload, legacy = true, now)
             REASONING_SUMMARY_EVENT -> {
-                if (reasoningEnabled) applyReasoningSummary(projection, event.payload) else projection
+                if (
+                    reasoningEnabled &&
+                    projection.serverReasoningAllowed != false &&
+                    event.payload.booleanValue("verbose") != false
+                ) {
+                    applyReasoningSummary(projection, event.payload)
+                } else {
+                    projection
+                }
             }
             REASONING_DELTA_EVENT -> {
-                if (reasoningEnabled) applyReasoningDelta(projection, event.payload) else projection
+                // Hermes marks the provider-facing reasoning callback with
+                // `verbose: true`. An unmarked delta is not a user-facing
+                // summary and must never become a CoT surface in Celeste.
+                if (
+                    reasoningEnabled &&
+                    projection.serverReasoningAllowed != false &&
+                    event.payload.booleanValue("verbose") == true
+                ) {
+                    applyReasoningDelta(projection, event.payload)
+                } else {
+                    projection
+                }
             }
-            "message.complete" -> settleReasoning(projection)
+            "session.info" -> applySessionInfo(projection, event.payload)
+            "message.complete" -> settleOpenItems(
+                projection,
+                failed = event.payload.isFailure(),
+                now = now,
+            )
+            "message.error", "error" -> settleOpenItems(projection, failed = true, now = now)
             "message.interrupted", "session.interrupted" -> markInterrupted(projection, now)
-            else -> projection
+            "tool.generating" -> projection.copy(presentation = ActivityPresentationState.Running)
+            else -> {
+                if (event.type.startsWith("tool.") || event.type.startsWith("reasoning.")) {
+                    unavailableAfterMalformed(projection)
+                } else {
+                    projection
+                }
+            }
+        }
+        return if (replayKey == null) {
+            updated
+        } else {
+            updated.copy(seenEventKeys = rememberReplayKey(projection.seenEventKeys, replayKey))
         }
     }
 
@@ -282,6 +342,7 @@ internal object AgentActivityReducer {
         items: List<ActivityItem>,
         binding: ActivityBinding,
         running: Boolean,
+        serverReasoningAllowed: Boolean? = projection.serverReasoningAllowed,
         now: Instant = Instant.now(),
     ): AgentActivityProjection {
         if (!sameBinding(projection, binding)) {
@@ -289,36 +350,73 @@ internal object AgentActivityReducer {
                 malformedEventCount = (projection.malformedEventCount + 1).coerceAtMost(1_000),
             )
         }
-        val rekeyed = items
-            .takeLast(MAX_ACTIVITY_ITEMS)
-            .mapIndexed { index, item ->
-                normalizeSnapshotItem(item, projection.storedSessionId, index)
-            }
-        val capability = if (
+        val visibleItems = items.filterNot {
+            serverReasoningAllowed == false && it is ServerReasoningActivity
+        }
+        val rekeyed = normalizeActivityKeys(
+            visibleItems.takeLast(MAX_ACTIVITY_ITEMS),
+            projection.storedSessionId,
+        )
+        val capability = when {
+            projection.capability == ActivityCapabilityState.Unsupported ->
+                ActivityCapabilityState.Unsupported
             projection.capability == ActivityCapabilityState.ToolAndServerReasoning &&
-                rekeyed.none { it is ServerReasoningActivity }
-        ) {
-            // A local disclosure choice may hide the already-proven reasoning
-            // stream. Keep the capability fact so the control can be restored
-            // without retaining the hidden body in memory.
-            ActivityCapabilityState.ToolAndServerReasoning
-        } else {
-            capabilityForItems(rekeyed)
+                serverReasoningAllowed != false &&
+                rekeyed.none { it is ServerReasoningActivity } -> {
+                // A local disclosure choice may hide the already-proven reasoning
+                // stream. Keep the capability fact so the control can be restored
+                // without retaining the hidden body in memory.
+                ActivityCapabilityState.ToolAndServerReasoning
+            }
+            else -> capabilityForItems(rekeyed)
         }
         return projection.copy(
             originKey = normalizeActivityOrigin(binding.originKey),
-            profile = binding.profile.ifBlank { "default" },
-            storedSessionId = binding.storedSessionId,
-            runtimeSessionId = binding.runtimeSessionId,
+            profile = binding.profile.trim().ifBlank { "default" },
+            storedSessionId = binding.storedSessionId.trim(),
+            runtimeSessionId = binding.runtimeSessionId?.trim()?.takeIf(String::isNotBlank),
             items = rekeyed,
-            source = ActivitySource.Resumed,
+            source = when {
+                capability == ActivityCapabilityState.Unsupported -> ActivitySource.Unavailable
+                rekeyed.any { item ->
+                    item is ToolActivity && item.correlation != CorrelationQuality.ExactId
+                } -> ActivitySource.Legacy
+                else -> ActivitySource.Resumed
+            },
             capability = capability,
+            serverReasoningAllowed = serverReasoningAllowed,
             lastAuthoritativeSnapshot = now,
             presentation = when {
                 capability == ActivityCapabilityState.Unsupported -> ActivityPresentationState.Unavailable
                 running || rekeyed.any(ActivityItem::isInFlight) -> ActivityPresentationState.Running
                 rekeyed.isNotEmpty() -> ActivityPresentationState.Available
                 capability == ActivityCapabilityState.ToolAndServerReasoning -> ActivityPresentationState.Available
+                else -> ActivityPresentationState.Discovering
+            },
+        )
+    }
+
+    /** Apply a server disclosure declaration without retaining a hidden body. */
+    fun applyServerReasoningCapability(
+        projection: AgentActivityProjection,
+        allowed: Boolean,
+    ): AgentActivityProjection {
+        if (allowed) return projection.copy(serverReasoningAllowed = true)
+        val items = projection.items.filterNot { it is ServerReasoningActivity }
+        val capability = if (projection.capability == ActivityCapabilityState.ToolAndServerReasoning) {
+            capabilityForItems(items)
+        } else {
+            projection.capability
+        }
+        return projection.copy(
+            items = items,
+            capability = capability,
+            serverReasoningAllowed = false,
+            presentation = when {
+                projection.presentation == ActivityPresentationState.Stale -> ActivityPresentationState.Stale
+                items.any(ActivityItem::isInFlight) -> ActivityPresentationState.Running
+                items.isNotEmpty() -> ActivityPresentationState.Available
+                capability == ActivityCapabilityState.Unsupported -> ActivityPresentationState.Unavailable
                 else -> ActivityPresentationState.Discovering
             },
         )
@@ -339,6 +437,34 @@ internal object AgentActivityReducer {
             capability = ActivityCapabilityState.Unsupported,
             presentation = ActivityPresentationState.Unavailable,
         )
+
+    /** Settle cards when Hermes ends a turn without sending tool.complete. */
+    fun settleOpenItems(
+        projection: AgentActivityProjection,
+        failed: Boolean,
+        now: Instant = Instant.now(),
+    ): AgentActivityProjection {
+        val phase = if (failed) ToolPhase.Failed else ToolPhase.Interrupted
+        val items = projection.items.map { item ->
+            when {
+                item is ToolActivity && item.phase.isInFlight() ->
+                    item.copy(phase = phase, finishedAt = now)
+                item is ServerReasoningActivity && item.phase == ReasoningPhase.Streaming ->
+                    item.copy(phase = if (failed) ReasoningPhase.Unavailable else ReasoningPhase.Complete)
+                else -> item
+            }
+        }
+        return projection.copy(
+            items = items,
+            presentation = if (items.any(ActivityItem::isInFlight)) {
+                ActivityPresentationState.Running
+            } else if (projection.presentation == ActivityPresentationState.Unavailable) {
+                ActivityPresentationState.Unavailable
+            } else {
+                ActivityPresentationState.Available
+            },
+        )
+    }
 
     fun withoutServerReasoning(projection: AgentActivityProjection): AgentActivityProjection {
         val items = projection.items.filterNot { it is ServerReasoningActivity }
@@ -384,12 +510,21 @@ internal object AgentActivityReducer {
     }
 
     private fun accepts(projection: AgentActivityProjection, event: GatewayEvent): Boolean {
-        val runtime = projection.runtimeSessionId
-        if (runtime == null && event.sessionId.isNotBlank()) return false
-        if (runtime != null && event.sessionId.isNotBlank() && event.sessionId != runtime) return false
+        val runtime = projection.runtimeSessionId?.trim()?.takeIf(String::isNotBlank)
+        val eventSession = event.sessionId.trim()
+        if (runtime == null && eventSession.isNotBlank()) return false
+        if (runtime != null && eventSession.isNotBlank() && eventSession != runtime) return false
         if (event.originKey != null && normalizeActivityOrigin(event.originKey) != projection.originKey) return false
-        if (event.profile != null && event.profile!!.isNotBlank() && event.profile != projection.profile) return false
-        if (event.storedSessionId != null && event.storedSessionId != projection.storedSessionId) return false
+        if (
+            event.profile != null &&
+            event.profile!!.trim().isNotBlank() &&
+            event.profile!!.trim() != projection.profile
+        ) return false
+        if (
+            event.storedSessionId != null &&
+            event.storedSessionId!!.trim().isNotBlank() &&
+            event.storedSessionId!!.trim() != projection.storedSessionId
+        ) return false
         return true
     }
 
@@ -400,32 +535,50 @@ internal object AgentActivityReducer {
         now: Instant,
     ): AgentActivityProjection {
         val rawName = payload.firstString("name", "tool_name")?.trim().orEmpty()
-        if (rawName.isBlank()) return malformed(projection)
+        if (rawName.isBlank()) return unavailableAfterMalformed(projection)
         val name = safeToolName(rawName)
         val callId = payload.activityCallId()
+        val effectiveLegacy = legacy || callId == null
         val input = payload.detailFrom(
             keys = listOf("args_text", "context", "args"),
             limit = TOOL_ACTIVITY_DETAIL_LIMIT,
         )
         val items = projection.items.toMutableList()
-        val activeIndex = callId?.let { id ->
-            items.indexOfFirst { item -> item is ToolActivity && item.callId == id && item.phase.isInFlight() }
-        } ?: -1
+        val activeCandidates = if (callId == null) {
+            items.withIndex().filter { (_, item) ->
+                item is ToolActivity && item.name == name && item.phase.isInFlight()
+            }
+        } else {
+            items.withIndex().filter { (_, item) ->
+                item is ToolActivity && item.callId == callId && item.phase.isInFlight()
+            }
+        }
+        val activeIndex = if (callId != null) {
+            activeCandidates.singleOrNull()?.index ?: -1
+        } else {
+            -1
+        }
         if (activeIndex >= 0) {
             val existing = items[activeIndex] as ToolActivity
+            // A repeated start for the same active occurrence is a harmless
+            // replay. A changed payload is allowed to create a new occurrence.
+            if (callId != null && existing.name == name && (input == null || input == existing.input)) {
+                return projection
+            }
             items[activeIndex] = existing.copy(
                 name = if (existing.name == "Tool activity") name else existing.name,
-                phase = if (existing.phase.isTerminal()) existing.phase else ToolPhase.Started,
+                phase = ToolPhase.Started,
                 input = input ?: existing.input,
                 startedAt = existing.startedAt ?: now,
-                correlation = if (legacy) CorrelationQuality.LegacyName else CorrelationQuality.ExactId,
+                correlation = if (effectiveLegacy) {
+                    CorrelationQuality.LegacyName
+                } else {
+                    CorrelationQuality.ExactId
+                },
             )
-        } else if (callId != null && items.any { item -> item is ToolActivity && item.callId == callId }) {
-            // A repeated start for a terminal server call is an idempotent replay.
-            return projection
         } else {
             items += ToolActivity(
-                uiKey = nextActivityKey(projection, items),
+                uiKey = nextActivityKey(projection, items, callId, name),
                 callId = callId,
                 name = name,
                 phase = ToolPhase.Started,
@@ -433,7 +586,7 @@ internal object AgentActivityReducer {
                 output = null,
                 startedAt = now,
                 finishedAt = null,
-                correlation = if (legacy || callId == null) {
+                correlation = if (effectiveLegacy) {
                     CorrelationQuality.LegacyName
                 } else {
                     CorrelationQuality.ExactId
@@ -442,9 +595,73 @@ internal object AgentActivityReducer {
         }
         return projection.copy(
             items = items.takeLast(MAX_ACTIVITY_ITEMS),
-            source = if (legacy) ActivitySource.Legacy else ActivitySource.Live,
-            capability = capabilityWithTool(projection.capability, legacy),
+            source = if (effectiveLegacy) ActivitySource.Legacy else ActivitySource.Live,
+            capability = capabilityWithTool(projection.capability, effectiveLegacy),
             presentation = ActivityPresentationState.Running,
+        )
+    }
+
+    private fun applyToolProgress(
+        projection: AgentActivityProjection,
+        payload: JsonObject,
+        now: Instant,
+    ): AgentActivityProjection {
+        val rawName = payload.firstString("name", "tool_name")?.trim().orEmpty()
+        val callId = payload.activityCallId()
+        val progress = payload.detailFrom(
+            keys = listOf("preview", "progress", "delta", "text", "context"),
+            limit = TOOL_ACTIVITY_DETAIL_LIMIT,
+        ) ?: return unavailableAfterMalformed(projection)
+        val fallbackName = if (rawName.isBlank()) "Tool activity" else safeToolName(rawName)
+        val items = projection.items.toMutableList()
+        val candidates = items.withIndex().filter { (_, item) ->
+            item is ToolActivity &&
+                item.phase.isInFlight() &&
+                if (callId != null) item.callId == callId else item.name == fallbackName
+        }
+        val ambiguous = candidates.size > 1
+        if (candidates.size == 1) {
+            val index = candidates.single().index
+            val existing = items[index] as ToolActivity
+            if (existing.progress == progress) return projection
+            items[index] = existing.copy(
+                phase = ToolPhase.Running,
+                progress = progress,
+                startedAt = existing.startedAt ?: now,
+                correlation = if (callId == null) {
+                    CorrelationQuality.LegacyName
+                } else {
+                    CorrelationQuality.ExactId
+                },
+            )
+        } else {
+            items += ToolActivity(
+                uiKey = nextActivityKey(projection, items, callId, fallbackName),
+                callId = callId,
+                name = fallbackName,
+                phase = ToolPhase.Running,
+                input = null,
+                output = null,
+                startedAt = now,
+                finishedAt = null,
+                correlation = when {
+                    ambiguous -> CorrelationQuality.Uncorrelated
+                    callId == null -> CorrelationQuality.LegacyName
+                    else -> CorrelationQuality.ExactId
+                },
+                progress = progress,
+            )
+        }
+        return projection.copy(
+            items = items.takeLast(MAX_ACTIVITY_ITEMS),
+            source = if (callId == null) ActivitySource.Legacy else ActivitySource.Live,
+            capability = capabilityWithTool(projection.capability, legacy = callId == null),
+            presentation = ActivityPresentationState.Running,
+            ambiguousCorrelationCount = if (ambiguous) {
+                (projection.ambiguousCorrelationCount + 1).coerceAtMost(1_000)
+            } else {
+                projection.ambiguousCorrelationCount
+            },
         )
     }
 
@@ -470,39 +687,37 @@ internal object AgentActivityReducer {
             payload.firstString("error")?.isNotBlank() == true
         val phase = if (failed) ToolPhase.Failed else ToolPhase.Completed
         val items = projection.items.toMutableList()
-        val matchIndex = when {
-            callId != null -> items.indexOfFirst { item ->
+        val candidates = when {
+            callId != null -> items.withIndex().filter { (_, item) ->
                 item is ToolActivity && item.callId == callId && item.phase.isInFlight()
             }
-            rawName.isNotBlank() -> {
-                val candidates = items.withIndex().filter { (_, item) ->
-                    item is ToolActivity && item.name == name && item.phase.isInFlight()
-                }
-                if (candidates.size == 1) candidates.single().index else -1
+            rawName.isNotBlank() -> items.withIndex().filter { (_, item) ->
+                item is ToolActivity && item.name == name && item.phase.isInFlight()
             }
-            else -> -1
+            else -> emptyList()
         }
-        val ambiguousLegacy = callId == null && rawName.isNotBlank() &&
-            items.count { item -> item is ToolActivity && item.name == name && item.phase.isInFlight() } > 1
-        if (callId != null && items.any { item -> item is ToolActivity && item.callId == callId && item.phase.isTerminal() }) {
-            // Retransmitted completion after a reconnect must not duplicate a card.
-            return projection
-        }
-        if (matchIndex >= 0 && !ambiguousLegacy) {
+        val ambiguous = candidates.size > 1
+        val matchIndex = candidates.singleOrNull()?.index ?: -1
+        val effectiveLegacy = legacy || callId == null || ambiguous
+        if (matchIndex >= 0) {
             val existing = items[matchIndex] as ToolActivity
             items[matchIndex] = existing.copy(
                 phase = phase,
                 input = input ?: existing.input,
                 output = output ?: existing.output,
                 finishedAt = now,
-                correlation = when {
-                    callId != null && !legacy -> CorrelationQuality.ExactId
-                    else -> CorrelationQuality.LegacyName
+                correlation = if (callId != null && !legacy) {
+                    CorrelationQuality.ExactId
+                } else {
+                    CorrelationQuality.LegacyName
                 },
             )
         } else {
+            // No matching in-flight occurrence is a new, occurrence-qualified
+            // card. In particular, a reused/terminal Hermes ID is not silently
+            // treated as a replay; explicit event IDs are deduplicated above.
             items += ToolActivity(
-                uiKey = nextActivityKey(projection, items),
+                uiKey = nextActivityKey(projection, items, callId, name),
                 callId = callId,
                 name = name,
                 phase = phase,
@@ -515,14 +730,14 @@ internal object AgentActivityReducer {
         }
         return projection.copy(
             items = items.takeLast(MAX_ACTIVITY_ITEMS),
-            source = if (legacy) ActivitySource.Legacy else ActivitySource.Live,
-            capability = capabilityWithTool(projection.capability, legacy),
+            source = if (effectiveLegacy) ActivitySource.Legacy else ActivitySource.Live,
+            capability = capabilityWithTool(projection.capability, effectiveLegacy),
             presentation = if (items.any(ActivityItem::isInFlight)) {
                 ActivityPresentationState.Running
             } else {
                 ActivityPresentationState.Available
             },
-            ambiguousCorrelationCount = if (ambiguousLegacy) {
+            ambiguousCorrelationCount = if (ambiguous) {
                 (projection.ambiguousCorrelationCount + 1).coerceAtMost(1_000)
             } else {
                 projection.ambiguousCorrelationCount
@@ -534,24 +749,42 @@ internal object AgentActivityReducer {
         projection: AgentActivityProjection,
         payload: JsonObject,
     ): AgentActivityProjection {
-        val detail = payload.detailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
-            ?: return malformed(projection)
+        val detail = payload.reasoningDetailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
+            ?: return projection.copy(serverReasoningAllowed = true)
+        val label = safeServerLabel(payload.firstString("label")) ?: "Server-provided summary"
         val item = ServerReasoningActivity(
-            uiKey = nextActivityKey(projection, projection.items),
+            uiKey = nextReasoningKey(projection, projection.items),
             source = ReasoningSource.ServerSummary,
             phase = ReasoningPhase.Complete,
-            text = detail.copy(text = stripReasoningTags(detail.text)),
-            serverLabel = safeServerLabel(payload.firstString("label")) ?: "Server-provided summary",
+            text = detail,
+            serverLabel = label,
         )
         val items = projection.items.toMutableList()
-        val existingIndex = items.indexOfLast {
+        val summaryIndex = items.indexOfLast {
             it is ServerReasoningActivity && it.source == ReasoningSource.ServerSummary
         }
-        if (existingIndex >= 0) items[existingIndex] = item.copy(uiKey = items[existingIndex].uiKey) else items += item
+        val streamingIndex = items.indexOfLast {
+            it is ServerReasoningActivity && it.source == ReasoningSource.ServerFull
+        }
+        val duplicateStreaming = streamingIndex >= 0 &&
+            items[streamingIndex] is ServerReasoningActivity &&
+            reasoningTextMatches(
+                (items[streamingIndex] as ServerReasoningActivity).text.text,
+                detail.text,
+            )
+        when {
+            duplicateStreaming -> {
+                val existing = items[streamingIndex] as ServerReasoningActivity
+                items[streamingIndex] = item.copy(uiKey = existing.uiKey)
+            }
+            summaryIndex >= 0 -> items[summaryIndex] = item.copy(uiKey = items[summaryIndex].uiKey)
+            else -> items += item
+        }
         return projection.copy(
             items = items.takeLast(MAX_ACTIVITY_ITEMS),
             source = ActivitySource.Live,
             capability = ActivityCapabilityState.ToolAndServerReasoning,
+            serverReasoningAllowed = true,
             presentation = ActivityPresentationState.Available,
         )
     }
@@ -560,9 +793,8 @@ internal object AgentActivityReducer {
         projection: AgentActivityProjection,
         payload: JsonObject,
     ): AgentActivityProjection {
-        val detail = payload.detailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
-            ?: return malformed(projection)
-        val delta = detail.copy(text = stripReasoningTags(detail.text))
+        val detail = payload.reasoningDetailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
+            ?: return projection.copy(serverReasoningAllowed = true)
         val items = projection.items.toMutableList()
         val index = items.indexOfLast {
             it is ServerReasoningActivity &&
@@ -571,22 +803,25 @@ internal object AgentActivityReducer {
         }
         if (index >= 0) {
             val existing = items[index] as ServerReasoningActivity
-            val combined = sanitizeActivityDetail(
-                existing.text.text + delta.text,
-                REASONING_ACTIVITY_DETAIL_LIMIT,
-            )
-            items[index] = existing.copy(
-                text = combined.copy(
-                    originalLength = existing.text.originalLength + delta.originalLength,
-                    wasRedacted = existing.text.wasRedacted || delta.wasRedacted,
-                ),
-            )
+            if (reasoningDeltaIsReplay(existing.text.text, detail.text)) return projection
+            val combined = if (detail.text.startsWith(existing.text.text)) {
+                detail
+            } else {
+                sanitizeActivityDetail(
+                    buildString(existing.text.text.length + detail.text.length) {
+                        append(existing.text.text)
+                        append(detail.text)
+                    },
+                    REASONING_ACTIVITY_DETAIL_LIMIT,
+                )
+            }
+            items[index] = existing.copy(text = combined)
         } else {
             items += ServerReasoningActivity(
-                uiKey = nextActivityKey(projection, items),
+                uiKey = nextReasoningKey(projection, items),
                 source = ReasoningSource.ServerFull,
                 phase = ReasoningPhase.Streaming,
-                text = delta,
+                text = detail,
                 serverLabel = "Server-provided reasoning",
             )
         }
@@ -594,6 +829,7 @@ internal object AgentActivityReducer {
             items = items.takeLast(MAX_ACTIVITY_ITEMS),
             source = ActivitySource.Live,
             capability = ActivityCapabilityState.ToolAndServerReasoning,
+            serverReasoningAllowed = true,
             presentation = ActivityPresentationState.Running,
         )
     }
@@ -616,21 +852,111 @@ internal object AgentActivityReducer {
         )
     }
 
+    private fun applySessionInfo(
+        projection: AgentActivityProjection,
+        payload: JsonObject,
+    ): AgentActivityProjection {
+        val serverAllowed = payload.reasoningDisplayCapability() ?: return projection
+        return AgentActivityReducer.applyServerReasoningCapability(projection, serverAllowed)
+    }
+
     private fun malformed(projection: AgentActivityProjection): AgentActivityProjection =
         projection.copy(malformedEventCount = (projection.malformedEventCount + 1).coerceAtMost(1_000))
 
+    private fun unavailableAfterMalformed(projection: AgentActivityProjection): AgentActivityProjection =
+        markUnavailable(malformed(projection))
+
+    private fun activityReplayKey(event: GatewayEvent): String? {
+        val explicit = (
+            event.eventId?.takeIf(String::isNotBlank)
+                ?: event.payload.firstString("event_id", "eventId", "event_seq", "seq")
+            )?.trim()?.takeIf(String::isNotBlank)
+        return explicit?.let { "${event.type}:$it" }
+    }
+
+    private fun rememberReplayKey(existing: Set<String>, key: String): Set<String> =
+        (existing.asSequence() + key)
+            .toList()
+            .distinct()
+            .takeLast(MAX_SEEN_ACTIVITY_EVENT_KEYS)
+            .toSet()
+
     private fun sameBinding(projection: AgentActivityProjection, binding: ActivityBinding): Boolean =
         normalizeActivityOrigin(binding.originKey) == projection.originKey &&
-            binding.profile.ifBlank { "default" } == projection.profile &&
-            binding.storedSessionId == projection.storedSessionId
+            binding.profile.trim().ifBlank { "default" } == projection.profile &&
+            binding.storedSessionId.trim() == projection.storedSessionId
 
-    private fun normalizeSnapshotItem(
-        item: ActivityItem,
+    private fun normalizeActivityKeys(
+        items: List<ActivityItem>,
         storedSessionId: String,
-        index: Int,
-    ): ActivityItem = when (item) {
-        is ToolActivity -> item.copy(uiKey = "activity:$storedSessionId:snapshot:tool:$index")
-        is ServerReasoningActivity -> item.copy(uiKey = "activity:$storedSessionId:snapshot:reasoning:$index")
+    ): List<ActivityItem> {
+        val occurrences = mutableMapOf<String, Int>()
+        return items.map { item ->
+            val identity = activityIdentity(item)
+            val occurrence = occurrences.getOrDefault(identity, 0) + 1
+            occurrences[identity] = occurrence
+            item.copyWithUiKey(stableActivityKey(storedSessionId, identity, occurrence))
+        }
+    }
+
+    private fun ActivityItem.copyWithUiKey(key: String): ActivityItem = when (this) {
+        is ToolActivity -> copy(uiKey = key)
+        is ServerReasoningActivity -> copy(uiKey = key)
+    }
+
+    private fun activityIdentity(item: ActivityItem): String = when (item) {
+        is ToolActivity -> item.callId?.takeIf(String::isNotBlank)?.let { "tool-id:${safeKeyPart(it)}" }
+            ?: "tool-legacy:${safeKeyPart(item.name.lowercase())}"
+        is ServerReasoningActivity -> "reasoning:server"
+    }
+
+    private fun stableActivityKey(
+        storedSessionId: String,
+        identity: String,
+        occurrence: Int,
+    ): String = "activity:${storedSessionId.ifBlank { "session" }}:$identity:occurrence:$occurrence"
+
+    private fun safeKeyPart(value: String): String = value.trim()
+        .replace(Regex("[^A-Za-z0-9_.:-]"), "_")
+        .take(96)
+        .ifBlank { "unknown" }
+
+    private fun nextActivityKey(
+        projection: AgentActivityProjection,
+        items: List<ActivityItem>,
+        callId: String?,
+        name: String,
+    ): String {
+        val identity = if (callId.isNullOrBlank()) {
+            "tool-legacy:${safeKeyPart(name.lowercase())}"
+        } else {
+            "tool-id:${safeKeyPart(callId)}"
+        }
+        val occurrence = items.count { activityIdentity(it) == identity } + 1
+        var candidate = stableActivityKey(projection.storedSessionId, identity, occurrence)
+        val keys = items.asSequence().map(ActivityItem::uiKey).toSet()
+        var nextOccurrence = occurrence
+        while (candidate in keys) {
+            nextOccurrence += 1
+            candidate = stableActivityKey(projection.storedSessionId, identity, nextOccurrence)
+        }
+        return candidate
+    }
+
+    private fun nextReasoningKey(
+        projection: AgentActivityProjection,
+        items: List<ActivityItem>,
+    ): String {
+        val identity = "reasoning:server"
+        val occurrence = items.count { it is ServerReasoningActivity } + 1
+        var candidate = stableActivityKey(projection.storedSessionId, identity, occurrence)
+        val keys = items.asSequence().map(ActivityItem::uiKey).toSet()
+        var nextOccurrence = occurrence
+        while (candidate in keys) {
+            nextOccurrence += 1
+            candidate = stableActivityKey(projection.storedSessionId, identity, nextOccurrence)
+        }
+        return candidate
     }
 
     private fun capabilityForItems(items: List<ActivityItem>): ActivityCapabilityState {
@@ -640,7 +966,7 @@ internal object AgentActivityReducer {
         val tools = items.filterIsInstance<ToolActivity>()
         if (hasReasoning) return ActivityCapabilityState.ToolAndServerReasoning
         if (tools.isEmpty()) return ActivityCapabilityState.Unknown
-        return if (tools.all { it.correlation != CorrelationQuality.ExactId }) {
+        return if (tools.any { it.correlation != CorrelationQuality.ExactId }) {
             ActivityCapabilityState.LegacyToolOnly
         } else {
             ActivityCapabilityState.ToolOnly
@@ -652,24 +978,11 @@ internal object AgentActivityReducer {
         legacy: Boolean,
     ): ActivityCapabilityState = when {
         current == ActivityCapabilityState.ToolAndServerReasoning -> current
-        legacy -> ActivityCapabilityState.LegacyToolOnly
+        legacy || current == ActivityCapabilityState.LegacyToolOnly ->
+            ActivityCapabilityState.LegacyToolOnly
         else -> ActivityCapabilityState.ToolOnly
     }
 
-    private fun nextActivityKey(
-        projection: AgentActivityProjection,
-        items: List<ActivityItem>,
-    ): String {
-        val prefix = "activity:${projection.storedSessionId.ifBlank { "session" }}:live:"
-        var occurrence = items.size + 1
-        var candidate = "$prefix$occurrence"
-        val keys = items.asSequence().map(ActivityItem::uiKey).toSet()
-        while (candidate in keys) {
-            occurrence += 1
-            candidate = "$prefix$occurrence"
-        }
-        return candidate
-    }
 }
 
 internal fun reduceActivityEvent(
@@ -704,15 +1017,24 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
         val row = element as? JsonObject ?: return@mapNotNull null
         when (row.stringValue("role")) {
             "tool" -> {
-                val rawName = row.firstString("name", "tool_name") ?: return@mapNotNull null
+                val rawName = row.firstString("name", "tool_name").orEmpty()
                 val callId = row.activityCallId()
+                val status = row.firstString("status")?.lowercase()
                 val failed = row.booleanLike("is_error", "failed") ||
-                    row.firstString("status")?.lowercase() in setOf("error", "failed", "failure")
+                    status in setOf("error", "failed", "failure")
+                val running = !failed && (
+                    row.booleanLike("pending", "running", "in_progress", "streaming") ||
+                        status in setOf("started", "running", "in_progress", "streaming", "queued")
+                    )
                 ToolActivity(
                     uiKey = "",
                     callId = callId,
-                    name = safeToolName(rawName),
-                    phase = if (failed) ToolPhase.Failed else ToolPhase.Completed,
+                    name = safeToolName(rawName.ifBlank { "Tool activity" }),
+                    phase = when {
+                        failed -> ToolPhase.Failed
+                        running -> ToolPhase.Running
+                        else -> ToolPhase.Completed
+                    },
                     input = row.detailFrom(listOf("args_text", "context", "args"), TOOL_ACTIVITY_DETAIL_LIMIT),
                     output = row.detailFrom(
                         listOf("result_text", "summary", "output", "result", "error"),
@@ -725,22 +1047,28 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
                     } else {
                         CorrelationQuality.ExactId
                     },
+                    progress = row.detailFrom(
+                        listOf("progress", "preview", "delta"),
+                        TOOL_ACTIVITY_DETAIL_LIMIT,
+                    ),
                 )
             }
             "assistant" -> {
-                val summary = row.detailFrom(listOf("reasoning"), REASONING_ACTIVITY_DETAIL_LIMIT)
-                val full = row.detailFrom(listOf("reasoning_content"), REASONING_ACTIVITY_DETAIL_LIMIT)
-                val detail = summary ?: full ?: return@mapNotNull null
+                // Hermes' `reasoning_content` is provider-facing thinking text,
+                // not a user-visible activity surface. Only the explicit
+                // server-authored `reasoning` summary is eligible here.
+                val detail = row.reasoningDetailFrom(listOf("reasoning"), REASONING_ACTIVITY_DETAIL_LIMIT)
+                    ?: return@mapNotNull null
+                if (
+                    row.reasoningDisplayCapability() == false ||
+                    row.booleanValue("verbose") == false
+                ) return@mapNotNull null
                 ServerReasoningActivity(
                     uiKey = "",
-                    source = if (summary != null) ReasoningSource.ServerSummary else ReasoningSource.ServerFull,
+                    source = ReasoningSource.ServerSummary,
                     phase = ReasoningPhase.Complete,
-                    text = detail.copy(text = stripReasoningTags(detail.text)),
-                    serverLabel = if (summary != null) {
-                        "Server-provided summary"
-                    } else {
-                        "Server-provided reasoning"
-                    },
+                    text = detail,
+                    serverLabel = safeServerLabel(row.firstString("label")) ?: "Server-provided summary",
                 )
             }
             else -> null
@@ -754,6 +1082,35 @@ private fun JsonObject.firstString(vararg keys: String): String? =
 
 private fun JsonObject.stringValue(key: String): String? =
     (this[key] as? JsonPrimitive)?.contentOrNull
+
+private fun JsonObject.booleanValue(key: String): Boolean? =
+    (this[key] as? JsonPrimitive)?.booleanOrNull
+
+private fun JsonObject.reasoningDisplayCapability(): Boolean? {
+    val direct = sequenceOf(
+        "show_reasoning",
+        "reasoning_visible",
+        "reasoning_enabled",
+        "server_reasoning",
+    ).mapNotNull(::booleanValue).firstOrNull()
+    if (direct != null) return direct
+    val display = this["display"] as? JsonObject
+    display?.booleanValue("show_reasoning")?.let { return it }
+    val capabilities = this["capabilities"] as? JsonObject
+    capabilities?.booleanValue("reasoning")?.let { return it }
+    return null
+}
+
+private fun JsonObject.isFailure(): Boolean =
+    booleanLike("is_error", "failed") ||
+        firstString("status")?.lowercase() in setOf("error", "failed", "failure") ||
+        firstString("error")?.isNotBlank() == true
+
+private fun reasoningTextMatches(existing: String, incoming: String): Boolean =
+    existing == incoming || existing.startsWith(incoming) || incoming.startsWith(existing)
+
+private fun reasoningDeltaIsReplay(existing: String, incoming: String): Boolean =
+    existing == incoming || existing.startsWith(incoming) || existing.endsWith(incoming)
 
 private fun JsonObject.activityCallId(): String? {
     val direct = sequenceOf("tool_call_id", "call_id", "id", "tool_id")
@@ -780,7 +1137,17 @@ private fun JsonObject.detailFrom(keys: List<String>, limit: Int): DisplayedDeta
         val value = this[key] ?: continue
         val text = value.displayText() ?: continue
         if (text.isBlank()) continue
-        return sanitizeActivityDetail(stripReasoningTags(text), limit)
+        return sanitizeActivityDetail(text, limit)
+    }
+    return null
+}
+
+private fun JsonObject.reasoningDetailFrom(keys: List<String>, limit: Int): DisplayedDetail? {
+    for (key in keys) {
+        val value = this[key] ?: continue
+        val text = value.displayText() ?: continue
+        if (text.isBlank() || hiddenReasoningTagPattern.containsMatchIn(text)) continue
+        return sanitizeActivityDetail(text, limit)
     }
     return null
 }
@@ -805,12 +1172,6 @@ private fun safeServerLabel(raw: String?): String? {
     if (candidate.isBlank() || candidate.length > 80) return null
     return if (candidate.matches(Regex("[A-Za-z0-9 ._:-]+"))) candidate else null
 }
-
-private fun stripReasoningTags(text: String): String =
-    text.replace(
-        Regex("</?(?:REASONING_SCRATCHPAD|think|reasoning)>", RegexOption.IGNORE_CASE),
-        "",
-    ).trim()
 
 private fun ToolPhase.isInFlight(): Boolean = this == ToolPhase.Started || this == ToolPhase.Running
 private fun ToolPhase.isTerminal(): Boolean = !isInFlight()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
@@ -1,11 +1,15 @@
 package dev.hazydreams.hermesceleste.network
 
 import java.time.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 
 /** The origin/profile/session chain that authorizes an activity projection. */
@@ -214,6 +218,12 @@ private val sessionTokenHeaderPattern = Regex(
 private val credentialAssignmentPattern = Regex(
     "(?i)(\\b(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token)\\s*[:=]\\s*[\\\"']?)[^\\\"'\\s,}&]+",
 )
+private val quotedCredentialAssignmentPattern = Regex(
+    """(?i)([\"'](?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|key)[\"']\s*:\s*)(\"(?:\\.|[^\"\\])*\"|[^,}\]\s]+)""",
+)
+private val credentialJsonKeyPattern = Regex(
+    "(?i)^(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|key)$",
+)
 private val credentialQueryPattern = Regex(
     "(?i)([?&](?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|secret|credential|token|key)=)[^&#\\s]+",
 )
@@ -226,15 +236,43 @@ private val hiddenReasoningTagPattern = Regex(
 )
 
 private fun redactActivitySecrets(raw: String): String {
-    var safe = privateKeyPattern.replace(raw, "[redacted]")
+    var safe = redactStructuredJson(raw)
+    safe = privateKeyPattern.replace(safe, "[redacted]")
     safe = authorizationHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = authorizationValuePattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = bearerPattern.replace(safe, "Bearer [redacted]")
     safe = cookieHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = sessionTokenHeaderPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     safe = credentialAssignmentPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
+    safe = quotedCredentialAssignmentPattern.replace(safe) {
+        "${it.groupValues[1]}\"[redacted]\""
+    }
     safe = credentialQueryPattern.replace(safe) { "${it.groupValues[1]}[redacted]" }
     return knownTokenPattern.replace(safe, "[redacted]")
+}
+
+private fun redactStructuredJson(raw: String): String {
+    val element = runCatching { Json.parseToJsonElement(raw) }.getOrNull()
+    return when (element) {
+        is JsonObject, is JsonArray -> redactJsonElement(element).toString()
+        else -> raw
+    }
+}
+
+private fun redactJsonElement(element: JsonElement): JsonElement = when (element) {
+    is JsonObject -> buildJsonObject {
+        element.forEach { (key, value) ->
+            if (credentialJsonKeyPattern.matches(key)) {
+                put(key, JsonPrimitive("[redacted]"))
+            } else {
+                put(key, redactJsonElement(value))
+            }
+        }
+    }
+    is JsonArray -> buildJsonArray {
+        element.forEach { add(redactJsonElement(it)) }
+    }
+    else -> element
 }
 
 private fun takeCodePoints(value: String, count: Int): String {
@@ -292,7 +330,7 @@ internal object AgentActivityReducer {
                 if (
                     reasoningEnabled &&
                     projection.serverReasoningAllowed != false &&
-                    event.payload.booleanValue("verbose") != false
+                    event.payload.booleanValue("verbose") == true
                 ) {
                     applyReasoningSummary(projection, event.payload)
                 } else {
@@ -313,7 +351,6 @@ internal object AgentActivityReducer {
                     projection
                 }
             }
-            "session.info" -> applySessionInfo(projection, event.payload)
             "message.complete" -> settleOpenItems(
                 projection,
                 failed = event.payload.isFailure(),
@@ -814,7 +851,10 @@ internal object AgentActivityReducer {
                 (input == null || tool.input?.text == input.text) &&
                 (output == null || tool.output?.text == output.text)
         }
-        return matches.singleOrNull()?.index ?: -1
+        // With no event ID, one or more matching terminal rows are enough to
+        // identify a replay. If the snapshot contains duplicate rows, adding
+        // another indistinguishable card would amplify the server's ambiguity.
+        return matches.firstOrNull()?.index ?: -1
     }
 
     private fun applyReasoningSummary(
@@ -930,14 +970,6 @@ internal object AgentActivityReducer {
                 ActivityPresentationState.Available
             },
         )
-    }
-
-    private fun applySessionInfo(
-        projection: AgentActivityProjection,
-        payload: JsonObject,
-    ): AgentActivityProjection {
-        val serverAllowed = payload.reasoningDisplayCapability() ?: return projection
-        return AgentActivityReducer.applyServerReasoningCapability(projection, serverAllowed)
     }
 
     private fun malformed(projection: AgentActivityProjection): AgentActivityProjection =
@@ -1143,15 +1175,7 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
                 // server-authored `reasoning` summary is eligible here.
                 val detail = row.reasoningDetailFrom(listOf("reasoning"), REASONING_ACTIVITY_DETAIL_LIMIT)
                     ?: return@mapNotNull null
-                // A persisted assistant `reasoning` field is not proof that the
-                // text was user-visible. Require either an explicit disclosure
-                // capability or the source-verified verbose marker; omission is
-                // deliberately fail-closed to protect provider/model reasoning.
-                val explicitCapability = row.reasoningDisplayCapability()
-                if (
-                    explicitCapability == false ||
-                    (explicitCapability != true && row.booleanValue("verbose") != true)
-                ) return@mapNotNull null
+                if (row.booleanValue("verbose") != true) return@mapNotNull null
                 ServerReasoningActivity(
                     uiKey = "",
                     source = ReasoningSource.ServerSummary,
@@ -1174,21 +1198,6 @@ private fun JsonObject.stringValue(key: String): String? =
 
 private fun JsonObject.booleanValue(key: String): Boolean? =
     (this[key] as? JsonPrimitive)?.booleanOrNull
-
-private fun JsonObject.reasoningDisplayCapability(): Boolean? {
-    val direct = sequenceOf(
-        "show_reasoning",
-        "reasoning_visible",
-        "reasoning_enabled",
-        "server_reasoning",
-    ).mapNotNull(::booleanValue).firstOrNull()
-    if (direct != null) return direct
-    val display = this["display"] as? JsonObject
-    display?.booleanValue("show_reasoning")?.let { return it }
-    val capabilities = this["capabilities"] as? JsonObject
-    capabilities?.booleanValue("reasoning")?.let { return it }
-    return null
-}
 
 private fun JsonObject.isFailure(): Boolean =
     booleanLike("is_error", "failed") ||

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
@@ -216,13 +216,13 @@ private val sessionTokenHeaderPattern = Regex(
     "(?im)(\\b(?:x[-_]?hermes[-_])?session[-_]?token\\s*[:=]\\s*)[^\\s,;]+",
 )
 private val credentialAssignmentPattern = Regex(
-    "(?i)(\\b(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token)\\s*[:=]\\s*[\\\"']?)[^\\\"'\\s,}&]+",
+    "(?i)(\\b(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|authorization|proxy[-_]?authorization|cookie|set[-_]?cookie)\\s*[:=]\\s*[\\\"']?)[^\\\"'\\s,}&]+",
 )
 private val quotedCredentialAssignmentPattern = Regex(
-    """(?i)([\"'](?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|key)[\"']\s*:\s*)(\"(?:\\.|[^\"\\])*\"|[^,}\]\s]+)""",
+    """(?i)([\"'](?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|key|authorization|proxy[-_]?authorization|cookie|set[-_]?cookie)[\"']\s*:\s*)(\"(?:\\.|[^\"\\])*\"|[^,}\]\s]+)""",
 )
 private val credentialJsonKeyPattern = Regex(
-    "(?i)^(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|key)$",
+    "(?i)^(?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|credential|private[_-]?key|token|key|authorization|proxy[-_]?authorization|cookie|set[-_]?cookie)$",
 )
 private val credentialQueryPattern = Regex(
     "(?i)([?&](?:api[_-]?key|api[_-]?secret|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|id[_-]?token|client[_-]?secret|password|secret|credential|token|key)=)[^&#\\s]+",
@@ -606,6 +606,19 @@ internal object AgentActivityReducer {
             limit = TOOL_ACTIVITY_DETAIL_LIMIT,
         )
         val items = projection.items.toMutableList()
+        if (!legacy && callId == null) {
+            // An ID-less replay has no protocol identity. Treat an identical
+            // active name/input occurrence as the same official start; legacy
+            // aliases retain their occurrence queue for ambiguity handling.
+            val replay = items.any { item ->
+                item is ToolActivity &&
+                    item.callId == null &&
+                    item.name == name &&
+                    item.phase.isInFlight() &&
+                    item.input?.text == input?.text
+            }
+            if (replay) return projection
+        }
         val activeCandidates = if (callId == null) {
             items.withIndex().filter { (_, item) ->
                 item is ToolActivity && item.name == name && item.phase.isInFlight()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
@@ -330,6 +330,7 @@ internal object AgentActivityReducer {
                 if (
                     reasoningEnabled &&
                     projection.serverReasoningAllowed != false &&
+                    event.payload.booleanValue("show_reasoning") != false &&
                     event.payload.booleanValue("verbose") == true
                 ) {
                     applyReasoningSummary(projection, event.payload)
@@ -344,6 +345,7 @@ internal object AgentActivityReducer {
                 if (
                     reasoningEnabled &&
                     projection.serverReasoningAllowed != false &&
+                    event.payload.booleanValue("show_reasoning") != false &&
                     event.payload.booleanValue("verbose") == true
                 ) {
                     applyReasoningDelta(projection, event.payload)
@@ -1188,7 +1190,10 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
                 // server-authored `reasoning` summary is eligible here.
                 val detail = row.reasoningDetailFrom(listOf("reasoning"), REASONING_ACTIVITY_DETAIL_LIMIT)
                     ?: return@mapNotNull null
-                if (row.booleanValue("verbose") != true) return@mapNotNull null
+                if (
+                    row.booleanValue("show_reasoning") == false ||
+                    row.booleanValue("verbose") != true
+                ) return@mapNotNull null
                 ServerReasoningActivity(
                     uiKey = "",
                     source = ReasoningSource.ServerSummary,
@@ -1203,7 +1208,7 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
 
 private fun JsonObject.firstString(vararg keys: String): String? =
     keys.asSequence()
-        .mapNotNull { key -> this[key]?.stringValue() }
+        .mapNotNull { key -> stringValue(key) }
         .firstOrNull { it.isNotBlank() }
 
 private fun JsonObject.stringValue(key: String): String? =

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/AgentActivity.kt
@@ -368,6 +368,10 @@ internal object AgentActivityReducer {
                 // without retaining the hidden body in memory.
                 ActivityCapabilityState.ToolAndServerReasoning
             }
+            projection.capability == ActivityCapabilityState.LegacyToolOnly ->
+                ActivityCapabilityState.LegacyToolOnly
+            projection.capability == ActivityCapabilityState.ToolOnly ->
+                ActivityCapabilityState.ToolOnly
             else -> capabilityForItems(rekeyed)
         }
         return projection.copy(
@@ -378,6 +382,7 @@ internal object AgentActivityReducer {
             items = rekeyed,
             source = when {
                 capability == ActivityCapabilityState.Unsupported -> ActivitySource.Unavailable
+                capability == ActivityCapabilityState.LegacyToolOnly -> ActivitySource.Legacy
                 rekeyed.any { item ->
                     item is ToolActivity && item.correlation != CorrelationQuality.ExactId
                 } -> ActivitySource.Legacy
@@ -390,7 +395,8 @@ internal object AgentActivityReducer {
                 capability == ActivityCapabilityState.Unsupported -> ActivityPresentationState.Unavailable
                 running || rekeyed.any(ActivityItem::isInFlight) -> ActivityPresentationState.Running
                 rekeyed.isNotEmpty() -> ActivityPresentationState.Available
-                capability == ActivityCapabilityState.ToolAndServerReasoning -> ActivityPresentationState.Available
+                capability != ActivityCapabilityState.Unknown &&
+                    capability != ActivityCapabilityState.Stale -> ActivityPresentationState.Available
                 else -> ActivityPresentationState.Discovering
             },
         )
@@ -437,6 +443,25 @@ internal object AgentActivityReducer {
             capability = ActivityCapabilityState.Unsupported,
             presentation = ActivityPresentationState.Unavailable,
         )
+
+    /**
+     * Resolve a completed resume with no activity evidence without leaving the
+     * user at the indefinite discovery state. Explicit legacy/tool capability
+     * remains truthful even when this particular session has no activity rows.
+     */
+    fun markAbsent(projection: AgentActivityProjection): AgentActivityProjection = when {
+        projection.capability == ActivityCapabilityState.Unknown -> markUnavailable(projection)
+        projection.capability == ActivityCapabilityState.LegacyToolOnly -> projection.copy(
+            source = ActivitySource.Legacy,
+            presentation = ActivityPresentationState.Available,
+        )
+        projection.capability == ActivityCapabilityState.Unsupported -> markUnavailable(projection)
+        projection.presentation == ActivityPresentationState.Stale -> projection
+        else -> projection.copy(
+            source = ActivitySource.Resumed,
+            presentation = ActivityPresentationState.Available,
+        )
+    }
 
     /** Settle cards when Hermes ends a turn without sending tool.complete. */
     fun settleOpenItems(
@@ -536,7 +561,7 @@ internal object AgentActivityReducer {
     ): AgentActivityProjection {
         val rawName = payload.firstString("name", "tool_name")?.trim().orEmpty()
         if (rawName.isBlank()) return unavailableAfterMalformed(projection)
-        val name = safeToolName(rawName)
+        val name = safeToolName(rawName, payload.toolNameIsUnsafe())
         val callId = payload.activityCallId()
         val effectiveLegacy = legacy || callId == null
         val input = payload.detailFrom(
@@ -612,7 +637,11 @@ internal object AgentActivityReducer {
             keys = listOf("preview", "progress", "delta", "text", "context"),
             limit = TOOL_ACTIVITY_DETAIL_LIMIT,
         ) ?: return unavailableAfterMalformed(projection)
-        val fallbackName = if (rawName.isBlank()) "Tool activity" else safeToolName(rawName)
+        val fallbackName = if (rawName.isBlank()) {
+            "Tool activity"
+        } else {
+            safeToolName(rawName, payload.toolNameIsUnsafe())
+        }
         val items = projection.items.toMutableList()
         val candidates = items.withIndex().filter { (_, item) ->
             item is ToolActivity &&
@@ -672,10 +701,13 @@ internal object AgentActivityReducer {
         now: Instant,
     ): AgentActivityProjection {
         val rawName = payload.firstString("name", "tool_name")?.trim().orEmpty()
-        val name = safeToolName(rawName.ifBlank { "Tool activity" })
+        val name = safeToolName(
+            rawName.ifBlank { "Tool activity" },
+            payload.toolNameIsUnsafe(),
+        )
         val callId = payload.activityCallId()
         val output = payload.detailFrom(
-            keys = listOf("result_text", "summary", "output", "result", "error"),
+            keys = listOf("result_text", "summary", "output", "result", "error", "failure_reason"),
             limit = TOOL_ACTIVITY_DETAIL_LIMIT,
         )
         val input = payload.detailFrom(
@@ -684,9 +716,25 @@ internal object AgentActivityReducer {
         )
         val failed = payload.booleanLike("is_error", "failed") ||
             payload.firstString("status")?.lowercase() in setOf("error", "failed", "failure") ||
-            payload.firstString("error")?.isNotBlank() == true
+            payload.firstString("error", "failure_reason")?.isNotBlank() == true
         val phase = if (failed) ToolPhase.Failed else ToolPhase.Completed
         val items = projection.items.toMutableList()
+
+        // A resume snapshot may already contain the terminal row for this
+        // completion. Old gateways commonly replay the same tool.complete
+        // without an event ID, so match the terminal row by its safe identity
+        // and displayed fields before creating another occurrence.
+        val terminalReplay = terminalToolReplayIndex(
+            items = items,
+            callId = callId,
+            rawName = rawName,
+            name = name,
+            input = input,
+            output = output,
+            phase = phase,
+        )
+        if (terminalReplay >= 0) return projection
+
         val candidates = when {
             callId != null -> items.withIndex().filter { (_, item) ->
                 item is ToolActivity && item.callId == callId && item.phase.isInFlight()
@@ -745,6 +793,30 @@ internal object AgentActivityReducer {
         )
     }
 
+    private fun terminalToolReplayIndex(
+        items: List<ActivityItem>,
+        callId: String?,
+        rawName: String,
+        name: String,
+        input: DisplayedDetail?,
+        output: DisplayedDetail?,
+        phase: ToolPhase,
+    ): Int {
+        val candidates = items.withIndex().filter { (_, item) ->
+            item is ToolActivity &&
+                item.phase.isTerminal() &&
+                (callId == null || item.callId == callId) &&
+                (rawName.isBlank() || item.name == name)
+        }
+        val matches = candidates.filter { (_, item) ->
+            val tool = item as ToolActivity
+            tool.phase == phase &&
+                (input == null || tool.input?.text == input.text) &&
+                (output == null || tool.output?.text == output.text)
+        }
+        return matches.singleOrNull()?.index ?: -1
+    }
+
     private fun applyReasoningSummary(
         projection: AgentActivityProjection,
         payload: JsonObject,
@@ -796,10 +868,13 @@ internal object AgentActivityReducer {
         val detail = payload.reasoningDetailFrom(listOf("text"), REASONING_ACTIVITY_DETAIL_LIMIT)
             ?: return projection.copy(serverReasoningAllowed = true)
         val items = projection.items.toMutableList()
-        val index = items.indexOfLast {
+        val streamingIndex = items.indexOfLast {
             it is ServerReasoningActivity &&
                 it.source == ReasoningSource.ServerFull &&
                 it.phase == ReasoningPhase.Streaming
+        }
+        val index = if (streamingIndex >= 0) streamingIndex else items.indexOfLast {
+            it is ServerReasoningActivity && it.phase != ReasoningPhase.Unavailable
         }
         if (index >= 0) {
             val existing = items[index] as ServerReasoningActivity
@@ -815,7 +890,12 @@ internal object AgentActivityReducer {
                     REASONING_ACTIVITY_DETAIL_LIMIT,
                 )
             }
-            items[index] = existing.copy(text = combined)
+            items[index] = existing.copy(
+                source = ReasoningSource.ServerFull,
+                phase = ReasoningPhase.Streaming,
+                text = combined,
+                serverLabel = existing.serverLabel ?: "Server-provided reasoning",
+            )
         } else {
             items += ServerReasoningActivity(
                 uiKey = nextReasoningKey(projection, items),
@@ -1021,7 +1101,8 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
                 val callId = row.activityCallId()
                 val status = row.firstString("status")?.lowercase()
                 val failed = row.booleanLike("is_error", "failed") ||
-                    status in setOf("error", "failed", "failure")
+                    status in setOf("error", "failed", "failure") ||
+                    row.firstString("failure_reason")?.isNotBlank() == true
                 val running = !failed && (
                     row.booleanLike("pending", "running", "in_progress", "streaming") ||
                         status in setOf("started", "running", "in_progress", "streaming", "queued")
@@ -1029,7 +1110,10 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
                 ToolActivity(
                     uiKey = "",
                     callId = callId,
-                    name = safeToolName(rawName.ifBlank { "Tool activity" }),
+                    name = safeToolName(
+                        rawName.ifBlank { "Tool activity" },
+                        row.toolNameIsUnsafe(),
+                    ),
                     phase = when {
                         failed -> ToolPhase.Failed
                         running -> ToolPhase.Running
@@ -1059,9 +1143,14 @@ internal fun decodeGatewayActivity(elements: List<JsonElement>): List<ActivityIt
                 // server-authored `reasoning` summary is eligible here.
                 val detail = row.reasoningDetailFrom(listOf("reasoning"), REASONING_ACTIVITY_DETAIL_LIMIT)
                     ?: return@mapNotNull null
+                // A persisted assistant `reasoning` field is not proof that the
+                // text was user-visible. Require either an explicit disclosure
+                // capability or the source-verified verbose marker; omission is
+                // deliberately fail-closed to protect provider/model reasoning.
+                val explicitCapability = row.reasoningDisplayCapability()
                 if (
-                    row.reasoningDisplayCapability() == false ||
-                    row.booleanValue("verbose") == false
+                    explicitCapability == false ||
+                    (explicitCapability != true && row.booleanValue("verbose") != true)
                 ) return@mapNotNull null
                 ServerReasoningActivity(
                     uiKey = "",
@@ -1104,7 +1193,7 @@ private fun JsonObject.reasoningDisplayCapability(): Boolean? {
 private fun JsonObject.isFailure(): Boolean =
     booleanLike("is_error", "failed") ||
         firstString("status")?.lowercase() in setOf("error", "failed", "failure") ||
-        firstString("error")?.isNotBlank() == true
+        firstString("error", "failure_reason")?.isNotBlank() == true
 
 private fun reasoningTextMatches(existing: String, incoming: String): Boolean =
     existing == incoming || existing.startsWith(incoming) || incoming.startsWith(existing)
@@ -1158,13 +1247,54 @@ private fun JsonElement.displayText(): String? = when (this) {
     else -> toString()
 }
 
-private fun safeToolName(raw: String): String {
+internal fun safeToolName(raw: String, unsafe: Boolean = false): String {
     val candidate = raw.trim()
-    if (candidate.isBlank()) return "Tool activity"
-    if (candidate.length > 80 || !candidate.matches(Regex("[A-Za-z0-9_.:-]+"))) {
+    if (candidate.isBlank() || unsafe) return "Tool activity"
+    if (
+        candidate.length > 80 ||
+        !candidate.matches(Regex("[A-Za-z0-9_.:-]+")) ||
+        sanitizeActivityText(candidate, 80) != candidate
+    ) {
         return "Tool activity"
     }
     return candidate.replace('_', ' ')
+}
+
+internal fun JsonObject.toolNameIsUnsafe(): Boolean {
+    fun marker(value: JsonObject): Boolean {
+        val unsafeKeys = listOf(
+            "unsafe_name",
+            "unsafe_tool_name",
+            "name_unsafe",
+            "sensitive_name",
+            "name_sensitive",
+            "tool_name_sensitive",
+            "private_name",
+        )
+        val safeKeys = listOf("name_safe", "tool_name_safe", "safe_tool_name", "name_is_safe")
+        if (unsafeKeys.any { key -> booleanMarker(value[key]) == true }) return true
+        if (safeKeys.any { key -> booleanMarker(value[key]) == false }) return true
+        if (booleanMarker(value["sensitive"]) == true || booleanMarker(value["private"]) == true) {
+            return true
+        }
+        return false
+    }
+
+    if (marker(this)) return true
+    return listOf("tool", "tool_call", "metadata", "tool_metadata")
+        .mapNotNull { this[it] as? JsonObject }
+        .any(::marker)
+}
+
+private fun booleanMarker(element: JsonElement?): Boolean? {
+    val primitive = element as? JsonPrimitive ?: return null
+    return primitive.booleanOrNull ?: primitive.contentOrNull?.trim()?.lowercase()?.let {
+        when (it) {
+            "true", "1", "yes", "on" -> true
+            "false", "0", "no", "off" -> false
+            else -> null
+        }
+    }
 }
 
 private fun safeServerLabel(raw: String?): String? {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -91,6 +91,9 @@ data class ResumedSession(
     val status: String? = null,
     val inflightAssistantText: String = "",
     val hasLiveProjection: Boolean = false,
+    val activityItems: List<ActivityItem> = emptyList(),
+    val originKey: NormalizedDashboardOrigin? = null,
+    val profile: String? = null,
 )
 
 sealed interface GatewayCredential {
@@ -543,12 +546,27 @@ class DashboardClient(
             if (runtimeId.isBlank()) {
                 throw InvalidDashboardResponse("Hermes returned no runtime session identity.")
             }
+            val info = result["info"] as? JsonObject
+            val running = result["running"]?.jsonPrimitive?.booleanOrNull ?: info?.boolean("running")
+            val status = result["status"]?.jsonPrimitive?.contentOrNull ?: info?.string("status")
+            val inflight = result["inflight"]
+            val queued = result["queued"]
+            val messages = result["messages"]?.jsonArray.orEmpty()
             ResumedSession(
                 runtimeSessionId = runtimeId,
                 storedSessionId = result["resumed"]?.jsonPrimitive?.contentOrNull
+                    ?: result["stored_session_id"]?.jsonPrimitive?.contentOrNull
                     ?: result["session_key"]?.jsonPrimitive?.contentOrNull
                     ?: storedSessionId,
-                messages = decodeGatewayMessages(result["messages"]?.jsonArray.orEmpty()),
+                messages = decodeGatewayMessages(messages),
+                running = running,
+                status = status,
+                inflightAssistantText = inflightAssistantText(inflight),
+                hasLiveProjection = inflight.isTruthy() || queued.isTruthy(),
+                activityItems = decodeGatewayActivity(messages),
+                profile = result["profile"]?.jsonPrimitive?.contentOrNull
+                    ?: result["profile_id"]?.jsonPrimitive?.contentOrNull
+                    ?: info?.string("profile_name"),
             )
         }
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -53,8 +53,67 @@ data class DashboardProbeResult(
     val authRequired: Boolean,
     val providers: List<AuthProvider>,
     val version: String?,
+    /** Explicit server declaration only; absent means capability is unknown. */
+    val activityCapability: ActivityCapabilityState = ActivityCapabilityState.Unknown,
 ) {
     val supportsPassword: Boolean = providers.any(AuthProvider::supportsPassword)
+}
+
+/**
+ * Decode only explicit activity declarations from /api/status. A version string
+ * is deliberately not used as a feature gate because Hermes has no contractual
+ * minimum version for this projection yet.
+ */
+internal fun decodeActivityCapability(status: JsonObject): ActivityCapabilityState {
+    val direct = sequenceOf(
+        status["activity_capability"],
+        status["activity_support"],
+        status["activity"],
+    ).mapNotNull(::activityCapabilityFromElement).firstOrNull()
+    if (direct != null) return direct
+
+    if (
+        (status["activity_supported"] as? JsonPrimitive)?.booleanOrNull == false ||
+        (status["activity_available"] as? JsonPrimitive)?.booleanOrNull == false
+    ) {
+        return ActivityCapabilityState.Unsupported
+    }
+    if (status["activity_legacy"]?.jsonPrimitive?.booleanOrNull == true) {
+        return ActivityCapabilityState.LegacyToolOnly
+    }
+
+    val capabilities = status["capabilities"] as? JsonObject
+    return capabilities?.let { nested ->
+        activityCapabilityFromElement(nested["activity"])
+    } ?: ActivityCapabilityState.Unknown
+}
+
+private fun activityCapabilityFromElement(element: JsonElement?): ActivityCapabilityState? {
+    if (element is JsonObject) {
+        (element["supported"] as? JsonPrimitive)?.booleanOrNull?.let {
+            if (!it) return ActivityCapabilityState.Unsupported
+        }
+        (element["available"] as? JsonPrimitive)?.booleanOrNull?.let {
+            if (!it) return ActivityCapabilityState.Unsupported
+        }
+        (element["legacy"] as? JsonPrimitive)?.booleanOrNull?.let {
+            if (it) return ActivityCapabilityState.LegacyToolOnly
+        }
+        val mode = element["mode"] ?: element["state"] ?: element["capability"]
+        return activityCapabilityFromElement(mode)
+    }
+    val primitive = element as? JsonPrimitive ?: return null
+    primitive.booleanOrNull?.let { return if (it) ActivityCapabilityState.ToolOnly else ActivityCapabilityState.Unsupported }
+    return when (primitive.contentOrNull?.trim()?.lowercase()) {
+        "unsupported", "unavailable", "none", "false", "off" -> ActivityCapabilityState.Unsupported
+        "legacy", "legacy_tool_only", "legacy-tool-only" -> ActivityCapabilityState.LegacyToolOnly
+        "tool_only", "tool-only", "tools", "available" -> ActivityCapabilityState.ToolOnly
+        "tool_and_server_reasoning", "tool-and-server-reasoning", "reasoning" ->
+            ActivityCapabilityState.ToolAndServerReasoning
+        "stale" -> ActivityCapabilityState.Stale
+        "unknown" -> ActivityCapabilityState.Unknown
+        else -> null
+    }
 }
 
 data class StoredSession(
@@ -92,8 +151,10 @@ data class ResumedSession(
     val inflightAssistantText: String = "",
     val hasLiveProjection: Boolean = false,
     val activityItems: List<ActivityItem> = emptyList(),
+    /** Server-provided origin, or the connection-bound origin when omitted. */
     val originKey: NormalizedDashboardOrigin? = null,
     val profile: String? = null,
+    val serverReasoningAllowed: Boolean? = null,
 )
 
 sealed interface GatewayCredential {
@@ -301,6 +362,7 @@ class DashboardClient(
             authRequired = authRequired,
             providers = providers,
             version = status["version"]?.jsonPrimitive?.contentOrNull,
+            activityCapability = decodeActivityCapability(status),
         )
     }
 
@@ -427,11 +489,20 @@ class DashboardClient(
         baseUrl: String,
         credential: GatewayCredential,
         storedSessionId: String,
+        profile: String? = null,
     ): ResumedSession {
         require(storedSessionId.isNotBlank()) { "Choose a Hermes session to open." }
-        val authParameter = resolveWebSocketCredential(baseUrl, credential)
-        val wsUrl = buildWebSocketUrl(baseUrl, authParameter?.first, authParameter?.second)
-        return withTimeout(20_000) { requestSessionResume(wsUrl, storedSessionId) }
+        val normalizedBaseUrl = DashboardUrlPolicy.normalize(baseUrl)
+        val authParameter = resolveWebSocketCredential(normalizedBaseUrl, credential)
+        val wsUrl = buildWebSocketUrl(normalizedBaseUrl, authParameter?.first, authParameter?.second)
+        return withTimeout(20_000) {
+            requestSessionResume(
+                wsUrl = wsUrl,
+                storedSessionId = storedSessionId,
+                profile = profile,
+                originKey = normalizedBaseUrl,
+            )
+        }
     }
 
     private suspend fun resolveWebSocketCredential(
@@ -520,6 +591,8 @@ class DashboardClient(
     private suspend fun requestSessionResume(
         wsUrl: String,
         storedSessionId: String,
+        profile: String?,
+        originKey: NormalizedDashboardOrigin,
     ): ResumedSession {
         val frame = buildJsonObject {
             put("jsonrpc", "2.0")
@@ -531,6 +604,7 @@ class DashboardClient(
                     put("session_id", storedSessionId)
                     put("cols", 80)
                     put("source", "android")
+                    profile?.trim()?.takeIf(String::isNotBlank)?.let { put("profile", it) }
                 },
             )
         }
@@ -564,11 +638,33 @@ class DashboardClient(
                 inflightAssistantText = inflightAssistantText(inflight),
                 hasLiveProjection = inflight.isTruthy() || queued.isTruthy(),
                 activityItems = decodeGatewayActivity(messages),
-                profile = result["profile"]?.jsonPrimitive?.contentOrNull
-                    ?: result["profile_id"]?.jsonPrimitive?.contentOrNull
-                    ?: info?.string("profile_name"),
+                originKey = firstResumeString(result, info, "origin_key", "origin", "dashboard_origin", "base_url")
+                    ?: originKey,
+                profile = firstResumeString(result, info, "profile", "profile_id", "profile_name")
+                    ?: profile?.trim()?.takeIf(String::isNotBlank),
+                serverReasoningAllowed = reasoningDisplayCapability(result)
+                    ?: info?.let(::reasoningDisplayCapability),
             )
         }
+    }
+
+    private fun firstResumeString(
+        result: JsonObject,
+        info: JsonObject?,
+        vararg keys: String,
+    ): String? = keys.asSequence()
+        .mapNotNull { key -> result.string(key) ?: info?.string(key) }
+        .map(String::trim)
+        .firstOrNull(String::isNotBlank)
+
+    private fun reasoningDisplayCapability(value: JsonObject): Boolean? {
+        sequenceOf("show_reasoning", "reasoning_visible", "reasoning_enabled", "server_reasoning")
+            .mapNotNull(value::boolean)
+            .firstOrNull()
+            ?.let { return it }
+        (value["display"] as? JsonObject)?.boolean("show_reasoning")?.let { return it }
+        (value["capabilities"] as? JsonObject)?.boolean("reasoning")?.let { return it }
+        return null
     }
 
     private suspend fun <T> requestSingleWebSocketResponse(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -53,84 +53,20 @@ data class DashboardProbeResult(
     val authRequired: Boolean,
     val providers: List<AuthProvider>,
     val version: String?,
-    /** Explicit server declaration only; absent means capability is unknown. */
+    /** `/api/status` has no source-verified activity capability contract. */
     val activityCapability: ActivityCapabilityState = ActivityCapabilityState.Unknown,
 ) {
     val supportsPassword: Boolean = providers.any(AuthProvider::supportsPassword)
 }
 
 /**
- * Decode only explicit activity declarations from /api/status. A version string
- * is deliberately not used as a feature gate because Hermes has no contractual
- * minimum version for this projection yet.
+ * `/api/status` does not currently expose a documented activity capability
+ * field. Leave the capability unknown until Hermes publishes a source-verified
+ * contract; observed activity events remain the feature evidence.
  */
-internal fun decodeActivityCapability(status: JsonObject): ActivityCapabilityState {
-    val direct = sequenceOf(
-        status["activity_capability"],
-        status["activity_support"],
-        status["activity"],
-    ).mapNotNull(::activityCapabilityFromElement).firstOrNull()
-    if (direct != null) return direct
+internal fun decodeActivityCapability(_status: JsonObject): ActivityCapabilityState =
+    ActivityCapabilityState.Unknown
 
-    if (
-        (status["activity_supported"] as? JsonPrimitive)?.booleanOrNull == false ||
-        (status["activity_available"] as? JsonPrimitive)?.booleanOrNull == false
-    ) {
-        return ActivityCapabilityState.Unsupported
-    }
-    if (status["activity_legacy"]?.jsonPrimitive?.booleanOrNull == true) {
-        return ActivityCapabilityState.LegacyToolOnly
-    }
-
-    val capabilities = status["capabilities"] as? JsonObject
-    return capabilities?.let { nested ->
-        activityCapabilityFromElement(nested["activity"])
-    } ?: ActivityCapabilityState.Unknown
-}
-
-private fun activityCapabilityFromElement(element: JsonElement?): ActivityCapabilityState? {
-    if (element is JsonObject) {
-        (element["supported"] as? JsonPrimitive)?.booleanOrNull?.let {
-            if (!it) return ActivityCapabilityState.Unsupported
-        }
-        (element["available"] as? JsonPrimitive)?.booleanOrNull?.let {
-            if (!it) return ActivityCapabilityState.Unsupported
-        }
-        (element["legacy"] as? JsonPrimitive)?.booleanOrNull?.let {
-            if (it) return ActivityCapabilityState.LegacyToolOnly
-        }
-        val mode = element["mode"] ?: element["state"] ?: element["capability"]
-        activityCapabilityFromElement(mode)?.let { return it }
-        val hasReasoning = sequenceOf(
-            "server_reasoning",
-            "reasoning",
-            "reasoning_events",
-            "reasoning_stream",
-        ).mapNotNull { key -> (element[key] as? JsonPrimitive)?.booleanOrNull }
-            .firstOrNull { it }
-        if (hasReasoning == true) return ActivityCapabilityState.ToolAndServerReasoning
-        val hasTools = sequenceOf("tools", "tool_events", "tool_activity")
-            .mapNotNull { key -> (element[key] as? JsonPrimitive)?.booleanOrNull }
-            .firstOrNull { it }
-        val explicitlySupported = sequenceOf("supported", "available")
-            .mapNotNull { key -> (element[key] as? JsonPrimitive)?.booleanOrNull }
-            .firstOrNull { it }
-        if (hasTools == true || explicitlySupported == true) return ActivityCapabilityState.ToolOnly
-        return null
-    }
-    val primitive = element as? JsonPrimitive ?: return null
-    primitive.booleanOrNull?.let { return if (it) ActivityCapabilityState.ToolOnly else ActivityCapabilityState.Unsupported }
-    return when (primitive.contentOrNull?.trim()?.lowercase()) {
-        "unsupported", "unavailable", "none", "false", "off" -> ActivityCapabilityState.Unsupported
-        "legacy", "legacy_tool_only", "legacy-tool-only" -> ActivityCapabilityState.LegacyToolOnly
-        "tool_only", "tool-only", "tools", "available" -> ActivityCapabilityState.ToolOnly
-        "tool_and_server_reasoning", "tool-and-server-reasoning", "reasoning" ->
-            ActivityCapabilityState.ToolAndServerReasoning
-        "stale" -> ActivityCapabilityState.Stale
-        "unknown" -> ActivityCapabilityState.Unknown
-        else -> null
-    }
-}
 
 data class StoredSession(
     val id: String,
@@ -658,8 +594,7 @@ class DashboardClient(
                     ?: originKey,
                 profile = firstResumeString(result, info, "profile", "profile_id", "profile_name")
                     ?: profile?.trim()?.takeIf(String::isNotBlank),
-                serverReasoningAllowed = reasoningDisplayCapability(result)
-                    ?: info?.let(::reasoningDisplayCapability),
+                serverReasoningAllowed = null,
             )
         }
     }
@@ -672,16 +607,6 @@ class DashboardClient(
         .mapNotNull { key -> result.string(key) ?: info?.string(key) }
         .map(String::trim)
         .firstOrNull(String::isNotBlank)
-
-    private fun reasoningDisplayCapability(value: JsonObject): Boolean? {
-        sequenceOf("show_reasoning", "reasoning_visible", "reasoning_enabled", "server_reasoning")
-            .mapNotNull(value::boolean)
-            .firstOrNull()
-            ?.let { return it }
-        (value["display"] as? JsonObject)?.boolean("show_reasoning")?.let { return it }
-        (value["capabilities"] as? JsonObject)?.boolean("reasoning")?.let { return it }
-        return null
-    }
 
     private suspend fun <T> requestSingleWebSocketResponse(
         request: Request,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -100,7 +100,23 @@ private fun activityCapabilityFromElement(element: JsonElement?): ActivityCapabi
             if (it) return ActivityCapabilityState.LegacyToolOnly
         }
         val mode = element["mode"] ?: element["state"] ?: element["capability"]
-        return activityCapabilityFromElement(mode)
+        activityCapabilityFromElement(mode)?.let { return it }
+        val hasReasoning = sequenceOf(
+            "server_reasoning",
+            "reasoning",
+            "reasoning_events",
+            "reasoning_stream",
+        ).mapNotNull { key -> (element[key] as? JsonPrimitive)?.booleanOrNull }
+            .firstOrNull { it }
+        if (hasReasoning == true) return ActivityCapabilityState.ToolAndServerReasoning
+        val hasTools = sequenceOf("tools", "tool_events", "tool_activity")
+            .mapNotNull { key -> (element[key] as? JsonPrimitive)?.booleanOrNull }
+            .firstOrNull { it }
+        val explicitlySupported = sequenceOf("supported", "available")
+            .mapNotNull { key -> (element[key] as? JsonPrimitive)?.booleanOrNull }
+            .firstOrNull { it }
+        if (hasTools == true || explicitlySupported == true) return ActivityCapabilityState.ToolOnly
+        return null
     }
     val primitive = element as? JsonPrimitive ?: return null
     primitive.booleanOrNull?.let { return if (it) ActivityCapabilityState.ToolOnly else ActivityCapabilityState.Unsupported }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -647,8 +647,8 @@ class DashboardClient(
                         return
                     }
                 if ((root["id"] as? JsonPrimitive)?.contentOrNull != expectedId) return
-                (root["error"] as? JsonObject)?.let { error ->
-                    fail(IOException((error["message"] as? JsonPrimitive)?.contentOrNull ?: "$operation failed."))
+                (root["error"] as? JsonObject)?.let {
+                    fail(IOException("$operation returned a JSON-RPC error."))
                     return
                 }
                 val result = root["result"]

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -202,8 +202,8 @@ internal fun JsonElement?.isTruthy(): Boolean = when (this) {
         ?: false
 }
 
-private fun JsonElement.asObject(errorMessage: String): JsonObject =
-    this as? JsonObject ?: throw IOException(errorMessage)
+private fun JsonElement.asObject(failureCopy: String): JsonObject =
+    this as? JsonObject ?: throw IOException(failureCopy)
 
 internal fun JsonObject.string(key: String): String? =
     get(key)?.jsonPrimitive?.contentOrNull

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -104,8 +104,7 @@ suspend fun GatewayConnection.resumeStoredSession(
             ?: originKey,
         profile = firstResumeString(result, info, "profile", "profile_id", "profile_name")
             ?: profile?.trim()?.takeIf(String::isNotBlank),
-        serverReasoningAllowed = reasoningDisplayCapability(result)
-            ?: info?.let(::reasoningDisplayCapability),
+        serverReasoningAllowed = null,
     )
 }
 
@@ -117,17 +116,6 @@ private fun firstResumeString(
     .mapNotNull { key -> result.string(key) ?: info?.string(key) }
     .map(String::trim)
     .firstOrNull(String::isNotBlank)
-
-/** Read only an explicit server disclosure bit; reasoning effort is not a capability bit. */
-private fun reasoningDisplayCapability(value: JsonObject): Boolean? {
-    sequenceOf("show_reasoning", "reasoning_visible", "reasoning_enabled", "server_reasoning")
-        .mapNotNull(value::boolean)
-        .firstOrNull()
-        ?.let { return it }
-    (value["display"] as? JsonObject)?.boolean("show_reasoning")?.let { return it }
-    (value["capabilities"] as? JsonObject)?.boolean("reasoning")?.let { return it }
-    return null
-}
 
 suspend fun GatewayConnection.submitPrompt(runtimeSessionId: String, text: String): JsonObject {
     require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -173,7 +173,11 @@ private fun decodeGatewayMessage(element: JsonElement): ConversationMessage? {
         ?: row.string("content")
         ?: row.string("context")
         ?: if (role == "tool") toolName.orEmpty() else ""
-    val safeToolName = if (role == "tool") toolName?.let { sanitizeActivityText(it, 80) } else toolName
+    val safeToolName = if (role == "tool") {
+        toolName?.let { safeToolName(it, row.toolNameIsUnsafe()) }
+    } else {
+        toolName
+    }
     val safeText = if (role == "tool") {
         sanitizeActivityText(text, TOOL_ACTIVITY_DETAIL_LIMIT)
     } else {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -1,6 +1,8 @@
 package dev.hazydreams.hermesceleste.network
 
 import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -46,7 +48,11 @@ suspend fun GatewayConnection.createSession(profile: String): CreatedSession {
     )
 }
 
-suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): ResumedSession {
+suspend fun GatewayConnection.resumeStoredSession(
+    storedSessionId: String,
+    profile: String? = null,
+    originKey: NormalizedDashboardOrigin? = null,
+): ResumedSession {
     require(storedSessionId.isNotBlank()) { "Choose a Hermes session to open." }
     val result = request(
         method = "session.resume",
@@ -54,6 +60,7 @@ suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): Resu
             put("session_id", storedSessionId)
             put("cols", 96)
             put("source", "android")
+            profile?.trim()?.takeIf(String::isNotBlank)?.let { put("profile", it) }
         },
         timeoutMillis = 30_000,
     ).asObject("Hermes returned no resumed session.")
@@ -66,27 +73,60 @@ suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): Resu
     val status = result.string("status") ?: info?.string("status")
     val inflight = result["inflight"]
     val queued = result["queued"]
+    val messages = result["messages"]?.jsonArray.orEmpty()
+    val decoded = withContext(Dispatchers.Default) {
+        decodeGatewayMessages(messages) to decodeGatewayActivity(messages)
+    }
+    val resolvedStoredSessionId = sequenceOf(
+        result.string("resumed"),
+        result.string("stored_session_id"),
+        result.string("session_key"),
+        storedSessionId,
+    ).map(String?::orEmpty)
+        .map(String::trim)
+        .firstOrNull(String::isNotBlank)
+        ?: storedSessionId.trim()
 
     return ResumedSession(
-        runtimeSessionId = runtimeId,
-        storedSessionId = result.string("resumed")
-            ?: result.string("stored_session_id")
-            ?: result.string("session_key")
-            ?: storedSessionId,
-        messages = decodeGatewayMessages(result["messages"]?.jsonArray.orEmpty()),
+        runtimeSessionId = runtimeId.trim(),
+        storedSessionId = resolvedStoredSessionId,
+        messages = decoded.first,
         running = running,
         status = status,
         inflightAssistantText = inflightAssistantText(inflight),
         hasLiveProjection = inflight.isTruthy() || queued.isTruthy(),
         // The current Hermes gateway exposes durable activity through its
         // server-authored `messages` projection: role=tool rows plus explicit
-        // `reasoning`/`reasoning_content` fields on assistant rows. No guessed
-        // activity RPC or speculative snapshot key is introduced here.
-        activityItems = decodeGatewayActivity(result["messages"]?.jsonArray.orEmpty()),
-        profile = result.string("profile")
-            ?: result.string("profile_id")
-            ?: info?.string("profile_name"),
+        // `reasoning` fields on assistant rows. Provider-facing
+        // `reasoning_content` is intentionally ignored by decodeGatewayActivity.
+        activityItems = decoded.second,
+        originKey = firstResumeString(result, info, "origin_key", "origin", "dashboard_origin", "base_url")
+            ?: originKey,
+        profile = firstResumeString(result, info, "profile", "profile_id", "profile_name")
+            ?: profile?.trim()?.takeIf(String::isNotBlank),
+        serverReasoningAllowed = reasoningDisplayCapability(result)
+            ?: info?.let(::reasoningDisplayCapability),
     )
+}
+
+private fun firstResumeString(
+    result: JsonObject,
+    info: JsonObject?,
+    vararg keys: String,
+): String? = keys.asSequence()
+    .mapNotNull { key -> result.string(key) ?: info?.string(key) }
+    .map(String::trim)
+    .firstOrNull(String::isNotBlank)
+
+/** Read only an explicit server disclosure bit; reasoning effort is not a capability bit. */
+private fun reasoningDisplayCapability(value: JsonObject): Boolean? {
+    sequenceOf("show_reasoning", "reasoning_visible", "reasoning_enabled", "server_reasoning")
+        .mapNotNull(value::boolean)
+        .firstOrNull()
+        ?.let { return it }
+    (value["display"] as? JsonObject)?.boolean("show_reasoning")?.let { return it }
+    (value["capabilities"] as? JsonObject)?.boolean("reasoning")?.let { return it }
+    return null
 }
 
 suspend fun GatewayConnection.submitPrompt(runtimeSessionId: String, text: String): JsonObject {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -78,6 +78,14 @@ suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): Resu
         status = status,
         inflightAssistantText = inflightAssistantText(inflight),
         hasLiveProjection = inflight.isTruthy() || queued.isTruthy(),
+        // The current Hermes gateway exposes durable activity through its
+        // server-authored `messages` projection: role=tool rows plus explicit
+        // `reasoning`/`reasoning_content` fields on assistant rows. No guessed
+        // activity RPC or speculative snapshot key is introduced here.
+        activityItems = decodeGatewayActivity(result["messages"]?.jsonArray.orEmpty()),
+        profile = result.string("profile")
+            ?: result.string("profile_id")
+            ?: info?.string("profile_name"),
     )
 }
 
@@ -125,10 +133,16 @@ private fun decodeGatewayMessage(element: JsonElement): ConversationMessage? {
         ?: row.string("content")
         ?: row.string("context")
         ?: if (role == "tool") toolName.orEmpty() else ""
+    val safeToolName = if (role == "tool") toolName?.let { sanitizeActivityText(it, 80) } else toolName
+    val safeText = if (role == "tool") {
+        sanitizeActivityText(text, TOOL_ACTIVITY_DETAIL_LIMIT)
+    } else {
+        text
+    }
     return ConversationMessage(
         role = role,
-        text = text,
-        toolName = toolName,
+        text = safeText,
+        toolName = safeToolName,
         id = row["row_id"].scalarIdentity()?.let { "row-$it" }
             ?: row["id"].scalarIdentity()
             ?: row["message_id"].scalarIdentity(),
@@ -138,7 +152,7 @@ private fun decodeGatewayMessage(element: JsonElement): ConversationMessage? {
 private fun JsonElement?.scalarIdentity(): String? =
     (this as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
 
-private fun inflightAssistantText(element: JsonElement?): String {
+internal fun inflightAssistantText(element: JsonElement?): String {
     val row = element as? JsonObject ?: return ""
     return sequenceOf("assistant", "text", "content")
         .mapNotNull(row::string)
@@ -146,7 +160,7 @@ private fun inflightAssistantText(element: JsonElement?): String {
         .orEmpty()
 }
 
-private fun JsonElement?.isTruthy(): Boolean = when (this) {
+internal fun JsonElement?.isTruthy(): Boolean = when (this) {
     null, JsonNull -> false
     is JsonObject, is JsonArray -> true
     is JsonPrimitive -> booleanOrNull

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -39,6 +39,10 @@ data class GatewayEvent(
     val type: String,
     val sessionId: String,
     val payload: JsonObject,
+    /** Optional local binding metadata; the wire event remains generic JSON-RPC. */
+    val originKey: NormalizedDashboardOrigin? = null,
+    val profile: String? = null,
+    val storedSessionId: String? = null,
 )
 
 class GatewayRpcException(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -39,7 +39,9 @@ data class GatewayEvent(
     val type: String,
     val sessionId: String,
     val payload: JsonObject,
-    /** Optional local binding metadata; the wire event remains generic JSON-RPC. */
+    /** Server event identity, when the gateway supplies one outside the payload. */
+    val eventId: String? = null,
+    /** Optional binding metadata decoded from the event envelope/payload. */
     val originKey: NormalizedDashboardOrigin? = null,
     val profile: String? = null,
     val storedSessionId: String? = null,
@@ -251,14 +253,49 @@ class HermesGateway(
         val params = root["params"] as? JsonObject ?: return
         val type = params["type"]?.jsonPrimitive?.contentOrNull.orEmpty()
         if (type.isBlank()) return
+        val payload = params["payload"] as? JsonObject ?: JsonObject(emptyMap())
+        val binding = params["binding"] as? JsonObject
         mutableEvents.tryEmit(
             GatewayEvent(
                 type = type,
                 sessionId = params["session_id"]?.jsonPrimitive?.contentOrNull.orEmpty(),
-                payload = params["payload"] as? JsonObject ?: JsonObject(emptyMap()),
+                payload = payload,
+                eventId = firstNonBlankString(root, "event_id", "eventId", "event_seq", "seq")
+                    ?: firstNonBlankString(params, "event_id", "eventId", "event_seq", "seq")
+                    ?: firstNonBlankString(binding, "event_id", "eventId", "event_seq", "seq")
+                    ?: firstNonBlankString(payload, "event_id", "eventId", "event_seq", "seq"),
+                originKey = firstNonBlankString(params, "origin_key", "origin", "dashboard_origin", "base_url")
+                    ?: firstNonBlankString(binding, "origin_key", "origin", "dashboard_origin", "base_url")
+                    ?: firstNonBlankString(payload, "origin_key", "origin", "dashboard_origin", "base_url"),
+                profile = firstNonBlankString(params, "profile", "profile_name")
+                    ?: firstNonBlankString(binding, "profile", "profile_name")
+                    ?: firstNonBlankString(payload, "profile", "profile_name"),
+                storedSessionId = firstNonBlankString(
+                    params,
+                    "stored_session_id",
+                    "session_key",
+                    "stored_id",
+                ) ?: firstNonBlankString(
+                    binding,
+                    "stored_session_id",
+                    "session_key",
+                    "stored_id",
+                ) ?: firstNonBlankString(
+                    payload,
+                    "stored_session_id",
+                    "session_key",
+                    "stored_id",
+                ),
             ),
         )
     }
+
+    private fun firstNonBlankString(objectValue: JsonObject?, vararg keys: String): String? =
+        objectValue?.let { value ->
+            keys.asSequence()
+                .mapNotNull { key -> (value[key] as? JsonPrimitive)?.contentOrNull?.trim() }
+                .firstOrNull(String::isNotBlank)
+        }
 
     private fun handleDisconnect(
         reason: String,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/HermesGateway.kt
@@ -4,6 +4,8 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -108,10 +110,10 @@ class HermesGateway(
 
         val endpoint = try {
             endpointProvider()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
-            mutableState.value = GatewayConnectionState.Disconnected(
-                error.message ?: "Could not refresh the Hermes connection.",
-            )
+            mutableState.value = GatewayConnectionState.Disconnected(safeDisconnectReason(error))
             throw error
         }
 
@@ -151,22 +153,19 @@ class HermesGateway(
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 if (generation != socketGeneration.get()) return
                 handleDisconnect(
-                    reason = reason.ifBlank { "Hermes closed the connection ($code)." },
+                    reason = "Hermes connection closed.",
                     opened = opened,
                 )
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 if (generation != socketGeneration.get()) return
-                val reason = when (response?.code) {
-                    401, 403 -> "Hermes rejected the dashboard credential."
-                    else -> t.message ?: "The Hermes connection failed."
-                }
                 val error = when (response?.code) {
-                    401, 403 -> AuthenticationRejected(reason)
-                    else -> IOException(reason, t)
+                    401, 403 -> AuthenticationRejected("Hermes rejected the dashboard credential.")
+                    429 -> RateLimited("Hermes rate-limited the dashboard connection.")
+                    else -> TransportUnavailable("Could not open the Hermes connection.", t)
                 }
-                handleDisconnect(reason, opened, error)
+                handleDisconnect(safeDisconnectReason(error), opened, error)
             }
         }
 
@@ -174,14 +173,23 @@ class HermesGateway(
         socket = candidate
         try {
             withTimeout(connectTimeoutMillis) { opened.await() }
+        } catch (error: CancellationException) {
+            if (socket === candidate) {
+                candidate.cancel()
+                socket = null
+                if (error is TimeoutCancellationException &&
+                    mutableState.value !is GatewayConnectionState.Disconnected
+                ) {
+                    mutableState.value = GatewayConnectionState.Disconnected(safeDisconnectReason(error))
+                }
+            }
+            throw error
         } catch (error: Throwable) {
             if (socket === candidate) {
                 candidate.cancel()
                 socket = null
                 if (mutableState.value !is GatewayConnectionState.Disconnected) {
-                    mutableState.value = GatewayConnectionState.Disconnected(
-                        error.message ?: "Hermes did not finish connecting.",
-                    )
+                    mutableState.value = GatewayConnectionState.Disconnected(safeDisconnectReason(error))
                 }
             }
             throw error
@@ -239,8 +247,7 @@ class HermesGateway(
                 deferred.completeExceptionally(
                     GatewayRpcException(
                         code = error["code"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
-                        message = error["message"]?.jsonPrimitive?.contentOrNull
-                            ?: "Hermes request failed.",
+                        message = "Hermes request failed.",
                     ),
                 )
             } else {
@@ -296,6 +303,15 @@ class HermesGateway(
                 .mapNotNull { key -> (value[key] as? JsonPrimitive)?.contentOrNull?.trim() }
                 .firstOrNull(String::isNotBlank)
         }
+
+    private fun safeDisconnectReason(error: Throwable): String = when (error) {
+        is AuthenticationRejected -> "Hermes rejected the dashboard credential."
+        is RateLimited -> "Hermes is busy right now."
+        is InvalidDashboardResponse -> "Hermes returned an unexpected response."
+        is TransportUnavailable -> "Hermes is unavailable right now."
+        is TimeoutCancellationException -> "Hermes did not finish connecting."
+        else -> "The Hermes connection failed."
+    }
 
     private fun handleDisconnect(
         reason: String,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -87,10 +87,13 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     turnState = ui.turnState,
                     loadingMessage = ui.loadingMessage,
                     errorMessage = ui.errorMessage,
+                    agentActivity = ui.agentActivity,
+                    reasoningDisclosureEnabled = ui.agentActivityReasoningDisclosureEnabled,
                     onDraftChange = viewModel::updateDraft,
                     onSend = viewModel::sendMessage,
                     onInterrupt = viewModel::interrupt,
                     onReconnect = viewModel::reconnectNow,
+                    onReasoningDisclosureChange = viewModel::setActivityReasoningDisclosureEnabled,
                     onBack = viewModel::leaveConversation,
                 )
             }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -86,7 +86,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     draft = ui.draft,
                     turnState = ui.turnState,
                     loadingMessage = ui.loadingMessage,
-                    errorMessage = ui.errorMessage,
+                    notice = ui.notice,
                     agentActivity = ui.agentActivity,
                     reasoningDisclosureEnabled = ui.agentActivityReasoningDisclosureEnabled,
                     onDraftChange = viewModel::updateDraft,
@@ -103,7 +103,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 profiles = ui.profiles,
                 selectedProfile = ui.selectedProfile,
                 loadingMessage = ui.loadingMessage,
-                errorMessage = ui.errorMessage,
+                notice = ui.notice,
                 onProfileSelected = viewModel::selectProfile,
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,
@@ -114,7 +114,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 ui.connectionPhase == ConnectionPhase.Restoring -> ConnectionLoadingScreen()
 
             ui.connectionPhase == ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(
-                errorMessage = ui.errorMessage,
+                notice = ui.notice,
                 onRetry = viewModel::retrySavedConnection,
                 onSettings = { destination = CelesteDestination.Gateway },
             )
@@ -146,7 +146,7 @@ private fun GatewaySettingsRoute(
             sessionToken = ui.sessionToken,
             connectionPhase = ui.connectionPhase,
             loadingMessage = ui.loadingMessage,
-            errorMessage = ui.errorMessage,
+            notice = ui.notice,
         ),
         actions = GatewaySettingsActions(
             onUsernameChange = viewModel::updateUsername,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -93,8 +93,12 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     onSend = viewModel::sendMessage,
                     onInterrupt = viewModel::interrupt,
                     onReconnect = viewModel::reconnectNow,
-                    onReasoningDisclosureChange = viewModel::setActivityReasoningDisclosureEnabled,
                     onBack = viewModel::leaveConversation,
+                    onSignIn = {
+                        viewModel.signOut()
+                        destination = CelesteDestination.Gateway
+                    },
+                    onReasoningDisclosureChange = viewModel::setActivityReasoningDisclosureEnabled,
                 )
             }
 
@@ -108,6 +112,11 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,
                 onSettings = { destination = CelesteDestination.Settings },
+                onRetry = viewModel::retrySavedConnection,
+                onSignIn = {
+                    viewModel.signOut()
+                    destination = CelesteDestination.Gateway
+                },
             )
 
             ui.connectionPhase == ConnectionPhase.CheckingSavedConnection ||
@@ -116,6 +125,10 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
             ui.connectionPhase == ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(
                 notice = ui.notice,
                 onRetry = viewModel::retrySavedConnection,
+                onSignIn = {
+                    viewModel.signOut()
+                    destination = CelesteDestination.Gateway
+                },
                 onSettings = { destination = CelesteDestination.Gateway },
             )
 
@@ -158,6 +171,7 @@ private fun GatewaySettingsRoute(
             },
             onConnect = viewModel::loadSessions,
             onRetry = viewModel::retrySavedConnection,
+            onSignIn = viewModel::loadSessions,
             onSignOut = viewModel::signOut,
             onForgetConnection = viewModel::forgetConnection,
             onBack = onBack,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/UiNoticeMessage.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/UiNoticeMessage.kt
@@ -1,0 +1,52 @@
+package dev.hazydreams.hermesceleste.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.hazydreams.hermesceleste.UiNotice
+import dev.hazydreams.hermesceleste.UiRecoveryAction
+
+/** Render a product notice without exposing exception or server-provided text. */
+@Composable
+internal fun UiNoticeMessage(
+    notice: UiNotice,
+    onRetry: () -> Unit = {},
+    onSignIn: () -> Unit = {},
+    showRecoveryAction: Boolean = true,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        StatusMessage(notice.message, CelesteError)
+        if (showRecoveryAction) {
+            when (notice.recovery) {
+                UiRecoveryAction.None -> Unit
+                UiRecoveryAction.Retry -> RecoveryActionButton(
+                    label = notice.recoveryLabel ?: "Retry",
+                    onClick = onRetry,
+                )
+                UiRecoveryAction.SignIn -> RecoveryActionButton(
+                    label = notice.recoveryLabel ?: "Sign in",
+                    onClick = onSignIn,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecoveryActionButton(label: String, onClick: () -> Unit) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.heightIn(min = 48.dp),
+    ) {
+        Text(label, color = CelesteBlue)
+    }
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
@@ -79,6 +79,19 @@ internal fun activityItemKeys(items: List<ActivityItem>): List<String> {
     }
 }
 
+/**
+ * Tracks phase announcements per rendered card. Repeated progress updates and
+ * recompositions must not make TalkBack repeat the same lifecycle state.
+ */
+internal class ActivityPhaseAnnouncementTracker {
+    private val announced = mutableSetOf<String>()
+
+    fun consume(itemKey: String, phase: String): Boolean {
+        if (itemKey.isBlank() || phase.isBlank()) return false
+        return announced.add("$itemKey|$phase")
+    }
+}
+
 @Composable
 internal fun AgentActivityPanel(
     projection: AgentActivityProjection,
@@ -93,6 +106,7 @@ internal fun AgentActivityPanel(
     val activityScopeKey = "${projection.originKey}|${projection.profile}|${projection.storedSessionId}"
     var expandedItemKey by remember(activityScopeKey) { mutableStateOf<String?>(null) }
     val keys = remember(projection.items) { activityItemKeys(projection.items) }
+    val announcementTracker = remember(activityScopeKey) { ActivityPhaseAnnouncementTracker() }
     val hasReasoningCapability =
         projection.capability == ActivityCapabilityState.ToolAndServerReasoning ||
             projection.serverReasoningAllowed == true
@@ -221,6 +235,10 @@ internal fun AgentActivityPanel(
                             ActivityCard(
                                 item = item,
                                 expanded = expandedItemKey == keys[index],
+                                announcePhase = announcementTracker.consume(
+                                    itemKey = keys[index],
+                                    phase = activityPhaseAnnouncementToken(item),
+                                ),
                                 onToggle = {
                                     expandedItemKey = if (expandedItemKey == keys[index]) {
                                         null
@@ -241,6 +259,7 @@ internal fun AgentActivityPanel(
 private fun ActivityCard(
     item: ActivityItem,
     expanded: Boolean,
+    announcePhase: Boolean,
     onToggle: () -> Unit,
 ) {
     val summary = activitySummary(item)
@@ -259,8 +278,8 @@ private fun ActivityCard(
             .padding(horizontal = 13.dp, vertical = 11.dp),
     ) {
         when (item) {
-            is ToolActivity -> ToolCardHeader(item, expanded)
-            is ServerReasoningActivity -> ReasoningCardHeader(item, expanded)
+            is ToolActivity -> ToolCardHeader(item, expanded, announcePhase)
+            is ServerReasoningActivity -> ReasoningCardHeader(item, expanded, announcePhase)
         }
         if (!expanded) {
             Spacer(Modifier.height(4.dp))
@@ -282,7 +301,7 @@ private fun ActivityCard(
 }
 
 @Composable
-private fun ToolCardHeader(item: ToolActivity, expanded: Boolean) {
+private fun ToolCardHeader(item: ToolActivity, expanded: Boolean, announcePhase: Boolean) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = "Tool",
@@ -306,7 +325,7 @@ private fun ToolCardHeader(item: ToolActivity, expanded: Boolean) {
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.semantics {
                 contentDescription = "Tool, ${activityAnnouncementPhase(item.phase)}"
-                liveRegion = LiveRegionMode.Polite
+                if (announcePhase) liveRegion = LiveRegionMode.Polite
             },
         )
         Spacer(Modifier.size(7.dp))
@@ -322,7 +341,11 @@ private fun ToolCardHeader(item: ToolActivity, expanded: Boolean) {
 }
 
 @Composable
-private fun ReasoningCardHeader(item: ServerReasoningActivity, expanded: Boolean) {
+private fun ReasoningCardHeader(
+    item: ServerReasoningActivity,
+    expanded: Boolean,
+    announcePhase: Boolean,
+) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = item.serverLabel ?: "Server-provided reasoning",
@@ -338,7 +361,7 @@ private fun ReasoningCardHeader(item: ServerReasoningActivity, expanded: Boolean
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.semantics {
                 contentDescription = "Server-provided reasoning, ${reasoningAnnouncementPhase(item.phase)}"
-                liveRegion = LiveRegionMode.Polite
+                if (announcePhase) liveRegion = LiveRegionMode.Polite
             },
         )
         Spacer(Modifier.size(7.dp))
@@ -436,6 +459,11 @@ internal fun reasoningAnnouncementPhase(phase: ReasoningPhase): String = when (p
     ReasoningPhase.Streaming -> "streaming"
     ReasoningPhase.Complete -> "complete"
     ReasoningPhase.Unavailable -> "unavailable"
+}
+
+private fun activityPhaseAnnouncementToken(item: ActivityItem): String = when (item) {
+    is ToolActivity -> "tool:${activityAnnouncementPhase(item.phase)}"
+    is ServerReasoningActivity -> "reasoning:${reasoningAnnouncementPhase(item.phase)}"
 }
 
 internal fun activityDetailContentDescription(label: String): String =

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -303,6 +304,10 @@ private fun ToolCardHeader(item: ToolActivity, expanded: Boolean) {
             color = toolPhaseColor(item.phase),
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                contentDescription = "Tool, ${activityAnnouncementPhase(item.phase)}"
+                liveRegion = LiveRegionMode.Polite
+            },
         )
         Spacer(Modifier.size(7.dp))
         Text(if (expanded) "⌃" else "⌄", color = CelesteBlue, fontSize = 17.sp)
@@ -331,6 +336,10 @@ private fun ReasoningCardHeader(item: ServerReasoningActivity, expanded: Boolean
             color = CelesteBlue,
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics {
+                contentDescription = "Server-provided reasoning, ${reasoningAnnouncementPhase(item.phase)}"
+                liveRegion = LiveRegionMode.Polite
+            },
         )
         Spacer(Modifier.size(7.dp))
         Text(if (expanded) "⌃" else "⌄", color = CelesteBlue, fontSize = 17.sp)
@@ -379,11 +388,16 @@ private fun ActivityDetailBlock(label: String, detail: DisplayedDetail) {
                 Text(if (copied) "Displayed detail copied" else "Copy")
             }
         }
-        Text(
-            text = detail.text,
-            color = CelesteInk,
-            style = MaterialTheme.typography.bodySmall,
-        )
+        SelectionContainer {
+            Text(
+                text = detail.text,
+                color = CelesteInk,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.semantics {
+                    contentDescription = activityDetailContentDescription(label)
+                },
+            )
+        }
         if (detail.wasTruncated) {
             Text(
                 text = "More content is unavailable in this view.",
@@ -409,6 +423,23 @@ private fun DetailUnavailable() {
         style = MaterialTheme.typography.bodySmall,
     )
 }
+
+internal fun activityAnnouncementPhase(phase: ToolPhase): String = when (phase) {
+    ToolPhase.Started,
+    ToolPhase.Running -> "running"
+    ToolPhase.Completed -> "completed"
+    ToolPhase.Failed -> "error"
+    ToolPhase.Interrupted -> "interrupted"
+}
+
+internal fun reasoningAnnouncementPhase(phase: ReasoningPhase): String = when (phase) {
+    ReasoningPhase.Streaming -> "streaming"
+    ReasoningPhase.Complete -> "complete"
+    ReasoningPhase.Unavailable -> "unavailable"
+}
+
+internal fun activityDetailContentDescription(label: String): String =
+    "$label, selectable displayed detail"
 
 private fun activityPresentationLabel(state: ActivityPresentationState): String = when (state) {
     ActivityPresentationState.Unknown -> "Checking activity support"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
@@ -12,16 +12,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -30,8 +29,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -65,8 +66,11 @@ import dev.hazydreams.hermesceleste.ui.CelestePanelRaised
  */
 internal fun activityItemKeys(items: List<ActivityItem>): List<String> {
     val occurrences = mutableMapOf<String, Int>()
-    return items.mapIndexed { index, item ->
-        val base = item.uiKey.takeIf(String::isNotBlank) ?: "fallback:$index"
+    return items.map { item ->
+        val base = item.uiKey.takeIf(String::isNotBlank) ?: when (item) {
+            is ToolActivity -> "fallback:tool:${item.callId ?: item.name}"
+            is ServerReasoningActivity -> "fallback:reasoning:${item.source}"
+        }
         val occurrence = occurrences.getOrDefault(base, 0) + 1
         occurrences[base] = occurrence
         val key = "activity-ui:${base.length}:$base"
@@ -80,13 +84,17 @@ internal fun AgentActivityPanel(
     reasoningDisclosureEnabled: Boolean,
     onReasoningDisclosureChange: (Boolean) -> Unit,
 ) {
-    var expanded by rememberSaveable(projection.storedSessionId) { mutableStateOf(false) }
-    var expandedItemKey by remember(projection.storedSessionId) { mutableStateOf<String?>(null) }
+    var expanded by rememberSaveable(
+        projection.originKey,
+        projection.profile,
+        projection.storedSessionId,
+    ) { mutableStateOf(false) }
+    val activityScopeKey = "${projection.originKey}|${projection.profile}|${projection.storedSessionId}"
+    var expandedItemKey by remember(activityScopeKey) { mutableStateOf<String?>(null) }
     val keys = remember(projection.items) { activityItemKeys(projection.items) }
-    val detailsScrollState = rememberScrollState()
     val hasReasoningCapability =
         projection.capability == ActivityCapabilityState.ToolAndServerReasoning ||
-            !reasoningDisclosureEnabled
+            projection.serverReasoningAllowed == true
     val stateLabel = activityPresentationLabel(projection.presentation)
 
     Column(
@@ -118,6 +126,9 @@ internal fun AgentActivityPanel(
                     text = stateLabel,
                     color = activityPresentationColor(projection.presentation),
                     style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    },
                 )
             }
             if (projection.items.isNotEmpty()) {
@@ -143,7 +154,6 @@ internal fun AgentActivityPanel(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(max = 320.dp)
-                    .verticalScroll(detailsScrollState)
                     .background(CelestePanel, RoundedCornerShape(16.dp))
                     .border(1.dp, CelesteHairline, RoundedCornerShape(16.dp))
                     .padding(horizontal = 14.dp, vertical = 12.dp),
@@ -199,8 +209,14 @@ internal fun AgentActivityPanel(
                         style = MaterialTheme.typography.bodySmall,
                     )
                 } else {
-                    projection.items.forEachIndexed { index, item ->
-                        key(keys[index]) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        itemsIndexed(
+                            items = projection.items,
+                            key = { index, _ -> keys[index] },
+                        ) { index, item ->
                             ActivityCard(
                                 item = item,
                                 expanded = expandedItemKey == keys[index],
@@ -323,11 +339,12 @@ private fun ReasoningCardHeader(item: ServerReasoningActivity, expanded: Boolean
 
 @Composable
 private fun ToolCardDetails(item: ToolActivity) {
-    if (item.input == null && item.output == null) {
+    if (item.input == null && item.progress == null && item.output == null) {
         DetailUnavailable()
         return
     }
     item.input?.let { ActivityDetailBlock(label = "Displayed input", detail = it) }
+    item.progress?.let { ActivityDetailBlock(label = "Displayed progress", detail = it) }
     item.output?.let { ActivityDetailBlock(label = "Displayed output", detail = it) }
 }
 
@@ -416,6 +433,7 @@ private fun activityPresentationColor(state: ActivityPresentationState): Color =
 private fun activitySummary(item: ActivityItem): String = when (item) {
     is ToolActivity -> buildString {
         append(toolPhaseLabel(item.phase))
+        if (item.progress != null) append(" · displayed progress available")
         if (item.output != null) append(" · displayed output available")
         else if (item.input != null) append(" · displayed input available")
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCards.kt
@@ -1,0 +1,460 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
+import dev.hazydreams.hermesceleste.network.ActivityItem
+import dev.hazydreams.hermesceleste.network.ActivityPresentationState
+import dev.hazydreams.hermesceleste.network.AgentActivityProjection
+import dev.hazydreams.hermesceleste.network.CorrelationQuality
+import dev.hazydreams.hermesceleste.network.DisplayedDetail
+import dev.hazydreams.hermesceleste.network.ReasoningPhase
+import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
+import dev.hazydreams.hermesceleste.network.ToolActivity
+import dev.hazydreams.hermesceleste.network.ToolPhase
+import dev.hazydreams.hermesceleste.ui.CelesteBlue
+import dev.hazydreams.hermesceleste.ui.CelesteGoldText
+import dev.hazydreams.hermesceleste.ui.CelesteHairline
+import dev.hazydreams.hermesceleste.ui.CelesteInk
+import dev.hazydreams.hermesceleste.ui.CelesteMuted
+import dev.hazydreams.hermesceleste.ui.CelestePanel
+import dev.hazydreams.hermesceleste.ui.CelestePanelRaised
+
+/**
+ * Compose-only identity for activity rows. The reducer owns the source identity;
+ * this helper only makes duplicate or malformed UI keys safe for LazyColumn and
+ * local recomposition.
+ */
+internal fun activityItemKeys(items: List<ActivityItem>): List<String> {
+    val occurrences = mutableMapOf<String, Int>()
+    return items.mapIndexed { index, item ->
+        val base = item.uiKey.takeIf(String::isNotBlank) ?: "fallback:$index"
+        val occurrence = occurrences.getOrDefault(base, 0) + 1
+        occurrences[base] = occurrence
+        val key = "activity-ui:${base.length}:$base"
+        if (occurrence == 1) key else "$key:occurrence:$occurrence"
+    }
+}
+
+@Composable
+internal fun AgentActivityPanel(
+    projection: AgentActivityProjection,
+    reasoningDisclosureEnabled: Boolean,
+    onReasoningDisclosureChange: (Boolean) -> Unit,
+) {
+    var expanded by rememberSaveable(projection.storedSessionId) { mutableStateOf(false) }
+    var expandedItemKey by remember(projection.storedSessionId) { mutableStateOf<String?>(null) }
+    val keys = remember(projection.items) { activityItemKeys(projection.items) }
+    val detailsScrollState = rememberScrollState()
+    val hasReasoningCapability =
+        projection.capability == ActivityCapabilityState.ToolAndServerReasoning ||
+            !reasoningDisclosureEnabled
+    val stateLabel = activityPresentationLabel(projection.presentation)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .clickable { expanded = !expanded }
+                .semantics {
+                    contentDescription = "Agent activity, $stateLabel"
+                    stateDescription = if (expanded) "Expanded" else "Collapsed"
+                    role = Role.Button
+                }
+                .padding(horizontal = 14.dp, vertical = 9.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = "Agent activity",
+                    color = CelesteInk,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stateLabel,
+                    color = activityPresentationColor(projection.presentation),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+            if (projection.items.isNotEmpty()) {
+                Text(
+                    text = projection.items.size.toString(),
+                    color = CelesteMuted,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(end = 10.dp),
+                )
+            }
+            Text(
+                text = if (expanded) "⌃" else "⌄",
+                color = CelesteBlue,
+                fontSize = 20.sp,
+                modifier = Modifier.semantics {
+                    contentDescription = if (expanded) "Collapse activity" else "Expand activity"
+                },
+            )
+        }
+
+        if (expanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 320.dp)
+                    .verticalScroll(detailsScrollState)
+                    .background(CelestePanel, RoundedCornerShape(16.dp))
+                    .border(1.dp, CelesteHairline, RoundedCornerShape(16.dp))
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                if (hasReasoningCapability) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 48.dp)
+                            .semantics {
+                                contentDescription = "Show server-provided reasoning"
+                                stateDescription = if (reasoningDisclosureEnabled) "On" else "Off"
+                            },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                text = "Server-provided reasoning",
+                                color = CelesteInk,
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                            Text(
+                                text = if (reasoningDisclosureEnabled) {
+                                    "Only explicitly labelled Hermes content is shown."
+                                } else {
+                                    "Hidden on this device; no private detail is retained here."
+                                },
+                                color = CelesteMuted,
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        }
+                        Switch(
+                            checked = reasoningDisclosureEnabled,
+                            onCheckedChange = onReasoningDisclosureChange,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Show server-provided reasoning"
+                            },
+                        )
+                    }
+                }
+
+                if (projection.items.isEmpty()) {
+                    Text(
+                        text = when (projection.presentation) {
+                            ActivityPresentationState.Discovering -> "Checking activity support."
+                            ActivityPresentationState.Restoring -> "Restoring activity from Hermes."
+                            ActivityPresentationState.Stale -> "Activity details will return after reconnect."
+                            ActivityPresentationState.Unavailable -> "This Hermes version does not expose activity details."
+                            else -> "No activity details are available for this turn."
+                        },
+                        color = CelesteMuted,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                } else {
+                    projection.items.forEachIndexed { index, item ->
+                        key(keys[index]) {
+                            ActivityCard(
+                                item = item,
+                                expanded = expandedItemKey == keys[index],
+                                onToggle = {
+                                    expandedItemKey = if (expandedItemKey == keys[index]) {
+                                        null
+                                    } else {
+                                        keys[index]
+                                    }
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActivityCard(
+    item: ActivityItem,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    val summary = activitySummary(item)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .background(CelestePanelRaised.copy(alpha = 0.72f), RoundedCornerShape(13.dp))
+            .border(1.dp, CelesteHairline, RoundedCornerShape(13.dp))
+            .clickable(onClick = onToggle)
+            .semantics {
+                contentDescription = activityContentDescription(item)
+                stateDescription = if (expanded) "Expanded" else "Collapsed"
+                role = Role.Button
+            }
+            .padding(horizontal = 13.dp, vertical = 11.dp),
+    ) {
+        when (item) {
+            is ToolActivity -> ToolCardHeader(item, expanded)
+            is ServerReasoningActivity -> ReasoningCardHeader(item, expanded)
+        }
+        if (!expanded) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = summary,
+                color = CelesteMuted,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        } else {
+            Spacer(Modifier.height(9.dp))
+            when (item) {
+                is ToolActivity -> ToolCardDetails(item)
+                is ServerReasoningActivity -> ReasoningCardDetails(item)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToolCardHeader(item: ToolActivity, expanded: Boolean) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = "Tool",
+            color = CelesteGoldText,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.size(7.dp))
+        Text(
+            text = item.name,
+            color = CelesteInk,
+            style = MaterialTheme.typography.labelLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = toolPhaseLabel(item.phase),
+            color = toolPhaseColor(item.phase),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.size(7.dp))
+        Text(if (expanded) "⌃" else "⌄", color = CelesteBlue, fontSize = 17.sp)
+    }
+    if (item.correlation != CorrelationQuality.ExactId) {
+        Text(
+            text = correlationLabel(item.correlation),
+            color = CelesteMuted,
+            style = MaterialTheme.typography.labelSmall,
+        )
+    }
+}
+
+@Composable
+private fun ReasoningCardHeader(item: ServerReasoningActivity, expanded: Boolean) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = item.serverLabel ?: "Server-provided reasoning",
+            color = CelesteBlue,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = reasoningPhaseLabel(item.phase),
+            color = CelesteBlue,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.size(7.dp))
+        Text(if (expanded) "⌃" else "⌄", color = CelesteBlue, fontSize = 17.sp)
+    }
+}
+
+@Composable
+private fun ToolCardDetails(item: ToolActivity) {
+    if (item.input == null && item.output == null) {
+        DetailUnavailable()
+        return
+    }
+    item.input?.let { ActivityDetailBlock(label = "Displayed input", detail = it) }
+    item.output?.let { ActivityDetailBlock(label = "Displayed output", detail = it) }
+}
+
+@Composable
+private fun ReasoningCardDetails(item: ServerReasoningActivity) {
+    if (item.phase == ReasoningPhase.Unavailable || item.text.text.isBlank()) {
+        DetailUnavailable()
+    } else {
+        ActivityDetailBlock(label = "Server-provided reasoning", detail = item.text)
+    }
+}
+
+@Composable
+private fun ActivityDetailBlock(label: String, detail: DisplayedDetail) {
+    var copied by remember(detail.text) { mutableStateOf(false) }
+    val clipboard = LocalClipboardManager.current
+    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                color = CelesteMuted,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(
+                onClick = {
+                    clipboard.setText(AnnotatedString(detail.text))
+                    copied = true
+                },
+                modifier = Modifier.heightIn(min = 48.dp),
+            ) {
+                Text(if (copied) "Displayed detail copied" else "Copy")
+            }
+        }
+        Text(
+            text = detail.text,
+            color = CelesteInk,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        if (detail.wasTruncated) {
+            Text(
+                text = "More content is unavailable in this view.",
+                color = CelesteMuted,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        if (detail.wasRedacted) {
+            Text(
+                text = "Sensitive detail hidden.",
+                color = CelesteMuted,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailUnavailable() {
+    Text(
+        text = "Details hidden or unavailable.",
+        color = CelesteMuted,
+        style = MaterialTheme.typography.bodySmall,
+    )
+}
+
+private fun activityPresentationLabel(state: ActivityPresentationState): String = when (state) {
+    ActivityPresentationState.Unknown -> "Checking activity support"
+    ActivityPresentationState.Discovering -> "Checking activity support"
+    ActivityPresentationState.Available -> "Available"
+    ActivityPresentationState.Running -> "Working"
+    ActivityPresentationState.Stale -> "Reconnecting"
+    ActivityPresentationState.Restoring -> "Restoring activity"
+    ActivityPresentationState.Unavailable -> "Unavailable"
+}
+
+private fun activityPresentationColor(state: ActivityPresentationState): Color = when (state) {
+    ActivityPresentationState.Running -> CelesteGoldText
+    ActivityPresentationState.Stale,
+    ActivityPresentationState.Restoring,
+    ActivityPresentationState.Discovering,
+    ActivityPresentationState.Unknown -> CelesteBlue
+    ActivityPresentationState.Available -> CelesteMuted
+    ActivityPresentationState.Unavailable -> CelesteMuted
+}
+
+private fun activitySummary(item: ActivityItem): String = when (item) {
+    is ToolActivity -> buildString {
+        append(toolPhaseLabel(item.phase))
+        if (item.output != null) append(" · displayed output available")
+        else if (item.input != null) append(" · displayed input available")
+    }
+    is ServerReasoningActivity -> when (item.phase) {
+        ReasoningPhase.Streaming -> "Server-provided content is streaming"
+        ReasoningPhase.Complete -> "Server-provided content is complete"
+        ReasoningPhase.Unavailable -> "Details hidden or unavailable"
+    }
+}
+
+private fun activityContentDescription(item: ActivityItem): String = when (item) {
+    is ToolActivity -> "Tool ${item.name}, ${toolPhaseLabel(item.phase)}"
+    is ServerReasoningActivity -> "Server-provided reasoning, ${reasoningPhaseLabel(item.phase)}"
+}
+
+private fun toolPhaseLabel(phase: ToolPhase): String = when (phase) {
+    ToolPhase.Started -> "Started"
+    ToolPhase.Running -> "Running"
+    ToolPhase.Completed -> "Completed"
+    ToolPhase.Failed -> "Failed"
+    ToolPhase.Interrupted -> "Interrupted"
+}
+
+private fun toolPhaseColor(phase: ToolPhase): Color = when (phase) {
+    ToolPhase.Failed,
+    ToolPhase.Interrupted -> CelesteMuted
+    ToolPhase.Started,
+    ToolPhase.Running -> CelesteGoldText
+    ToolPhase.Completed -> CelesteInk
+}
+
+private fun reasoningPhaseLabel(phase: ReasoningPhase): String = when (phase) {
+    ReasoningPhase.Streaming -> "Streaming"
+    ReasoningPhase.Complete -> "Complete"
+    ReasoningPhase.Unavailable -> "Unavailable"
+}
+
+private fun correlationLabel(correlation: CorrelationQuality): String = when (correlation) {
+    CorrelationQuality.ExactId -> "Exact server correlation"
+    CorrelationQuality.LegacyName -> "Legacy correlation"
+    CorrelationQuality.Uncorrelated -> "Correlation unavailable"
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -84,7 +84,9 @@ internal fun ConversationScreen(
 ) {
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
-    val transcriptMessages = remember(messages) { messages.filterNot { it.role == "tool" } }
+    val transcriptMessages = remember(messages, agentActivity) {
+        transcriptMessagesForActivity(messages, agentActivity)
+    }
     val transcriptKeys = remember(transcriptMessages) { transcriptItemKeys(transcriptMessages) }
     val visibleMessageCount = transcriptMessages.size + if (streamingText.isNotBlank()) 1 else 0
     val safeDrawingInsets = WindowInsets.safeDrawing

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -62,8 +62,8 @@ import dev.hazydreams.hermesceleste.ui.CelesteInk
 import dev.hazydreams.hermesceleste.ui.CelesteMuted
 import dev.hazydreams.hermesceleste.ui.CelestePanel
 import dev.hazydreams.hermesceleste.ui.CelestePaper
-
 import dev.hazydreams.hermesceleste.ui.StatusMessage
+import dev.hazydreams.hermesceleste.ui.UiNoticeMessage
 
 @Composable
 internal fun ConversationScreen(
@@ -79,6 +79,7 @@ internal fun ConversationScreen(
     onInterrupt: () -> Unit,
     onReconnect: () -> Unit,
     onBack: () -> Unit,
+    onSignIn: () -> Unit = {},
     agentActivity: AgentActivityProjection? = null,
     reasoningDisclosureEnabled: Boolean = true,
     onReasoningDisclosureChange: (Boolean) -> Unit = {},
@@ -157,7 +158,13 @@ internal fun ConversationScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    notice?.let { StatusMessage(it.message, CelesteError) }
+                    notice?.let {
+                        UiNoticeMessage(
+                            notice = it,
+                            onRetry = onReconnect,
+                            onSignIn = onSignIn,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.TurnState
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.AgentActivityProjection
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
@@ -77,11 +78,15 @@ internal fun ConversationScreen(
     onInterrupt: () -> Unit,
     onReconnect: () -> Unit,
     onBack: () -> Unit,
+    agentActivity: AgentActivityProjection? = null,
+    reasoningDisclosureEnabled: Boolean = true,
+    onReasoningDisclosureChange: (Boolean) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
-    val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
-    val visibleMessageCount = messages.size + if (streamingText.isNotBlank()) 1 else 0
+    val transcriptMessages = remember(messages) { messages.filterNot { it.role == "tool" } }
+    val transcriptKeys = remember(transcriptMessages) { transcriptItemKeys(transcriptMessages) }
+    val visibleMessageCount = transcriptMessages.size + if (streamingText.isNotBlank()) 1 else 0
     val safeDrawingInsets = WindowInsets.safeDrawing
     val headerTopPadding = maxOf(
         34.dp,
@@ -153,6 +158,16 @@ internal fun ConversationScreen(
                 }
             }
 
+            agentActivity?.let { projection ->
+                Spacer(Modifier.height(8.dp))
+                AgentActivityPanel(
+                    projection = projection,
+                    reasoningDisclosureEnabled = reasoningDisclosureEnabled,
+                    onReasoningDisclosureChange = onReasoningDisclosureChange,
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+
             LazyColumn(
                 state = listState,
                 modifier = Modifier.weight(1f).fillMaxWidth(),
@@ -160,7 +175,7 @@ internal fun ConversationScreen(
                 verticalArrangement = Arrangement.spacedBy(25.dp),
             ) {
                 itemsIndexed(
-                    items = messages,
+                    items = transcriptMessages,
                     key = { index, _ -> transcriptKeys[index] },
                 ) { _, message ->
                     MessageBubble(message)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.TurnState
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.AgentActivityProjection
 import dev.hazydreams.hermesceleste.network.StoredSession
@@ -72,7 +73,7 @@ internal fun ConversationScreen(
     draft: String,
     turnState: TurnState,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
     onInterrupt: () -> Unit,
@@ -150,13 +151,13 @@ internal fun ConversationScreen(
                 }
             }
 
-            if (loadingMessage != null || errorMessage != null) {
+            if (loadingMessage != null || notice != null) {
                 Column(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    notice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
@@ -30,6 +30,7 @@ import dev.hazydreams.hermesceleste.network.ActivityPresentationState
 import dev.hazydreams.hermesceleste.network.ActivitySource
 import dev.hazydreams.hermesceleste.network.AgentActivityProjection
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.CorrelationQuality
 import dev.hazydreams.hermesceleste.network.ToolActivity
 import dev.hazydreams.hermesceleste.network.safeToolName
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
@@ -107,9 +108,17 @@ private fun projectedToolsCorrelateToMessages(
                     tool.output?.text == detail
             }
         }
+        val legacyNameOnlyMatches = named.filter { (_, tool) ->
+            tool.correlation == CorrelationQuality.LegacyName &&
+                tool.callId == null &&
+                tool.input == null &&
+                tool.progress == null &&
+                tool.output == null
+        }
         val match = when {
             identityMatches.size == 1 -> identityMatches.single()
             detailMatches.size == 1 -> detailMatches.single()
+            legacyNameOnlyMatches.size == 1 -> legacyNameOnlyMatches.single()
             detail != null -> return@all false
             named.size == 1 -> named.single()
             else -> return@all false

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
@@ -25,7 +25,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
+import dev.hazydreams.hermesceleste.network.ActivityPresentationState
+import dev.hazydreams.hermesceleste.network.ActivitySource
+import dev.hazydreams.hermesceleste.network.AgentActivityProjection
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.ToolActivity
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteCoral
 import dev.hazydreams.hermesceleste.ui.CelesteGoldText
@@ -46,6 +51,31 @@ internal fun transcriptItemKeys(messages: List<ConversationMessage>): List<Strin
         val occurrence = occurrences.getOrDefault(base, 0) + 1
         occurrences[base] = occurrence
         if (occurrence == 1) base else "$base:occurrence:$occurrence"
+    }
+}
+
+/**
+ * Tool rows are hidden from the transcript only after the activity projection
+ * has a bounded card for every row. An unavailable/unsupported projection must
+ * leave legacy tool messages visible rather than silently dropping server data.
+ */
+internal fun transcriptMessagesForActivity(
+    messages: List<ConversationMessage>,
+    projection: AgentActivityProjection?,
+): List<ConversationMessage> {
+    val toolMessageCount = messages.count { it.role == "tool" }
+    if (toolMessageCount == 0) return messages
+
+    val projectedToolCount = projection?.items?.count { it is ToolActivity } ?: 0
+    val canRenderTools = projection != null &&
+        projection.source != ActivitySource.Unavailable &&
+        projection.capability != ActivityCapabilityState.Unsupported &&
+        projection.presentation != ActivityPresentationState.Unavailable &&
+        projectedToolCount >= toolMessageCount
+    return if (canRenderTools) {
+        messages.filterNot { it.role == "tool" }
+    } else {
+        messages
     }
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
@@ -31,6 +31,7 @@ import dev.hazydreams.hermesceleste.network.ActivitySource
 import dev.hazydreams.hermesceleste.network.AgentActivityProjection
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.ToolActivity
+import dev.hazydreams.hermesceleste.network.safeToolName
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteCoral
 import dev.hazydreams.hermesceleste.ui.CelesteGoldText
@@ -66,16 +67,55 @@ internal fun transcriptMessagesForActivity(
     val toolMessageCount = messages.count { it.role == "tool" }
     if (toolMessageCount == 0) return messages
 
-    val projectedToolCount = projection?.items?.count { it is ToolActivity } ?: 0
+    val projectedTools = projection?.items?.filterIsInstance<ToolActivity>().orEmpty()
     val canRenderTools = projection != null &&
         projection.source != ActivitySource.Unavailable &&
         projection.capability != ActivityCapabilityState.Unsupported &&
         projection.presentation != ActivityPresentationState.Unavailable &&
-        projectedToolCount >= toolMessageCount
+        projectedToolsCorrelateToMessages(messages, projectedTools)
     return if (canRenderTools) {
         messages.filterNot { it.role == "tool" }
     } else {
         messages
+    }
+}
+
+private fun projectedToolsCorrelateToMessages(
+    messages: List<ConversationMessage>,
+    projectedTools: List<ToolActivity>,
+): Boolean {
+    val used = mutableSetOf<Int>()
+    return messages.filter { it.role == "tool" }.all { message ->
+        val expectedName = safeToolName(message.toolName ?: "Tool activity")
+        val named = projectedTools.withIndex().filter { (index, tool) ->
+            index !in used && tool.name == expectedName
+        }
+        if (named.isEmpty()) return@all false
+
+        val identityMatches = message.id?.takeIf(String::isNotBlank)?.let { messageId ->
+            named.filter { (_, tool) ->
+                tool.callId == messageId || tool.callId == messageId.removePrefix("row-")
+            }
+        }.orEmpty()
+        val detail = message.text.takeIf(String::isNotBlank)
+        val detailMatches = if (detail == null) {
+            emptyList()
+        } else {
+            named.filter { (_, tool) ->
+                tool.input?.text == detail ||
+                    tool.progress?.text == detail ||
+                    tool.output?.text == detail
+            }
+        }
+        val match = when {
+            identityMatches.size == 1 -> identityMatches.single()
+            detailMatches.size == 1 -> detailMatches.single()
+            detail != null -> return@all false
+            named.size == 1 -> named.single()
+            else -> return@all false
+        }
+        used += match.index
+        true
     }
 }
 
@@ -151,7 +191,7 @@ private fun ToolMessage(message: ConversationMessage) {
             .padding(horizontal = 15.dp, vertical = 13.dp),
     ) {
         MessageLabel(
-            message.toolName?.replace('_', ' ') ?: "Tool",
+            safeToolName(message.toolName ?: "Tool"),
             CelesteGoldText,
             message.pending,
         )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -74,6 +74,7 @@ import dev.hazydreams.hermesceleste.ui.CelesteSectionLabel
 import dev.hazydreams.hermesceleste.ui.CelesteWordmark
 import dev.hazydreams.hermesceleste.ui.EditorialDivider
 import dev.hazydreams.hermesceleste.ui.StatusMessage
+import dev.hazydreams.hermesceleste.ui.UiNoticeMessage
 
 internal data class GatewaySettingsUiState(
     val dashboardUrl: String,
@@ -97,6 +98,7 @@ internal data class GatewaySettingsActions(
     val onSignOut: () -> Unit,
     val onForgetConnection: () -> Unit,
     val onBack: (() -> Unit)?,
+    val onSignIn: () -> Unit = {},
 )
 
 @Composable
@@ -129,6 +131,7 @@ internal fun ConnectionUnavailableScreen(
     notice: UiNotice?,
     onRetry: () -> Unit,
     onSettings: () -> Unit,
+    onSignIn: () -> Unit = {},
 ) {
     CelesteBackdrop {
         Column(
@@ -150,7 +153,11 @@ internal fun ConnectionUnavailableScreen(
             )
             notice?.let {
                 Spacer(Modifier.height(26.dp))
-                StatusMessage(it.message, CelesteError)
+                UiNoticeMessage(
+                    notice = it,
+                    onRetry = onRetry,
+                    onSignIn = onSignIn,
+                )
             }
             Spacer(Modifier.height(34.dp))
             CelestePrimaryButton(
@@ -374,7 +381,13 @@ internal fun GatewaySettingsScreen(
                 Column(modifier = Modifier.padding(vertical = 22.dp)) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
                     if (loadingMessage != null && visibleNotice != null) Spacer(Modifier.height(10.dp))
-                    visibleNotice?.let { StatusMessage(it.message, CelesteError) }
+                    visibleNotice?.let {
+                        UiNoticeMessage(
+                            notice = it,
+                            onRetry = actions.onRetry,
+                            onSignIn = actions.onSignIn,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.ConnectionPhase
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -83,7 +84,7 @@ internal data class GatewaySettingsUiState(
     val sessionToken: String,
     val connectionPhase: ConnectionPhase,
     val loadingMessage: String?,
-    val errorMessage: String?,
+    val notice: UiNotice?,
 )
 
 internal data class GatewaySettingsActions(
@@ -125,7 +126,7 @@ internal fun ConnectionLoadingScreen() {
 
 @Composable
 internal fun ConnectionUnavailableScreen(
-    errorMessage: String?,
+    notice: UiNotice?,
     onRetry: () -> Unit,
     onSettings: () -> Unit,
 ) {
@@ -147,9 +148,9 @@ internal fun ConnectionUnavailableScreen(
                 color = CelesteMuted,
                 style = MaterialTheme.typography.bodyLarge,
             )
-            errorMessage?.let {
+            notice?.let {
                 Spacer(Modifier.height(26.dp))
-                StatusMessage(it, CelesteError)
+                StatusMessage(it.message, CelesteError)
             }
             Spacer(Modifier.height(34.dp))
             CelestePrimaryButton(
@@ -233,7 +234,7 @@ internal fun GatewaySettingsScreen(
     val sessionToken = state.sessionToken
     val connectionPhase = state.connectionPhase
     val loadingMessage = state.loadingMessage
-    val errorMessage = state.errorMessage
+    val notice = state.notice
     val onBack = actions.onBack
     var address by rememberSaveable(dashboardUrl) { mutableStateOf(dashboardUrl) }
     var confirmForgetConnection by remember { mutableStateOf(false) }
@@ -366,14 +367,14 @@ internal fun GatewaySettingsScreen(
                 EditorialDivider()
             }
 
-            val visibleError = errorMessage.takeUnless {
-                connectionPhase == ConnectionPhase.AuthenticationRequired
+            val visibleNotice = notice?.takeUnless {
+                it.category == dev.hazydreams.hermesceleste.UiNoticeCategory.AuthenticationRequired
             }
-            AnimatedVisibility(visibleError != null || loadingMessage != null) {
+            AnimatedVisibility(visibleNotice != null || loadingMessage != null) {
                 Column(modifier = Modifier.padding(vertical = 22.dp)) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    if (loadingMessage != null && visibleError != null) Spacer(Modifier.height(10.dp))
-                    visibleError?.let { StatusMessage(it, CelesteError) }
+                    if (loadingMessage != null && visibleNotice != null) Spacer(Modifier.height(10.dp))
+                    visibleNotice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 
@@ -385,7 +386,7 @@ internal fun GatewaySettingsScreen(
             }
             val showPrimaryAction = !isConnected || addressChanged
             if (showPrimaryAction) {
-                Spacer(Modifier.height(if (visibleError == null && loadingMessage == null) 28.dp else 4.dp))
+                Spacer(Modifier.height(if (visibleNotice == null && loadingMessage == null) 28.dp else 4.dp))
                 CelestePrimaryButton(
                     text = when {
                         effectiveProbe == null -> "Find my Hermes"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -41,15 +41,13 @@ import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
-
-import dev.hazydreams.hermesceleste.ui.CelesteError
 import dev.hazydreams.hermesceleste.ui.CelesteHairline
 import dev.hazydreams.hermesceleste.ui.CelesteInk
 import dev.hazydreams.hermesceleste.ui.CelesteMuted
 import dev.hazydreams.hermesceleste.ui.CelestePanel
-
 import dev.hazydreams.hermesceleste.ui.EditorialDivider
 import dev.hazydreams.hermesceleste.ui.StatusMessage
+import dev.hazydreams.hermesceleste.ui.UiNoticeMessage
 
 @Composable
 internal fun SessionListScreen(
@@ -62,6 +60,8 @@ internal fun SessionListScreen(
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
     onSettings: () -> Unit,
+    onRetry: () -> Unit = {},
+    onSignIn: () -> Unit = {},
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
 
@@ -151,7 +151,13 @@ internal fun SessionListScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    notice?.let { StatusMessage(it.message, CelesteError) }
+                    notice?.let {
+                        UiNoticeMessage(
+                            notice = it,
+                            onRetry = onRetry,
+                            onSignIn = onSignIn,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -56,7 +57,7 @@ internal fun SessionListScreen(
     profiles: List<DashboardProfile>,
     selectedProfile: String,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
     onProfileSelected: (String) -> Unit,
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
@@ -144,13 +145,13 @@ internal fun SessionListScreen(
                 }
             }
 
-            if (loadingMessage != null || errorMessage != null) {
+            if (loadingMessage != null || notice != null) {
                 Column(
                     modifier = Modifier.padding(horizontal = 28.dp, vertical = 4.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    notice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -83,7 +83,7 @@ private val gatewaySetupState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.ManualSetup,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private val passwordSignInState = GatewaySettingsUiState(
@@ -100,7 +100,7 @@ private val passwordSignInState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.AuthenticationRequired,
     loadingMessage = null,
-    errorMessage = "Sign in required.",
+    notice = UiNotice.authentication(),
 )
 
 private val sessionTokenState = GatewaySettingsUiState(
@@ -117,7 +117,7 @@ private val sessionTokenState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.ManualSetup,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private val connectedGatewayState = GatewaySettingsUiState(
@@ -134,7 +134,7 @@ private val connectedGatewayState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.Connected,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private fun gatewayPreviewActions(onBack: (() -> Unit)?): GatewaySettingsActions =
@@ -227,7 +227,7 @@ fun RestoringConnectionPreviewScreenshot() {
 fun RestoreFailedPreviewScreenshot() {
     HermesCelesteTheme {
         ConnectionUnavailableScreen(
-            errorMessage = "Could not reach Hermes.",
+            notice = UiNotice.unavailable(),
             onRetry = {},
             onSettings = {},
         )
@@ -247,7 +247,7 @@ fun SessionListPreviewScreenshot() {
             ),
             selectedProfile = "work",
             loadingMessage = null,
-            errorMessage = null,
+            notice = null,
             onProfileSelected = {},
             onNewConversation = {},
             onSessionSelected = {},
@@ -339,7 +339,7 @@ fun ReconnectingPreviewScreenshot() {
         PreviewConversation(
             draft = "This draft stays here while the connection recovers.",
             turnState = TurnState.Reconnecting,
-            errorMessage = "The dashboard connection closed before Hermes finished responding.",
+            notice = UiNotice.reconnecting(),
         )
     }
 }
@@ -351,7 +351,7 @@ private fun PreviewConversation(
     streamingText: String = "",
     draft: String = "",
     turnState: TurnState,
-    errorMessage: String? = null,
+    notice: UiNotice? = null,
 ) {
     ConversationScreen(
         summary = summary,
@@ -360,7 +360,7 @@ private fun PreviewConversation(
         draft = draft,
         turnState = turnState,
         loadingMessage = null,
-        errorMessage = errorMessage,
+        notice = notice,
         onDraftChange = {},
         onSend = {},
         onInterrupt = {},

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
@@ -1,5 +1,7 @@
 package dev.hazydreams.hermesceleste
 
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewModelScope
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
 import dev.hazydreams.hermesceleste.connection.ReusableSecret
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
@@ -20,6 +22,7 @@ import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.TransportUnavailable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -29,6 +32,8 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import org.junit.After
@@ -42,15 +47,30 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class CelesteViewModelAutoLoginTest {
     private val mainDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModelStore: ViewModelStore
+    private val trackedViewModels = mutableListOf<CelesteViewModel>()
+    private var viewModelKey = 0
 
     @Before
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        viewModelStore = ViewModelStore()
+        trackedViewModels.clear()
+        viewModelKey = 0
     }
 
     @After
     fun tearDown() {
+        val scopeJobs = trackedViewModels.mapNotNull { it.viewModelScope.coroutineContext[Job] }
+        viewModelStore.clear()
+        runBlocking { scopeJobs.joinAll() }
+        mainDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
+    }
+
+    private fun track(viewModel: CelesteViewModel) {
+        viewModelStore.put("celeste-view-model-${viewModelKey++}", viewModel)
+        trackedViewModels += viewModel
     }
 
     @Test
@@ -63,7 +83,7 @@ class CelesteViewModelAutoLoginTest {
         val store = InMemoryConnectionStore(StoredConnection(descriptor, null))
         val dashboard = AutoLoginDashboard(openProbe)
 
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         val state = viewModel.state.value
@@ -78,7 +98,7 @@ class CelesteViewModelAutoLoginTest {
     fun successfulPasswordConnectionIsRememberedAndVisibleSecretsAreCleared() = runTest {
         val store = InMemoryConnectionStore()
         val dashboard = AutoLoginDashboard(passwordProbe)
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         viewModel.updateDashboardUrl("https://hermes.example.net")
@@ -121,7 +141,7 @@ class CelesteViewModelAutoLoginTest {
             exportedMaterial = "rotated-session-cookies"
         }
 
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         assertEquals(ConnectionPhase.Connected, viewModel.state.value.connectionPhase)
@@ -146,7 +166,7 @@ class CelesteViewModelAutoLoginTest {
             restoreAccepted = false
         }
 
-        val rejected = CelesteViewModel(dashboard = rejectedDashboard, connectionStore = store)
+        val rejected = CelesteViewModel(dashboard = rejectedDashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         assertEquals(ConnectionPhase.AuthenticationRequired, rejected.state.value.connectionPhase)
@@ -157,7 +177,7 @@ class CelesteViewModelAutoLoginTest {
         assertEquals(1, rejectedDashboard.restoreAuthenticationCalls)
 
         val nextDashboard = AutoLoginDashboard(passwordProbe)
-        val nextLaunch = CelesteViewModel(dashboard = nextDashboard, connectionStore = store)
+        val nextLaunch = CelesteViewModel(dashboard = nextDashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         assertEquals(ConnectionPhase.ManualSetup, nextLaunch.state.value.connectionPhase)
@@ -178,7 +198,7 @@ class CelesteViewModelAutoLoginTest {
         val dashboard = AutoLoginDashboard(openProbe).apply {
             probeFailure = TransportUnavailable("Hermes is unavailable.")
         }
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         assertEquals(ConnectionPhase.RestoreFailed, viewModel.state.value.connectionPhase)
@@ -208,7 +228,7 @@ class CelesteViewModelAutoLoginTest {
             probeFailure = InvalidDashboardResponse("Malformed response.")
         }
 
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         assertEquals(ConnectionPhase.RestoreFailed, viewModel.state.value.connectionPhase)
@@ -225,7 +245,7 @@ class CelesteViewModelAutoLoginTest {
         )
         val store = InMemoryConnectionStore(StoredConnection(original, null))
         val dashboard = AutoLoginDashboard(openProbe)
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
 
         viewModel.updateDashboardUrl("https://new-hermes.example.net")
@@ -258,7 +278,7 @@ class CelesteViewModelAutoLoginTest {
             StoredConnection(descriptor, ReusableSecret("synthetic-session-cookies")),
         )
         val dashboard = AutoLoginDashboard(passwordProbe)
-        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store)
+        val viewModel = CelesteViewModel(dashboard = dashboard, connectionStore = store).also(::track)
         advanceUntilIdle()
         dashboard.onLogout = { assertNull(store.load()?.secret) }
 
@@ -280,7 +300,7 @@ class CelesteViewModelAutoLoginTest {
         val forgetViewModel = CelesteViewModel(
             dashboard = forgetDashboard,
             connectionStore = forgetStore,
-        )
+        ).also(::track)
         advanceUntilIdle()
         forgetDashboard.onLogout = { assertNull(forgetStore.load()) }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -7,6 +7,7 @@ import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
 import dev.hazydreams.hermesceleste.network.ActivityDisclosurePreferenceStore
+import dev.hazydreams.hermesceleste.network.ActivityDisclosureScope
 import dev.hazydreams.hermesceleste.network.AuthProvider
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.CorrelationQuality
@@ -97,7 +98,15 @@ class CelesteViewModelTest {
 
         viewModel.setActivityReasoningDisclosureEnabled(false)
         assertFalse(viewModel.state.value.agentActivityReasoningDisclosureEnabled)
-        assertFalse(preferences.isServerReasoningDisclosureEnabled())
+        assertFalse(
+            preferences.isServerReasoningDisclosureEnabled(
+                ActivityDisclosureScope(
+                    originKey = "http://hermes.test:9119",
+                    profile = "default",
+                    storedSessionId = "stored-42",
+                ),
+            ),
+        )
         assertTrue(viewModel.state.value.agentActivity?.items.orEmpty().none { it is ServerReasoningActivity })
         assertEquals(
             ActivityCapabilityState.ToolAndServerReasoning,
@@ -347,6 +356,75 @@ class CelesteViewModelTest {
         )
 
         assertEquals("and still arriving", suffix)
+    }
+
+    @Test
+    fun disclosurePreferenceIsScopedToOriginProfileAndStoredSession() = runTest {
+        val preferences = InMemoryActivityDisclosurePreferenceStore()
+        val first = ActivityDisclosureScope(
+            originKey = "https://hermes.test/",
+            profile = "default",
+            storedSessionId = "stored-42",
+        )
+        val second = first.copy(profile = "work")
+
+        preferences.setServerReasoningDisclosureEnabled(first, false)
+
+        assertFalse(preferences.isServerReasoningDisclosureEnabled(first))
+        assertTrue(preferences.isServerReasoningDisclosureEnabled(second))
+        assertTrue(preferences.isServerReasoningDisclosureEnabled())
+    }
+
+    @Test
+    fun viewModelReloadsDisclosureChoiceWhenSwitchingActivityScope() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val preferences = InMemoryActivityDisclosurePreferenceStore()
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+            activityDisclosurePreferences = preferences,
+        )
+        advanceUntilIdle()
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+        viewModel.setActivityReasoningDisclosureEnabled(false)
+        viewModel.leaveConversation()
+
+        viewModel.openSession(dashboard.session.copy(profile = "work"))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.agentActivityReasoningDisclosureEnabled)
+        viewModel.leaveConversation()
+
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+        assertFalse(viewModel.state.value.agentActivityReasoningDisclosureEnabled)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun messageCompletionSettlesAnUnfinishedToolWithoutBlockingTheTurn() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        gateway.emit(
+            "tool.start",
+            """{"name":"terminal","tool_call_id":"call-incomplete"}""",
+        )
+        gateway.emit("message.complete", """{"status":"complete"}""")
+        advanceUntilIdle()
+
+        assertEquals(
+            ToolPhase.Interrupted,
+            viewModel.state.value.agentActivity?.items
+                ?.filterIsInstance<ToolActivity>()
+                ?.single()
+                ?.phase,
+        )
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        viewModel.leaveConversation()
     }
 
     private suspend fun openConversation(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -537,7 +537,8 @@ class CelesteViewModelTest {
 
         assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
         assertNull(viewModel.state.value.sessions)
-        assertEquals("Hermes rejected profile access.", viewModel.state.value.errorMessage)
+        assertEquals(UiNoticeCategory.AuthenticationRequired, viewModel.state.value.notice?.category)
+        assertEquals("Your Hermes sign-in has expired. Sign in again.", viewModel.state.value.notice?.message)
     }
 
     @Test
@@ -606,6 +607,101 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun closingGatewayCancelsAnInFlightOpenOperationBeforeItsResumeReturns() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        advanceUntilIdle()
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        val resumeGate = CompletableDeferred<JsonObject>()
+        gateway.resumeGates += resumeGate
+        viewModel.openSession(dashboard.session)
+        runCurrent()
+        assertEquals(1, gateway.resumeRequestCount)
+
+        viewModel.leaveConversation()
+        resumeGate.complete(resumePayload(messages = emptyList(), running = false))
+        advanceUntilIdle()
+
+        assertNull(viewModel.state.value.activeSummary)
+        assertTrue(viewModel.state.value.messages.isEmpty())
+    }
+
+    @Test
+    fun closingGatewayCancelsAnInFlightCreateOperationBeforeItsResponseReturns() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        val createGate = CompletableDeferred<Unit>()
+        gateway.createGates += createGate
+
+        viewModel.createNewConversation()
+        runCurrent()
+        assertEquals(1, gateway.createCount)
+
+        viewModel.leaveConversation()
+        createGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertNull(viewModel.state.value.activeSummary)
+        assertTrue(viewModel.state.value.messages.isEmpty())
+    }
+
+    @Test
+    fun closingGatewayCancelsAnInFlightSendOperationBeforeItsResponseReturns() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        val promptGate = CompletableDeferred<Unit>()
+        gateway.promptGates += promptGate
+
+        viewModel.updateDraft("<synthetic-prompt>")
+        viewModel.sendMessage()
+        runCurrent()
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+
+        viewModel.leaveConversation()
+        promptGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertNull(viewModel.state.value.activeSummary)
+        assertTrue(viewModel.state.value.messages.isEmpty())
+    }
+
+    @Test
+    fun closingGatewayCancelsAnInFlightInterruptOperationBeforeItsResponseReturns() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        viewModel.updateDraft("<synthetic-prompt>")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        gateway.emit("message.start")
+        runCurrent()
+
+        val interruptGate = CompletableDeferred<Unit>()
+        gateway.interruptGates += interruptGate
+        viewModel.interrupt()
+        runCurrent()
+        assertEquals(1, gateway.methods.count { it == "session.interrupt" })
+
+        viewModel.leaveConversation()
+        interruptGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertNull(viewModel.state.value.activeSummary)
+        assertTrue(viewModel.state.value.messages.isEmpty())
+    }
+
+    @Test
     fun removesPersistedPrefixFromInflightProjection() {
         val suffix = CelesteViewModel.unpersistedInflightText(
             inflight = "Already stored and still arriving",
@@ -663,6 +759,29 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun disclosurePreferenceFailureRollsBackTheProjectionAndShowsRetryNotice() = runTest {
+        val gateway = FakeGateway()
+        val preferences = FailingPreferenceStore()
+        val viewModel = openConversation(gateway, preferences)
+
+        viewModel.setActivityReasoningDisclosureEnabled(false)
+
+        assertTrue(viewModel.state.value.agentActivityReasoningDisclosureEnabled)
+        assertEquals(UiNoticeCategory.PreferencePersistence, viewModel.state.value.notice?.category)
+        assertEquals(UiRecoveryAction.Retry, viewModel.state.value.notice?.recovery)
+        assertTrue(
+            preferences.isServerReasoningDisclosureEnabled(
+                ActivityDisclosureScope(
+                    originKey = "http://hermes.test:9119",
+                    profile = "default",
+                    storedSessionId = "stored-42",
+                ),
+            ),
+        )
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun messageFailureReasonSurfacesAsAUserSafeErrorAndSettlesTheTurn() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
@@ -675,7 +794,8 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
-        assertEquals("Synthetic failure detail", viewModel.state.value.errorMessage)
+        assertEquals(UiNoticeCategory.ServerTurnFailure, viewModel.state.value.notice?.category)
+        assertEquals("Hermes couldn’t finish that response.", viewModel.state.value.notice?.message)
         viewModel.leaveConversation()
     }
 
@@ -721,6 +841,38 @@ class CelesteViewModelTest {
         viewModel.loadSessions()
         viewModel.openSession(dashboard.session)
         return viewModel
+    }
+
+    private class FailingPreferenceStore : ActivityDisclosurePreferenceStore {
+        private var enabled = true
+        private val scopedValues = mutableMapOf<String, Boolean>()
+        private var failNextWrite = true
+
+        override fun isServerReasoningDisclosureEnabled(): Boolean = enabled
+
+        override fun setServerReasoningDisclosureEnabled(enabled: Boolean): Boolean {
+            if (failNextWrite) {
+                failNextWrite = false
+                return false
+            }
+            this.enabled = enabled
+            return true
+        }
+
+        override fun isServerReasoningDisclosureEnabled(scope: ActivityDisclosureScope): Boolean =
+            scopedValues[scope.stablePreferenceKey()] ?: enabled
+
+        override fun setServerReasoningDisclosureEnabled(
+            scope: ActivityDisclosureScope,
+            enabled: Boolean,
+        ): Boolean {
+            scopedValues[scope.stablePreferenceKey()] = enabled
+            if (failNextWrite) {
+                failNextWrite = false
+                return false
+            }
+            return true
+        }
     }
 
     private class FakeDashboard(
@@ -797,12 +949,17 @@ class CelesteViewModelTest {
         var failPrompt = false
         var connectFailure: Throwable? = null
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
+        val connectGates = mutableListOf<CompletableDeferred<Unit>>()
+        val createGates = mutableListOf<CompletableDeferred<Unit>>()
+        val promptGates = mutableListOf<CompletableDeferred<Unit>>()
+        val interruptGates = mutableListOf<CompletableDeferred<Unit>>()
         val resumeGates = mutableListOf<CompletableDeferred<JsonObject>>()
         var resumeRequestCount = 0
 
         override suspend fun connect() {
             connectCount += 1
             connectFailure?.let { throw it }
+            if (connectGates.isNotEmpty()) connectGates.removeAt(0).await()
             mutableState.value = GatewayConnectionState.Connected
         }
 
@@ -820,6 +977,7 @@ class CelesteViewModelTest {
                 }
                 "session.create" -> {
                     createCount += 1
+                    if (createGates.isNotEmpty()) createGates.removeAt(0).await()
                     buildJsonObject {
                         put("session_id", "runtime-new-$createCount")
                         put("stored_session_id", "stored-new-$createCount")
@@ -834,13 +992,17 @@ class CelesteViewModelTest {
                     buildJsonObject { put("sessions", "healthy") }
                 }
                 "prompt.submit" -> {
+                    if (promptGates.isNotEmpty()) promptGates.removeAt(0).await()
                     if (failPrompt) {
                         failPrompt = false
                         throw IOException("prompt delivery failed")
                     }
                     buildJsonObject { put("status", "streaming") }
                 }
-                "session.interrupt" -> buildJsonObject { put("status", "interrupting") }
+                "session.interrupt" -> {
+                    if (interruptGates.isNotEmpty()) interruptGates.removeAt(0).await()
+                    buildJsonObject { put("status", "interrupting") }
+                }
                 else -> buildJsonObject {}
             }
         }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -24,6 +24,7 @@ import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.ToolActivity
 import dev.hazydreams.hermesceleste.network.ToolPhase
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -386,6 +387,104 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun overlappingRecoverySerializesResumeAndReplaysEventsAfterItsSnapshot() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        val firstResume = CompletableDeferred<JsonObject>()
+        val secondResume = CompletableDeferred<JsonObject>()
+        gateway.resumeGates += firstResume
+        gateway.resumeGates += secondResume
+        gateway.failPrompt = true
+
+        viewModel.updateDraft("Recover this turn")
+        viewModel.sendMessage()
+        runCurrent()
+        assertEquals(2, gateway.resumeRequestCount)
+
+        viewModel.interrupt()
+        runCurrent()
+        assertEquals(1, gateway.methods.count { it == "session.interrupt" })
+        assertEquals(2, gateway.resumeRequestCount)
+
+        gateway.emit("message.delta", """{"text":"buffered-after-snapshot"}""")
+        runCurrent()
+        firstResume.complete(resumePayload(messages = emptyList(), running = true))
+        runCurrent()
+
+        assertEquals("buffered-after-snapshot", viewModel.state.value.streamingText)
+        assertEquals(3, gateway.resumeRequestCount)
+
+        secondResume.complete(
+            resumePayload(
+                messages = listOf(
+                    ConversationMessage(role = "assistant", text = "new-authoritative-state", id = "new-state"),
+                ),
+                running = false,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("new-authoritative-state"),
+            viewModel.state.value.messages.map(ConversationMessage::text),
+        )
+        assertEquals("", viewModel.state.value.streamingText)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun lateResumeFromAnOlderGatewayGenerationCannotOverwriteTheSelectedSession() = runTest {
+        val oldGateway = FakeGateway()
+        val dashboard = FakeDashboard(oldGateway)
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+
+        val oldResume = CompletableDeferred<JsonObject>()
+        oldGateway.resumeGates += oldResume
+        oldGateway.failPrompt = true
+        viewModel.updateDraft("This must not leak")
+        viewModel.sendMessage()
+        runCurrent()
+        assertEquals(2, oldGateway.resumeRequestCount)
+
+        val newGateway = FakeGateway()
+        newGateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "assistant", text = "selected-session", id = "selected-state"),
+            ),
+            running = false,
+            storedSessionId = "stored-new",
+            runtimeSessionId = "runtime-new",
+        )
+        dashboard.gateway = newGateway
+        viewModel.openSession(dashboard.session.copy(id = "stored-new", title = "Selected conversation"))
+
+        oldResume.complete(
+            resumePayload(
+                messages = listOf(
+                    ConversationMessage(role = "assistant", text = "stale-old-session", id = "stale-state"),
+                ),
+                running = false,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertEquals("stored-new", viewModel.state.value.activeSummary?.id)
+        assertEquals(
+            listOf("selected-session"),
+            viewModel.state.value.messages.map(ConversationMessage::text),
+        )
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun revokedProviderSessionStopsReconnectAndDeletesReusableAuthentication() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway, authRequired = true)
@@ -625,7 +724,7 @@ class CelesteViewModelTest {
     }
 
     private class FakeDashboard(
-        private val gateway: FakeGateway,
+        var gateway: FakeGateway,
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
@@ -695,8 +794,11 @@ class CelesteViewModelTest {
         var connectCount = 0
         var createCount = 0
         var failHealthCheck = false
+        var failPrompt = false
         var connectFailure: Throwable? = null
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
+        val resumeGates = mutableListOf<CompletableDeferred<JsonObject>>()
+        var resumeRequestCount = 0
 
         override suspend fun connect() {
             connectCount += 1
@@ -712,7 +814,10 @@ class CelesteViewModelTest {
             methods += method
             requests += method to params
             return when (method) {
-                "session.resume" -> resumePayload
+                "session.resume" -> {
+                    resumeRequestCount += 1
+                    if (resumeGates.isEmpty()) resumePayload else resumeGates.removeAt(0).await()
+                }
                 "session.create" -> {
                     createCount += 1
                     buildJsonObject {
@@ -728,7 +833,13 @@ class CelesteViewModelTest {
                     }
                     buildJsonObject { put("sessions", "healthy") }
                 }
-                "prompt.submit" -> buildJsonObject { put("status", "streaming") }
+                "prompt.submit" -> {
+                    if (failPrompt) {
+                        failPrompt = false
+                        throw IOException("prompt delivery failed")
+                    }
+                    buildJsonObject { put("status", "streaming") }
+                }
                 "session.interrupt" -> buildJsonObject { put("status", "interrupting") }
                 else -> buildJsonObject {}
             }
@@ -757,12 +868,14 @@ class CelesteViewModelTest {
         private fun resumePayload(
             messages: List<ConversationMessage>,
             running: Boolean,
+            storedSessionId: String = "stored-42",
+            runtimeSessionId: String = "runtime-7",
         ): JsonObject {
             val encodedMessages = messages.joinToString(",") { message ->
                 """{"id":${Json.encodeToString(message.id ?: "")},"role":${Json.encodeToString(message.role)},"text":${Json.encodeToString(message.text)}}"""
             }
             return Json.parseToJsonElement(
-                """{"session_id":"runtime-7","resumed":"stored-42","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":null,"messages":[$encodedMessages]}""",
+                """{"session_id":"$runtimeSessionId","resumed":"$storedSessionId","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":null,"messages":[$encodedMessages]}""",
             ) as JsonObject
         }
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -237,6 +237,73 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun finalAssistantContentRemovesEmbeddedLongServerReasoning() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        val disclosed = "<long-server-summary>" + "x".repeat(13_000)
+
+        gateway.emit(
+            "reasoning.available",
+            buildJsonObject {
+                put("text", disclosed)
+                put("verbose", true)
+            }.toString(),
+        )
+        gateway.emit(
+            "message.complete",
+            buildJsonObject {
+                put("content", "<assistant-before>\n$disclosed\n<assistant-after>")
+                put("status", "complete")
+            }.toString(),
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(
+            "<assistant-before>\n<assistant-after>",
+            state.messages.single { it.role == "assistant" }.text,
+        )
+        val reasoning = state.agentActivity?.items
+            ?.filterIsInstance<ServerReasoningActivity>()
+            ?.single()
+        assertTrue(reasoning?.text?.wasTruncated == true)
+        assertTrue(reasoning?.text?.text?.contains("<long-server-summary>") == true)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun embeddedReasoningInInterimContentIsRemovedWhenFinalSettles() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+
+        gateway.emit(
+            "reasoning.available",
+            """{"text":"<server-summary>","verbose":true}""",
+        )
+        gateway.emit(
+            "message.interim",
+            """{"text":"<server-summary>\n<assistant-content>"}""",
+        )
+        gateway.emit(
+            "message.complete",
+            """{"content":"<server-summary>\n<assistant-content>","status":"complete"}""",
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("<assistant-content>"),
+            viewModel.state.value.messages.filter { it.role == "assistant" }.map { it.text },
+        )
+        assertEquals(
+            1,
+            viewModel.state.value.agentActivity?.items
+                ?.filterIsInstance<ServerReasoningActivity>()
+                ?.size,
+        )
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun sendsAndReducesStreamingEventsWithoutDuplicatingCompletion() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -137,7 +137,7 @@ class CelesteViewModelTest {
         )
         gateway.emit(
             "reasoning.available",
-            """{"text":"<server-summary>","label":"Server summary"}""",
+            """{"text":"<server-summary>","label":"Server summary","verbose":true}""",
         )
         gateway.emit(
             "tool.complete",
@@ -176,6 +176,34 @@ class CelesteViewModelTest {
             viewModel.state.value.agentActivity?.capability,
         )
         assertTrue(gateway.methods.none { it.contains("activity", ignoreCase = true) })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun finalAssistantContentDoesNotRepeatServerReasoningSummary() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+
+        gateway.emit(
+            "reasoning.available",
+            """{"text":"<server-summary>","verbose":true}""",
+        )
+        gateway.emit(
+            "message.complete",
+            """{"content":"<server-summary>\n<assistant-content>","status":"complete"}""",
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("<assistant-content>", state.messages.single { it.role == "assistant" }.text)
+        assertEquals(
+            "<server-summary>",
+            state.agentActivity?.items
+                ?.filterIsInstance<ServerReasoningActivity>()
+                ?.single()
+                ?.text
+                ?.text,
+        )
         viewModel.leaveConversation()
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -1,5 +1,7 @@
 package dev.hazydreams.hermesceleste
 
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewModelScope
 import java.io.IOException
 
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
@@ -27,10 +29,12 @@ import dev.hazydreams.hermesceleste.network.ToolPhase
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -38,6 +42,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -55,15 +61,30 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class CelesteViewModelTest {
     private val mainDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModelStore: ViewModelStore
+    private val trackedViewModels = mutableListOf<CelesteViewModel>()
+    private var viewModelKey = 0
 
     @Before
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        viewModelStore = ViewModelStore()
+        trackedViewModels.clear()
+        viewModelKey = 0
     }
 
     @After
     fun tearDown() {
+        val scopeJobs = trackedViewModels.mapNotNull { it.viewModelScope.coroutineContext[Job] }
+        viewModelStore.clear()
+        runBlocking { scopeJobs.joinAll() }
+        mainDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
+    }
+
+    private fun track(viewModel: CelesteViewModel) {
+        viewModelStore.put("celeste-view-model-${viewModelKey++}", viewModel)
+        trackedViewModels += viewModel
     }
 
     @Test
@@ -82,6 +103,9 @@ class CelesteViewModelTest {
 
         advanceTimeBy(100L)
         runCurrent()
+        viewModel.state.first {
+            it.agentActivity?.presentation == ActivityPresentationState.Unavailable
+        }
 
         assertEquals(
             ActivityPresentationState.Unavailable,
@@ -102,11 +126,11 @@ class CelesteViewModelTest {
 
         gateway.emit(
             "reasoning.delta",
-            """{"text":"<reasoning-one>","verbose":true}""",
+            """{"text":"<server-summary-one>","verbose":true}""",
         )
         gateway.emit(
             "reasoning.delta",
-            """{"text":"<reasoning-two>","verbose":true}""",
+            """{"text":"<server-summary-two>","verbose":true}""",
         )
         runCurrent()
         assertTrue(
@@ -117,12 +141,45 @@ class CelesteViewModelTest {
         advanceTimeBy(100L)
         runCurrent()
 
-        val reasoning = viewModel.state.value.agentActivity?.items
-            ?.filterIsInstance<ServerReasoningActivity>()
-            ?.single()
-        assertEquals("<reasoning-one><reasoning-two>", reasoning?.text?.text)
+        viewModel.state.first { state ->
+            state.agentActivity?.items
+                ?.filterIsInstance<ServerReasoningActivity>()
+                ?.size == 1
+        }
+
+        val reasoning = viewModel.state.value.agentActivity?.items.orEmpty()
+            .filterIsInstance<ServerReasoningActivity>()
+            .single()
+        assertEquals("<server-summary-one><server-summary-two>", reasoning.text.text)
         assertEquals(1, viewModel.state.value.agentActivity?.items
             ?.filterIsInstance<ServerReasoningActivity>()?.size)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun showReasoningFalseSuppressesVerboseDeltaBeforeCoalescing() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(
+            gateway = gateway,
+            reasoningCoalescingWindowMillis = 100L,
+        )
+        runCurrent()
+
+        gateway.emit(
+            "reasoning.delta",
+            """{"text":"<hidden-delta>","show_reasoning":false,"verbose":true}""",
+        )
+        advanceTimeBy(100L)
+        runCurrent()
+
+        assertTrue(
+            viewModel.state.value.agentActivity?.items.orEmpty()
+                .none { it is ServerReasoningActivity },
+        )
+        assertEquals(
+            ActivityCapabilityState.Unknown,
+            viewModel.state.value.agentActivity?.capability,
+        )
         viewModel.leaveConversation()
     }
 
@@ -145,6 +202,12 @@ class CelesteViewModelTest {
             """{"name":"terminal","tool_call_id":"call-1","output":"<tool-output>"}""",
         )
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            val activity = state.agentActivity ?: return@first false
+            activity.items.size == 2 &&
+                activity.items.filterIsInstance<ToolActivity>().singleOrNull()?.phase == ToolPhase.Completed &&
+                activity.items.filterIsInstance<ServerReasoningActivity>().size == 1
+        }
 
         val activity = requireNotNull(viewModel.state.value.agentActivity)
         assertEquals(2, activity.items.size)
@@ -194,6 +257,10 @@ class CelesteViewModelTest {
             """{"content":"<server-summary>\n<assistant-content>","status":"complete"}""",
         )
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.messages.any { it.role == "assistant" && it.text == "<assistant-content>" } &&
+                state.agentActivity?.items?.filterIsInstance<ServerReasoningActivity>()?.size == 1
+        }
 
         val state = viewModel.state.value
         assertEquals("<assistant-content>", state.messages.single { it.role == "assistant" }.text)
@@ -211,12 +278,18 @@ class CelesteViewModelTest {
     @Test
     fun reconnectRestoresActivityProjectionAndFallsBackWhenSnapshotIsEmpty() = runTest {
         val gateway = FakeGateway()
-        val viewModel = openConversation(gateway)
+        val viewModel = openConversation(
+            gateway = gateway,
+            activityDiscoveryTimeoutMillis = 100L,
+        )
         gateway.emit(
             "tool.start",
             """{"name":"terminal","tool_call_id":"call-1"}""",
         )
         advanceUntilIdle()
+        viewModel.state.first {
+            it.agentActivity?.presentation == ActivityPresentationState.Running
+        }
         assertEquals(
             dev.hazydreams.hermesceleste.network.ActivityPresentationState.Running,
             viewModel.state.value.agentActivity?.presentation,
@@ -227,7 +300,17 @@ class CelesteViewModelTest {
             running = false,
         )
         gateway.disconnect("reconnect for activity")
-        advanceUntilIdle()
+        gateway.resumeRequests.first { it >= 2 }
+        viewModel.state.first { state ->
+            state.agentActivity?.presentation == ActivityPresentationState.Discovering &&
+                state.turnState == TurnState.Idle
+        }
+        advanceTimeBy(100L)
+        runCurrent()
+        viewModel.state.first { state ->
+            state.agentActivity?.presentation == ActivityPresentationState.Unavailable &&
+                state.turnState == TurnState.Idle
+        }
 
         assertEquals(
             ActivityPresentationState.Unavailable,
@@ -258,6 +341,12 @@ class CelesteViewModelTest {
             }.toString(),
         )
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.messages.any {
+                it.role == "assistant" &&
+                    it.text == "<assistant-before>\n<assistant-after>"
+            } && state.agentActivity?.items?.filterIsInstance<ServerReasoningActivity>()?.size == 1
+        }
 
         val state = viewModel.state.value
         assertEquals(
@@ -290,6 +379,11 @@ class CelesteViewModelTest {
             """{"content":"<server-summary>\n<assistant-content>","status":"complete"}""",
         )
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.messages.filter { it.role == "assistant" }.map { it.text } ==
+                listOf("<assistant-content>") &&
+                state.agentActivity?.items?.filterIsInstance<ServerReasoningActivity>()?.size == 1
+        }
 
         assertEquals(
             listOf("<assistant-content>"),
@@ -319,6 +413,13 @@ class CelesteViewModelTest {
         gateway.emit("message.complete", """{"content":"Hello continued","status":"complete"}""")
         gateway.emit("message.complete", """{"content":"Hello continued","status":"complete"}""")
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.turnState == TurnState.Idle &&
+                state.streamingText.isEmpty() &&
+                state.messages.map { it.role } == listOf("user", "assistant") &&
+                state.messages.singleOrNull { it.role == "assistant" }?.text == "Hello continued" &&
+                state.messages.singleOrNull { it.role == "user" }?.pending == false
+        }
 
         val state = viewModel.state.value
         assertEquals(TurnState.Idle, state.turnState)
@@ -338,7 +439,10 @@ class CelesteViewModelTest {
         viewModel.sendMessage()
         gateway.emit("message.start")
         gateway.emit("message.delta", """{"text":"Partial work"}""")
-        advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.turnState == TurnState.Running &&
+                state.streamingText == "Partial work"
+        }
 
         gateway.resumePayload = resumePayload(
             messages = listOf(
@@ -348,12 +452,17 @@ class CelesteViewModelTest {
             running = false,
         )
         viewModel.interrupt()
-        advanceUntilIdle()
+        gateway.interruptRequests.first { it >= 1 }
+        viewModel.state.first { state ->
+            state.turnState == TurnState.Idle &&
+                state.messages.lastOrNull()?.text == "Partial work"
+        }
 
         assertTrue(gateway.methods.contains("session.interrupt"))
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         assertEquals("Partial work", viewModel.state.value.messages.last().text)
         viewModel.leaveConversation()
+        advanceUntilIdle()
     }
 
     @Test
@@ -375,6 +484,13 @@ class CelesteViewModelTest {
         )
         gateway.disconnect("dashboard restarted")
         advanceUntilIdle()
+
+        viewModel.state.first { state ->
+            state.messages.map(ConversationMessage::text) ==
+                listOf("Do this once", "Finished exactly once") &&
+                state.streamingText.isEmpty() &&
+                state.turnState == TurnState.Idle
+        }
 
         val state = viewModel.state.value
         assertEquals(2, gateway.connectCount)
@@ -411,7 +527,10 @@ class CelesteViewModelTest {
         firstResume.complete(resumePayload(messages = emptyList(), running = true))
         runCurrent()
 
-        assertEquals("buffered-after-snapshot", viewModel.state.value.streamingText)
+        viewModel.state.first { state ->
+            state.streamingText == "buffered-after-snapshot"
+        }
+        gateway.resumeRequests.first { it >= 3 }
         assertEquals(3, gateway.resumeRequestCount)
 
         secondResume.complete(
@@ -424,12 +543,20 @@ class CelesteViewModelTest {
         )
         advanceUntilIdle()
 
+        viewModel.state.first { state ->
+            state.messages.map(ConversationMessage::text) ==
+                listOf("new-authoritative-state") &&
+                state.streamingText.isEmpty() &&
+                state.turnState == TurnState.Idle
+        }
+
         assertEquals(
             listOf("new-authoritative-state"),
             viewModel.state.value.messages.map(ConversationMessage::text),
         )
         assertEquals("", viewModel.state.value.streamingText)
         viewModel.leaveConversation()
+        advanceUntilIdle()
     }
 
     @Test
@@ -439,19 +566,22 @@ class CelesteViewModelTest {
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
-        )
+        ).also(::track)
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
         viewModel.loadSessions()
         viewModel.openSession(dashboard.session)
-        advanceUntilIdle()
+        viewModel.state.first {
+            it.agentActivity?.runtimeSessionId?.isNotBlank() == true &&
+                it.loadingMessage == null
+        }
 
         val oldResume = CompletableDeferred<JsonObject>()
         oldGateway.resumeGates += oldResume
         oldGateway.failPrompt = true
         viewModel.updateDraft("This must not leak")
         viewModel.sendMessage()
-        runCurrent()
+        oldGateway.resumeRequests.first { it >= 2 }
         assertEquals(2, oldGateway.resumeRequestCount)
 
         val newGateway = FakeGateway()
@@ -474,7 +604,11 @@ class CelesteViewModelTest {
                 running = false,
             ),
         )
-        advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.activeSummary?.id == "stored-new" &&
+                state.messages.map(ConversationMessage::text) == listOf("selected-session") &&
+                state.agentActivity?.presentation == ActivityPresentationState.Unavailable
+        }
 
         assertEquals("stored-new", viewModel.state.value.activeSummary?.id)
         assertEquals(
@@ -493,7 +627,7 @@ class CelesteViewModelTest {
             dashboard = dashboard,
             connectionStore = store,
             reconnectDelayMillis = { _, _ -> 0L },
-        )
+        ).also(::track)
         advanceUntilIdle()
         viewModel.updateDashboardUrl("https://hermes.test")
         viewModel.findDashboard()
@@ -527,7 +661,7 @@ class CelesteViewModelTest {
         val dashboard = FakeDashboard(FakeGateway()).apply {
             profileFailure = AuthenticationRejected("Hermes rejected profile access.")
         }
-        val viewModel = CelesteViewModel(dashboard = dashboard)
+        val viewModel = CelesteViewModel(dashboard = dashboard).also(::track)
         advanceUntilIdle()
 
         viewModel.updateDashboardUrl("http://hermes.test:9119")
@@ -549,6 +683,10 @@ class CelesteViewModelTest {
 
         viewModel.onForeground()
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.turnState == TurnState.Idle &&
+                state.agentActivity?.presentation == ActivityPresentationState.Unavailable
+        }
 
         assertEquals(2, gateway.connectCount)
         assertEquals(1, gateway.methods.count { it == "session.list" })
@@ -564,7 +702,7 @@ class CelesteViewModelTest {
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
-        )
+        ).also(::track)
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
         viewModel.loadSessions()
@@ -613,7 +751,7 @@ class CelesteViewModelTest {
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
-        )
+        ).also(::track)
         advanceUntilIdle()
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
@@ -685,12 +823,12 @@ class CelesteViewModelTest {
         viewModel.sendMessage()
         advanceUntilIdle()
         gateway.emit("message.start")
-        runCurrent()
+        viewModel.state.first { it.turnState == TurnState.Running }
 
         val interruptGate = CompletableDeferred<Unit>()
         gateway.interruptGates += interruptGate
         viewModel.interrupt()
-        runCurrent()
+        gateway.interruptRequests.first { it >= 1 }
         assertEquals(1, gateway.methods.count { it == "session.interrupt" })
 
         viewModel.leaveConversation()
@@ -737,7 +875,7 @@ class CelesteViewModelTest {
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
             activityDisclosurePreferences = preferences,
-        )
+        ).also(::track)
         advanceUntilIdle()
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
@@ -792,6 +930,10 @@ class CelesteViewModelTest {
             """{"status":"complete","failure_reason":"Synthetic failure detail"}""",
         )
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.turnState == TurnState.Idle &&
+                state.notice?.category == UiNoticeCategory.ServerTurnFailure
+        }
 
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
         assertEquals(UiNoticeCategory.ServerTurnFailure, viewModel.state.value.notice?.category)
@@ -809,6 +951,13 @@ class CelesteViewModelTest {
         )
         gateway.emit("message.complete", """{"status":"complete"}""")
         advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.agentActivity?.items.orEmpty()
+                .filterIsInstance<ToolActivity>()
+                .singleOrNull()
+                ?.phase == ToolPhase.Interrupted &&
+                state.turnState == TurnState.Idle
+        }
 
         assertEquals(
             ToolPhase.Interrupted,
@@ -835,11 +984,16 @@ class CelesteViewModelTest {
             activityDisclosurePreferences = activityDisclosurePreferences,
             activityDiscoveryTimeoutMillis = activityDiscoveryTimeoutMillis,
             reasoningCoalescingWindowMillis = reasoningCoalescingWindowMillis,
-        )
+        ).also(::track)
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
         viewModel.loadSessions()
         viewModel.openSession(dashboard.session)
+        viewModel.state.first {
+            it.agentActivity?.runtimeSessionId?.isNotBlank() == true &&
+                it.loadingMessage == null
+        }
+        gateway.eventSubscribers.first { it > 0 }
         return viewModel
     }
 
@@ -940,6 +1094,7 @@ class CelesteViewModelTest {
         private val mutableEvents = MutableSharedFlow<GatewayEvent>(extraBufferCapacity = 32)
         override val state: StateFlow<GatewayConnectionState> = mutableState
         override val events: SharedFlow<GatewayEvent> = mutableEvents
+        val eventSubscribers: StateFlow<Int> = mutableEvents.subscriptionCount
 
         val methods = mutableListOf<String>()
         val requests = mutableListOf<Pair<String, JsonObject>>()
@@ -955,6 +1110,10 @@ class CelesteViewModelTest {
         val interruptGates = mutableListOf<CompletableDeferred<Unit>>()
         val resumeGates = mutableListOf<CompletableDeferred<JsonObject>>()
         var resumeRequestCount = 0
+        private val mutableResumeRequests = MutableStateFlow(0)
+        val resumeRequests: StateFlow<Int> = mutableResumeRequests
+        private val mutableInterruptRequests = MutableStateFlow(0)
+        val interruptRequests: StateFlow<Int> = mutableInterruptRequests
 
         override suspend fun connect() {
             connectCount += 1
@@ -973,6 +1132,7 @@ class CelesteViewModelTest {
             return when (method) {
                 "session.resume" -> {
                     resumeRequestCount += 1
+                    mutableResumeRequests.value = resumeRequestCount
                     if (resumeGates.isEmpty()) resumePayload else resumeGates.removeAt(0).await()
                 }
                 "session.create" -> {
@@ -1000,6 +1160,7 @@ class CelesteViewModelTest {
                     buildJsonObject { put("status", "streaming") }
                 }
                 "session.interrupt" -> {
+                    mutableInterruptRequests.value += 1
                     if (interruptGates.isNotEmpty()) interruptGates.removeAt(0).await()
                     buildJsonObject { put("status", "interrupting") }
                 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -949,8 +949,13 @@ class CelesteViewModelTest {
             "tool.start",
             """{"name":"terminal","tool_call_id":"call-incomplete"}""",
         )
+        viewModel.state.first { state ->
+            state.agentActivity?.items.orEmpty()
+                .filterIsInstance<ToolActivity>()
+                .singleOrNull()
+                ?.phase == ToolPhase.Running
+        }
         gateway.emit("message.complete", """{"status":"complete"}""")
-        advanceUntilIdle()
         viewModel.state.first { state ->
             state.agentActivity?.items.orEmpty()
                 .filterIsInstance<ToolActivity>()

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -5,8 +5,11 @@ import java.io.IOException
 import dev.hazydreams.hermesceleste.connection.InMemoryConnectionStore
 import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
+import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
+import dev.hazydreams.hermesceleste.network.ActivityDisclosurePreferenceStore
 import dev.hazydreams.hermesceleste.network.AuthProvider
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.CorrelationQuality
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.DashboardService
@@ -14,7 +17,11 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.InMemoryActivityDisclosurePreferenceStore
+import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.network.ToolActivity
+import dev.hazydreams.hermesceleste.network.ToolPhase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -52,6 +59,81 @@ class CelesteViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun projectsToolAndServerReasoningSeparatelyAndHonorsDeviceDisclosure() = runTest {
+        val gateway = FakeGateway()
+        val preferences = InMemoryActivityDisclosurePreferenceStore()
+        val viewModel = openConversation(gateway, preferences)
+
+        gateway.emit(
+            "tool.start",
+            """{"name":"terminal","tool_call_id":"call-1","args":"<tool-input>"}""",
+        )
+        gateway.emit(
+            "reasoning.available",
+            """{"text":"<server-summary>","label":"Server summary"}""",
+        )
+        gateway.emit(
+            "tool.complete",
+            """{"name":"terminal","tool_call_id":"call-1","output":"<tool-output>"}""",
+        )
+        advanceUntilIdle()
+
+        val activity = requireNotNull(viewModel.state.value.agentActivity)
+        assertEquals(2, activity.items.size)
+        assertEquals(1, activity.items.filterIsInstance<ToolActivity>().size)
+        assertEquals(1, activity.items.filterIsInstance<ServerReasoningActivity>().size)
+        assertEquals(
+            ToolPhase.Completed,
+            activity.items.filterIsInstance<ToolActivity>().single().phase,
+        )
+        assertEquals(
+            CorrelationQuality.ExactId,
+            activity.items.filterIsInstance<ToolActivity>().single().correlation,
+        )
+        assertEquals(ActivityCapabilityState.ToolAndServerReasoning, activity.capability)
+
+        viewModel.setActivityReasoningDisclosureEnabled(false)
+        assertFalse(viewModel.state.value.agentActivityReasoningDisclosureEnabled)
+        assertFalse(preferences.isServerReasoningDisclosureEnabled())
+        assertTrue(viewModel.state.value.agentActivity?.items.orEmpty().none { it is ServerReasoningActivity })
+        assertEquals(
+            ActivityCapabilityState.ToolAndServerReasoning,
+            viewModel.state.value.agentActivity?.capability,
+        )
+        assertTrue(gateway.methods.none { it.contains("activity", ignoreCase = true) })
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun reconnectRestoresActivityProjectionFromAuthoritativeSnapshot() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        gateway.emit(
+            "tool.start",
+            """{"name":"terminal","tool_call_id":"call-1"}""",
+        )
+        advanceUntilIdle()
+        assertEquals(
+            dev.hazydreams.hermesceleste.network.ActivityPresentationState.Running,
+            viewModel.state.value.agentActivity?.presentation,
+        )
+
+        gateway.resumePayload = resumePayload(
+            messages = emptyList(),
+            running = false,
+        )
+        gateway.disconnect("reconnect for activity")
+        advanceUntilIdle()
+
+        assertEquals(
+            dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering,
+            viewModel.state.value.agentActivity?.presentation,
+        )
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        viewModel.leaveConversation()
     }
 
     @Test
@@ -267,11 +349,16 @@ class CelesteViewModelTest {
         assertEquals("and still arriving", suffix)
     }
 
-    private suspend fun openConversation(gateway: FakeGateway): CelesteViewModel {
+    private suspend fun openConversation(
+        gateway: FakeGateway,
+        activityDisclosurePreferences: ActivityDisclosurePreferenceStore =
+            InMemoryActivityDisclosurePreferenceStore(),
+    ): CelesteViewModel {
         val dashboard = FakeDashboard(gateway)
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
+            activityDisclosurePreferences = activityDisclosurePreferences,
         )
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -8,6 +8,7 @@ import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
 import dev.hazydreams.hermesceleste.network.ActivityDisclosurePreferenceStore
 import dev.hazydreams.hermesceleste.network.ActivityDisclosureScope
+import dev.hazydreams.hermesceleste.network.ActivityPresentationState
 import dev.hazydreams.hermesceleste.network.AuthProvider
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.CorrelationQuality
@@ -30,8 +31,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.json.Json
@@ -60,6 +63,66 @@ class CelesteViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun emptyActivitySnapshotTimesOutToUnavailableWithoutBlockingTheConversation() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(
+            gateway = gateway,
+            activityDiscoveryTimeoutMillis = 100L,
+        )
+        runCurrent()
+
+        assertEquals(
+            ActivityPresentationState.Discovering,
+            viewModel.state.value.agentActivity?.presentation,
+        )
+
+        advanceTimeBy(100L)
+        runCurrent()
+
+        assertEquals(
+            ActivityPresentationState.Unavailable,
+            viewModel.state.value.agentActivity?.presentation,
+        )
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun reasoningDeltasAreCoalescedIntoOneProjectionUpdate() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(
+            gateway = gateway,
+            reasoningCoalescingWindowMillis = 100L,
+        )
+        runCurrent()
+
+        gateway.emit(
+            "reasoning.delta",
+            """{"text":"<reasoning-one>","verbose":true}""",
+        )
+        gateway.emit(
+            "reasoning.delta",
+            """{"text":"<reasoning-two>","verbose":true}""",
+        )
+        runCurrent()
+        assertTrue(
+            viewModel.state.value.agentActivity?.items.orEmpty()
+                .filterIsInstance<ServerReasoningActivity>().isEmpty(),
+        )
+
+        advanceTimeBy(100L)
+        runCurrent()
+
+        val reasoning = viewModel.state.value.agentActivity?.items
+            ?.filterIsInstance<ServerReasoningActivity>()
+            ?.single()
+        assertEquals("<reasoning-one><reasoning-two>", reasoning?.text?.text)
+        assertEquals(1, viewModel.state.value.agentActivity?.items
+            ?.filterIsInstance<ServerReasoningActivity>()?.size)
+        viewModel.leaveConversation()
     }
 
     @Test
@@ -117,7 +180,7 @@ class CelesteViewModelTest {
     }
 
     @Test
-    fun reconnectRestoresActivityProjectionFromAuthoritativeSnapshot() = runTest {
+    fun reconnectRestoresActivityProjectionAndFallsBackWhenSnapshotIsEmpty() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
         gateway.emit(
@@ -138,7 +201,7 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            dev.hazydreams.hermesceleste.network.ActivityPresentationState.Discovering,
+            ActivityPresentationState.Unavailable,
             viewModel.state.value.agentActivity?.presentation,
         )
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
@@ -406,6 +469,23 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun messageFailureReasonSurfacesAsAUserSafeErrorAndSettlesTheTurn() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        viewModel.updateDraft("Trigger a synthetic failure")
+        viewModel.sendMessage()
+        gateway.emit(
+            "message.complete",
+            """{"status":"complete","failure_reason":"Synthetic failure detail"}""",
+        )
+        advanceUntilIdle()
+
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertEquals("Synthetic failure detail", viewModel.state.value.errorMessage)
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun messageCompletionSettlesAnUnfinishedToolWithoutBlockingTheTurn() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
@@ -431,12 +511,16 @@ class CelesteViewModelTest {
         gateway: FakeGateway,
         activityDisclosurePreferences: ActivityDisclosurePreferenceStore =
             InMemoryActivityDisclosurePreferenceStore(),
+        activityDiscoveryTimeoutMillis: Long = 1_000L,
+        reasoningCoalescingWindowMillis: Long = 75L,
     ): CelesteViewModel {
         val dashboard = FakeDashboard(gateway)
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
             activityDisclosurePreferences = activityDisclosurePreferences,
+            activityDiscoveryTimeoutMillis = activityDiscoveryTimeoutMillis,
+            reasoningCoalescingWindowMillis = reasoningCoalescingWindowMillis,
         )
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()

--- a/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
@@ -1,9 +1,18 @@
 package dev.hazydreams.hermesceleste
 
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.ActivityItem
+import dev.hazydreams.hermesceleste.network.CorrelationQuality
+import dev.hazydreams.hermesceleste.network.ReasoningPhase
+import dev.hazydreams.hermesceleste.network.ReasoningSource
+import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
+import dev.hazydreams.hermesceleste.network.ToolActivity
+import dev.hazydreams.hermesceleste.network.ToolPhase
 import dev.hazydreams.hermesceleste.ui.conversation.STREAMING_TRANSCRIPT_KEY
+import dev.hazydreams.hermesceleste.ui.conversation.activityItemKeys
 import dev.hazydreams.hermesceleste.ui.conversation.transcriptItemKeys
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TranscriptItemKeysTest {
@@ -41,6 +50,53 @@ class TranscriptItemKeysTest {
             transcriptItemKeys(messages),
         )
         assertEquals(transcriptItemKeys(messages), transcriptItemKeys(messages))
+    }
+
+    @Test
+    fun activityRowsUseStableNamespacedKeysForDuplicateOrBlankSourceKeys() {
+        val items: List<ActivityItem> = listOf(
+            ToolActivity(
+                uiKey = "activity:stored-42:live:1",
+                callId = "call-1",
+                name = "terminal",
+                phase = ToolPhase.Running,
+                input = null,
+                output = null,
+                startedAt = null,
+                finishedAt = null,
+                correlation = CorrelationQuality.ExactId,
+            ),
+            ToolActivity(
+                uiKey = "activity:stored-42:live:1",
+                callId = "call-2",
+                name = "terminal",
+                phase = ToolPhase.Completed,
+                input = null,
+                output = null,
+                startedAt = null,
+                finishedAt = null,
+                correlation = CorrelationQuality.ExactId,
+            ),
+            ServerReasoningActivity(
+                uiKey = "",
+                source = ReasoningSource.ServerSummary,
+                phase = ReasoningPhase.Complete,
+                text = dev.hazydreams.hermesceleste.network.DisplayedDetail(
+                    text = "<server-summary>",
+                    originalLength = "<server-summary>".length,
+                    wasTruncated = false,
+                    wasRedacted = false,
+                    canRestore = false,
+                ),
+                serverLabel = "Server-provided summary",
+            ),
+        )
+
+        val keys = activityItemKeys(items)
+        assertEquals(3, keys.toSet().size)
+        assertTrue(keys.all { it.startsWith("activity-ui:") })
+        assertTrue(keys[1].contains(":occurrence:2"))
+        assertEquals(keys, activityItemKeys(items))
     }
 
     private fun message(id: String?): ConversationMessage =

--- a/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
@@ -1,16 +1,21 @@
 package dev.hazydreams.hermesceleste
 
-import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.ActivityCapabilityState
 import dev.hazydreams.hermesceleste.network.ActivityItem
+import dev.hazydreams.hermesceleste.network.ActivityPresentationState
+import dev.hazydreams.hermesceleste.network.ActivitySource
+import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.CorrelationQuality
 import dev.hazydreams.hermesceleste.network.ReasoningPhase
 import dev.hazydreams.hermesceleste.network.ReasoningSource
 import dev.hazydreams.hermesceleste.network.ServerReasoningActivity
 import dev.hazydreams.hermesceleste.network.ToolActivity
 import dev.hazydreams.hermesceleste.network.ToolPhase
+import dev.hazydreams.hermesceleste.network.initialActivityProjection
 import dev.hazydreams.hermesceleste.ui.conversation.STREAMING_TRANSCRIPT_KEY
 import dev.hazydreams.hermesceleste.ui.conversation.activityItemKeys
 import dev.hazydreams.hermesceleste.ui.conversation.transcriptItemKeys
+import dev.hazydreams.hermesceleste.ui.conversation.transcriptMessagesForActivity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -97,6 +102,60 @@ class TranscriptItemKeysTest {
         assertTrue(keys.all { it.startsWith("activity-ui:") })
         assertTrue(keys[1].contains(":occurrence:2"))
         assertEquals(keys, activityItemKeys(items))
+    }
+
+    @Test
+    fun legacyToolTranscriptRowsRemainVisibleWhenActivityIsUnavailable() {
+        val messages = listOf(
+            message("user-1").copy(role = "user", text = "Run this"),
+            message("tool-1").copy(role = "tool", text = "Legacy output", toolName = "terminal"),
+        )
+        val unavailable = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+        ).copy(
+            source = ActivitySource.Unavailable,
+            capability = ActivityCapabilityState.Unsupported,
+            presentation = ActivityPresentationState.Unavailable,
+        )
+
+        assertEquals(messages, transcriptMessagesForActivity(messages, null))
+        assertEquals(messages, transcriptMessagesForActivity(messages, unavailable))
+    }
+
+    @Test
+    fun transcriptToolRowsAreRemovedOnlyWhenEveryRowHasAnActivityCard() {
+        val tool = ToolActivity(
+            uiKey = "activity:stored-42:tool-legacy:terminal:occurrence:1",
+            callId = null,
+            name = "terminal",
+            phase = ToolPhase.Completed,
+            input = null,
+            output = null,
+            startedAt = null,
+            finishedAt = null,
+            correlation = CorrelationQuality.LegacyName,
+        )
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+        ).copy(
+            items = listOf(tool),
+            source = ActivitySource.Legacy,
+            capability = ActivityCapabilityState.LegacyToolOnly,
+            presentation = ActivityPresentationState.Available,
+        )
+        val messages = listOf(
+            message("tool-1").copy(role = "tool", text = "First", toolName = "terminal"),
+            message("tool-2").copy(role = "tool", text = "Second", toolName = "terminal"),
+        )
+
+        assertEquals(messages, transcriptMessagesForActivity(messages, projection))
+        assertTrue(
+            transcriptMessagesForActivity(messages.dropLast(1), projection).isEmpty(),
+        )
     }
 
     private fun message(id: String?): ConversationMessage =

--- a/app/src/test/java/dev/hazydreams/hermesceleste/UiProjectionTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/UiProjectionTest.kt
@@ -1,0 +1,43 @@
+package dev.hazydreams.hermesceleste
+
+import java.util.concurrent.CancellationException
+import dev.hazydreams.hermesceleste.network.AuthenticationRejected
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
+import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
+import dev.hazydreams.hermesceleste.network.RateLimited
+import dev.hazydreams.hermesceleste.network.TransportUnavailable
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UiProjectionTest {
+    @Test
+    fun projectsFailuresToFixedCopyWithoutCauseOrServerText() {
+        val privateText = "private prompt https://internal.example/path /srv/secret"
+        val cases = listOf(
+            AuthenticationRejected(privateText) to UiNoticeCategory.AuthenticationRequired,
+            RateLimited(privateText) to UiNoticeCategory.RateLimited,
+            TransportUnavailable(privateText) to UiNoticeCategory.TransportUnavailable,
+            InvalidDashboardResponse(privateText) to UiNoticeCategory.InvalidResponse,
+            GatewayRpcException(500, privateText) to UiNoticeCategory.GenericTurnFailure,
+        )
+
+        cases.forEach { (error, category) ->
+            val notice = requireNotNull(projectUiNotice(error, UiNoticeScope.Turn))
+            assertEquals(category, notice.category)
+            assertFalse(notice.message.contains(privateText))
+            assertFalse(notice.message.contains("internal.example"))
+            assertFalse(notice.message.contains("/srv/secret"))
+        }
+    }
+
+    @Test
+    fun wrappedCancellationIsSilentWhileTimeoutIsRecoverable() {
+        val cancellation = CancellationException("private cancellation detail")
+        val wrapped = IllegalStateException("legacy wrapper", cancellation)
+
+        assertNull(projectUiNotice(cancellation, UiNoticeScope.Turn))
+        assertNull(projectUiNotice(wrapped, UiNoticeScope.Connection))
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStoreTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStoreTest.kt
@@ -1,0 +1,119 @@
+package dev.hazydreams.hermesceleste.network
+
+import android.content.SharedPreferences
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActivityDisclosurePreferenceStoreTest {
+    @Test
+    fun androidPreferencesPersistScopedChoicesWithoutStoringTheAuthorityValues() {
+        val preferences = inMemorySharedPreferences()
+        val scope = ActivityDisclosureScope(
+            originKey = "https://hermes.test/",
+            profile = "default",
+            storedSessionId = "stored-42",
+        )
+        val otherScope = scope.copy(profile = "work")
+
+        AndroidActivityDisclosurePreferenceStore.fromPreferences(preferences)
+            .setServerReasoningDisclosureEnabled(scope, false)
+
+        val reopened = AndroidActivityDisclosurePreferenceStore.fromPreferences(preferences)
+        assertFalse(
+            reopened.isServerReasoningDisclosureEnabled(
+                scope.copy(originKey = "https://hermes.test"),
+            ),
+        )
+        assertTrue(reopened.isServerReasoningDisclosureEnabled(otherScope))
+        assertTrue(reopened.isServerReasoningDisclosureEnabled())
+
+        val storedKeys = preferences.all.keys
+        assertTrue(storedKeys.none { key -> key.contains("hermes.test") })
+        assertTrue(storedKeys.none { key -> key.contains("stored-42") })
+    }
+
+    @Test
+    fun androidPreferencesRetainGlobalDefaultAcrossStoreInstances() {
+        val preferences = inMemorySharedPreferences()
+        val first = AndroidActivityDisclosurePreferenceStore.fromPreferences(preferences)
+
+        first.setServerReasoningDisclosureEnabled(false)
+
+        val reopened = AndroidActivityDisclosurePreferenceStore.fromPreferences(preferences)
+        assertFalse(reopened.isServerReasoningDisclosureEnabled())
+        assertFalse(
+            reopened.isServerReasoningDisclosureEnabled(
+                ActivityDisclosureScope(
+                    originKey = "https://other.test",
+                    profile = "default",
+                    storedSessionId = "other-session",
+                ),
+            ),
+        )
+    }
+
+    private fun inMemorySharedPreferences(): SharedPreferences {
+        val values = mutableMapOf<String, Any?>()
+        lateinit var editor: SharedPreferences.Editor
+        val editorHandler = InvocationHandler { _, method, args ->
+            when (method.name) {
+                "putBoolean" -> {
+                    val arguments = requireNotNull(args)
+                    values[arguments[0] as String] = arguments[1] as Boolean
+                    editor
+                }
+                "remove" -> {
+                    val arguments = requireNotNull(args)
+                    values.remove(arguments[0] as String)
+                    editor
+                }
+                "clear" -> {
+                    values.clear()
+                    editor
+                }
+                "commit" -> true
+                "apply" -> Unit
+                else -> defaultReturn(method)
+            }
+        }
+        editor = Proxy.newProxyInstance(
+            SharedPreferences.Editor::class.java.classLoader,
+            arrayOf(SharedPreferences.Editor::class.java),
+            editorHandler,
+        ) as SharedPreferences.Editor
+
+        val preferencesHandler = InvocationHandler { _, method, args ->
+            when (method.name) {
+                "getBoolean" -> {
+                    val arguments = requireNotNull(args)
+                    values[arguments[0] as String] as? Boolean ?: arguments[1] as Boolean
+                }
+                "getAll" -> values.toMap()
+                "contains" -> {
+                    val arguments = requireNotNull(args)
+                    values.containsKey(arguments[0] as String)
+                }
+                "edit" -> editor
+                else -> defaultReturn(method)
+            }
+        }
+        return Proxy.newProxyInstance(
+            SharedPreferences::class.java.classLoader,
+            arrayOf(SharedPreferences::class.java),
+            preferencesHandler,
+        ) as SharedPreferences
+    }
+
+    private fun defaultReturn(method: Method): Any? = when (method.returnType) {
+        Boolean::class.javaPrimitiveType -> false
+        Int::class.javaPrimitiveType -> 0
+        Long::class.javaPrimitiveType -> 0L
+        Float::class.javaPrimitiveType -> 0f
+        Double::class.javaPrimitiveType -> 0.0
+        else -> null
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStoreTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/ActivityDisclosurePreferenceStoreTest.kt
@@ -56,14 +56,27 @@ class ActivityDisclosurePreferenceStoreTest {
         )
     }
 
-    private fun inMemorySharedPreferences(): SharedPreferences {
+    @Test
+    fun androidPreferencesRejectAnUnverifiedCommit() {
+        val preferences = inMemorySharedPreferences(writeOnPut = false)
+        val store = AndroidActivityDisclosurePreferenceStore.fromPreferences(preferences)
+
+        assertFalse(store.setServerReasoningDisclosureEnabled(false))
+        assertTrue(store.isServerReasoningDisclosureEnabled())
+    }
+
+    private fun inMemorySharedPreferences(
+        writeOnPut: Boolean = true,
+    ): SharedPreferences {
         val values = mutableMapOf<String, Any?>()
         lateinit var editor: SharedPreferences.Editor
         val editorHandler = InvocationHandler { _, method, args ->
             when (method.name) {
                 "putBoolean" -> {
                     val arguments = requireNotNull(args)
-                    values[arguments[0] as String] = arguments[1] as Boolean
+                    if (writeOnPut) {
+                        values[arguments[0] as String] = arguments[1] as Boolean
+                    }
                     editor
                 }
                 "remove" -> {

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
@@ -14,37 +14,18 @@ class AgentActivityTest {
     private val now = Instant.parse("2026-08-15T12:00:00Z")
 
     @Test
-    fun statusCapabilityDecodingDistinguishesUnknownUnsupportedAndSupportedModes() {
-        assertEquals(
-            ActivityCapabilityState.Unknown,
-            decodeActivityCapability(buildJsonObject {}),
-        )
-        assertEquals(
-            ActivityCapabilityState.Unsupported,
-            decodeActivityCapability(buildJsonObject { put("activity_supported", false) }),
-        )
-        assertEquals(
-            ActivityCapabilityState.ToolOnly,
-            decodeActivityCapability(
-                buildJsonObject {
-                    put(
-                        "activity",
-                        buildJsonObject {
-                            put("supported", true)
-                            put("tools", true)
-                        },
-                    )
-                },
-            ),
-        )
-        assertEquals(
-            ActivityCapabilityState.ToolAndServerReasoning,
-            decodeActivityCapability(
-                buildJsonObject {
-                    put("activity", buildJsonObject { put("server_reasoning", true) })
-                },
-            ),
-        )
+    fun statusCapabilityDecodingIgnoresUndocumentedFields() {
+        listOf(
+            buildJsonObject { put("activity_capability", "tool_only") },
+            buildJsonObject { put("activity_support", "available") },
+            buildJsonObject { put("activity_supported", false) },
+            buildJsonObject { put("activity", buildJsonObject { put("server_reasoning", true) }) },
+            buildJsonObject {
+                put("capabilities", buildJsonObject { put("activity", "legacy") })
+            },
+        ).forEach { status ->
+            assertEquals(ActivityCapabilityState.Unknown, decodeActivityCapability(status))
+        }
     }
 
     @Test
@@ -59,6 +40,31 @@ class AgentActivityTest {
         assertFalse(detail.text.contains("synthetic-bearer-token"))
         assertFalse(detail.text.contains("synthetic-api-key"))
         assertEquals(24, detail.text.codePointCount(0, detail.text.length))
+    }
+
+    @Test
+    fun sanitizerRedactsNestedAndQuotedJsonCredentials() {
+        val structured = sanitizeActivityDetail(
+            """{"credentials":{"password":"synthetic-json-password","api_key":"synthetic-json-api-key"},"safe":"<tool-output>"}""",
+            maxCodePoints = 1_000,
+        )
+        val quotedKeyText = sanitizeActivityDetail(
+            """payload {"password":"synthetic-quoted-password"} trailing""",
+            maxCodePoints = 1_000,
+        )
+
+        listOf(structured, quotedKeyText).forEach { detail ->
+            assertTrue(detail.wasRedacted)
+            assertTrue(detail.text.contains("[redacted]"))
+        }
+        listOf(
+            "synthetic-json-password",
+            "synthetic-json-api-key",
+            "synthetic-quoted-password",
+        ).forEach { secret ->
+            assertFalse(structured.text.contains(secret))
+            assertFalse(quotedKeyText.text.contains(secret))
+        }
     }
 
     @Test
@@ -87,7 +93,10 @@ class AgentActivityTest {
             event(
                 type = "reasoning.available",
                 sessionId = "runtime-7",
-                payload = buildJsonObject { put("text", "<server-summary>") },
+                payload = buildJsonObject {
+                    put("text", "<server-summary>")
+                    put("verbose", true)
+                },
             ),
             now = now,
         )
@@ -116,13 +125,36 @@ class AgentActivityTest {
     }
 
     @Test
+    fun reasoningAvailableWithoutVerboseIsSuppressedFailClosed() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val suppressed = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.available",
+                sessionId = "runtime-7",
+                payload = buildJsonObject { put("text", "<undisclosed-summary>") },
+            ),
+            now = now,
+        )
+
+        assertEquals(projection, suppressed)
+        assertTrue(suppressed.items.isEmpty())
+        assertEquals(ActivityCapabilityState.Unknown, suppressed.capability)
+    }
+
+    @Test
     fun snapshotDecoderKeepsToolDetailsAndServerReasoningAsDifferentItems() {
         val items = decodeGatewayActivity(
             Json.parseToJsonElement(
                 """
                 [
                   {"role":"tool","name":"terminal","tool_call_id":"call-1","args":"<tool-input>","output":"<tool-output>"},
-                  {"role":"assistant","reasoning":"<server-summary>","content":"<assistant-content>"}
+                  {"role":"assistant","reasoning":"<server-summary>","verbose":true,"content":"<assistant-content>"}
                 ]
                 """.trimIndent(),
             ).jsonArray,
@@ -279,7 +311,10 @@ class AgentActivityTest {
             event(
                 type = "reasoning.available",
                 sessionId = "runtime-7",
-                payload = buildJsonObject { put("text", "<server-summary>") },
+                payload = buildJsonObject {
+                    put("text", "<server-summary>")
+                    put("verbose", true)
+                },
             ),
             now = now,
         )
@@ -424,28 +459,27 @@ class AgentActivityTest {
     }
 
     @Test
-    fun terminalReplayWithoutEventIdDoesNotCreateSecondCard() {
+    fun duplicateTerminalRowsWithoutEventIdDoNotAmplifyReplay() {
         val projection = initialActivityProjection(
             originKey = "https://hermes.test",
             profile = "default",
             storedSessionId = "stored-42",
             runtimeSessionId = "runtime-7",
         )
+        val terminalRow = ToolActivity(
+            uiKey = "",
+            callId = null,
+            name = "terminal",
+            phase = ToolPhase.Completed,
+            input = null,
+            output = sanitizeActivityDetail("<tool-output>", TOOL_ACTIVITY_DETAIL_LIMIT),
+            startedAt = null,
+            finishedAt = now,
+            correlation = CorrelationQuality.LegacyName,
+        )
         val terminalSnapshot = AgentActivityReducer.applySnapshot(
             projection = projection,
-            items = listOf(
-                ToolActivity(
-                    uiKey = "",
-                    callId = null,
-                    name = "terminal",
-                    phase = ToolPhase.Completed,
-                    input = null,
-                    output = sanitizeActivityDetail("<tool-output>", TOOL_ACTIVITY_DETAIL_LIMIT),
-                    startedAt = null,
-                    finishedAt = now,
-                    correlation = CorrelationQuality.LegacyName,
-                ),
-            ),
+            items = listOf(terminalRow, terminalRow),
             binding = ActivityBinding(
                 originKey = "https://hermes.test/",
                 profile = "default",
@@ -470,7 +504,7 @@ class AgentActivityTest {
         )
 
         assertEquals(terminalSnapshot, replay)
-        assertEquals(1, replay.items.filterIsInstance<ToolActivity>().size)
+        assertEquals(2, replay.items.filterIsInstance<ToolActivity>().size)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
@@ -1,0 +1,264 @@
+package dev.hazydreams.hermesceleste.network
+
+import java.time.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentActivityTest {
+    private val now = Instant.parse("2026-08-15T12:00:00Z")
+
+    @Test
+    fun sanitizerRedactsCredentialsAndBoundsUnicodeWithoutRestoration() {
+        val raw = "Bearer synthetic-bearer-token api_key=synthetic-api-key " + "😀".repeat(30)
+
+        val detail = sanitizeActivityDetail(raw, maxCodePoints = 24)
+
+        assertTrue(detail.wasRedacted)
+        assertTrue(detail.wasTruncated)
+        assertFalse(detail.canRestore)
+        assertFalse(detail.text.contains("synthetic-bearer-token"))
+        assertFalse(detail.text.contains("synthetic-api-key"))
+        assertEquals(24, detail.text.codePointCount(0, detail.text.length))
+    }
+
+    @Test
+    fun exactToolIdPairsCompletionAndKeepsToolSeparateFromReasoning() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test/",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.start",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("tool_call_id", "call-1")
+                    put("args", "<tool-input>")
+                },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.available",
+                sessionId = "runtime-7",
+                payload = buildJsonObject { put("text", "<server-summary>") },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.complete",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("tool_call_id", "call-1")
+                    put("output", "<tool-output>")
+                },
+            ),
+            now = now,
+        )
+
+        val tool = projection.items.filterIsInstance<ToolActivity>().single()
+        val reasoning = projection.items.filterIsInstance<ServerReasoningActivity>().single()
+        assertEquals("call-1", tool.callId)
+        assertEquals(ToolPhase.Completed, tool.phase)
+        assertEquals(CorrelationQuality.ExactId, tool.correlation)
+        assertEquals(ReasoningSource.ServerSummary, reasoning.source)
+        assertEquals("<server-summary>", reasoning.text.text)
+        assertEquals(ActivityCapabilityState.ToolAndServerReasoning, projection.capability)
+    }
+
+    @Test
+    fun snapshotDecoderKeepsToolDetailsAndServerReasoningAsDifferentItems() {
+        val items = decodeGatewayActivity(
+            Json.parseToJsonElement(
+                """
+                [
+                  {"role":"tool","name":"terminal","tool_call_id":"call-1","args":"<tool-input>","output":"<tool-output>"},
+                  {"role":"assistant","reasoning":"<server-summary>","content":"<assistant-content>"}
+                ]
+                """.trimIndent(),
+            ).jsonArray,
+        )
+
+        assertEquals(
+            listOf("tool", "reasoning"),
+            items.map { item ->
+                when (item) {
+                    is ToolActivity -> "tool"
+                    is ServerReasoningActivity -> "reasoning"
+                }
+            },
+        )
+        assertEquals("<tool-input>", items.filterIsInstance<ToolActivity>().single().input?.text)
+        assertEquals("<tool-output>", items.filterIsInstance<ToolActivity>().single().output?.text)
+        assertEquals("<server-summary>", items.filterIsInstance<ServerReasoningActivity>().single().text.text)
+    }
+
+    @Test
+    fun overlappingLegacyCallsDoNotClaimACompletionPairing() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        repeat(2) {
+            projection = reduceActivityEvent(
+                projection,
+                event(
+                    type = "tool_call",
+                    sessionId = "runtime-7",
+                    payload = buildJsonObject { put("name", "terminal") },
+                ),
+                now = now,
+            )
+        }
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool_result",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("output", "<ambiguous-output>")
+                },
+            ),
+            now = now,
+        )
+
+        assertEquals(1, projection.ambiguousCorrelationCount)
+        assertEquals(3, projection.items.size)
+        assertEquals(
+            listOf(ToolPhase.Started, ToolPhase.Started, ToolPhase.Completed),
+            projection.items.filterIsInstance<ToolActivity>().map(ToolActivity::phase),
+        )
+        assertEquals(
+            CorrelationQuality.Uncorrelated,
+            projection.items.filterIsInstance<ToolActivity>().last().correlation,
+        )
+    }
+
+    @Test
+    fun wrongRuntimeEventsAndWrongSnapshotBindingsAreIgnored() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val event = event(
+            type = "tool.start",
+            sessionId = "other-runtime",
+            payload = buildJsonObject { put("name", "terminal") },
+        )
+
+        assertEquals(projection, reduceActivityEvent(projection, event, now = now))
+        val snapshot = AgentActivityReducer.applySnapshot(
+            projection = projection,
+            items = emptyList(),
+            binding = ActivityBinding(
+                originKey = "https://other.example",
+                profile = "default",
+                storedSessionId = "stored-42",
+                runtimeSessionId = "other-runtime",
+            ),
+            running = false,
+            now = now,
+        )
+        assertEquals(1, snapshot.malformedEventCount)
+        assertEquals(projection.items, snapshot.items)
+    }
+
+    @Test
+    fun snapshotItemsReceiveDeterministicNamespacedKeys() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "work",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val snapshot = AgentActivityReducer.applySnapshot(
+            projection = projection,
+            items = listOf(
+                ToolActivity(
+                    uiKey = "",
+                    callId = null,
+                    name = "terminal",
+                    phase = ToolPhase.Completed,
+                    input = null,
+                    output = null,
+                    startedAt = null,
+                    finishedAt = null,
+                    correlation = CorrelationQuality.LegacyName,
+                ),
+                ServerReasoningActivity(
+                    uiKey = "",
+                    source = ReasoningSource.ServerSummary,
+                    phase = ReasoningPhase.Complete,
+                    text = sanitizeActivityDetail("<server-summary>", REASONING_ACTIVITY_DETAIL_LIMIT),
+                    serverLabel = "Server-provided summary",
+                ),
+            ),
+            binding = ActivityBinding(
+                originKey = "https://hermes.test/",
+                profile = "work",
+                storedSessionId = "stored-42",
+                runtimeSessionId = "runtime-8",
+            ),
+            running = false,
+            now = now,
+        )
+
+        assertEquals(
+            listOf(
+                "activity:stored-42:snapshot:tool:0",
+                "activity:stored-42:snapshot:reasoning:1",
+            ),
+            snapshot.items.map(ActivityItem::uiKey),
+        )
+    }
+
+    @Test
+    fun disabledDisclosureRemovesReasoningBodyButRetainsCapabilityFact() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.available",
+                sessionId = "runtime-7",
+                payload = buildJsonObject { put("text", "<server-summary>") },
+            ),
+            now = now,
+        )
+
+        val hidden = AgentActivityReducer.withoutServerReasoning(projection)
+
+        assertTrue(hidden.items.isEmpty())
+        assertEquals(ActivityCapabilityState.ToolAndServerReasoning, hidden.capability)
+    }
+
+    private fun event(
+        type: String,
+        sessionId: String,
+        payload: kotlinx.serialization.json.JsonObject,
+    ): GatewayEvent = GatewayEvent(type = type, sessionId = sessionId, payload = payload)
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
@@ -68,6 +68,43 @@ class AgentActivityTest {
     }
 
     @Test
+    fun sanitizerRecursivelyRedactsTransportCredentialJsonKeys() {
+        val detail = sanitizeActivityDetail(
+            """
+            {"outer":[
+              {"Authorization":"synthetic-authorization"},
+              {"proxy-authorization":"synthetic-proxy-authorization"},
+              {"Cookie":"synthetic-cookie"},
+              {"set-cookie":["synthetic-set-cookie"]}
+            ]}
+            """.trimIndent(),
+            maxCodePoints = 1_000,
+        )
+
+        val embedded = sanitizeActivityDetail(
+            "wrapper {\"headers\":{\"authorization\":\"synthetic-embedded-authorization\"}}",
+            maxCodePoints = 1_000,
+        )
+
+        assertTrue(detail.wasRedacted)
+        assertTrue(embedded.wasRedacted)
+        listOf(
+            detail,
+            embedded,
+        ).forEach { sanitized ->
+            listOf(
+                "synthetic-authorization",
+                "synthetic-proxy-authorization",
+                "synthetic-cookie",
+                "synthetic-set-cookie",
+                "synthetic-embedded-authorization",
+            ).forEach { secret -> assertFalse(sanitized.text.contains(secret)) }
+        }
+        assertTrue(detail.text.contains("[redacted]"))
+        assertTrue(embedded.text.contains("[redacted]"))
+    }
+
+    @Test
     fun exactToolIdPairsCompletionAndKeepsToolSeparateFromReasoning() {
         var projection = initialActivityProjection(
             originKey = "https://hermes.test/",
@@ -416,6 +453,34 @@ class AgentActivityTest {
         assertEquals(CorrelationQuality.LegacyName, tool.correlation)
         assertEquals(ActivitySource.Legacy, projection.source)
         assertEquals(ActivityCapabilityState.LegacyToolOnly, projection.capability)
+    }
+
+    @Test
+    fun idlessToolStartReplayDoesNotCreateAnotherOccurrence() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val start = event(
+            type = "tool.start",
+            sessionId = "runtime-7",
+            payload = buildJsonObject {
+                put("name", "terminal")
+                put("args", "<tool-input>")
+            },
+        )
+
+        val first = reduceActivityEvent(projection, start, now = now)
+        val replay = reduceActivityEvent(first, start, now = now.plusSeconds(1))
+
+        assertEquals(first, replay)
+        assertEquals(1, replay.items.filterIsInstance<ToolActivity>().size)
+        assertEquals(
+            CorrelationQuality.LegacyName,
+            (replay.items.single() as ToolActivity).correlation,
+        )
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
@@ -14,6 +14,40 @@ class AgentActivityTest {
     private val now = Instant.parse("2026-08-15T12:00:00Z")
 
     @Test
+    fun statusCapabilityDecodingDistinguishesUnknownUnsupportedAndSupportedModes() {
+        assertEquals(
+            ActivityCapabilityState.Unknown,
+            decodeActivityCapability(buildJsonObject {}),
+        )
+        assertEquals(
+            ActivityCapabilityState.Unsupported,
+            decodeActivityCapability(buildJsonObject { put("activity_supported", false) }),
+        )
+        assertEquals(
+            ActivityCapabilityState.ToolOnly,
+            decodeActivityCapability(
+                buildJsonObject {
+                    put(
+                        "activity",
+                        buildJsonObject {
+                            put("supported", true)
+                            put("tools", true)
+                        },
+                    )
+                },
+            ),
+        )
+        assertEquals(
+            ActivityCapabilityState.ToolAndServerReasoning,
+            decodeActivityCapability(
+                buildJsonObject {
+                    put("activity", buildJsonObject { put("server_reasoning", true) })
+                },
+            ),
+        )
+    }
+
+    @Test
     fun sanitizerRedactsCredentialsAndBoundsUnicodeWithoutRestoration() {
         val raw = "Bearer synthetic-bearer-token api_key=synthetic-api-key " + "😀".repeat(30)
 
@@ -390,6 +424,56 @@ class AgentActivityTest {
     }
 
     @Test
+    fun terminalReplayWithoutEventIdDoesNotCreateSecondCard() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val terminalSnapshot = AgentActivityReducer.applySnapshot(
+            projection = projection,
+            items = listOf(
+                ToolActivity(
+                    uiKey = "",
+                    callId = null,
+                    name = "terminal",
+                    phase = ToolPhase.Completed,
+                    input = null,
+                    output = sanitizeActivityDetail("<tool-output>", TOOL_ACTIVITY_DETAIL_LIMIT),
+                    startedAt = null,
+                    finishedAt = now,
+                    correlation = CorrelationQuality.LegacyName,
+                ),
+            ),
+            binding = ActivityBinding(
+                originKey = "https://hermes.test/",
+                profile = "default",
+                storedSessionId = "stored-42",
+                runtimeSessionId = "runtime-7",
+            ),
+            running = false,
+            now = now,
+        )
+
+        val replay = reduceActivityEvent(
+            terminalSnapshot,
+            event(
+                type = "tool.complete",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("output", "<tool-output>")
+                },
+            ),
+            now = now,
+        )
+
+        assertEquals(terminalSnapshot, replay)
+        assertEquals(1, replay.items.filterIsInstance<ToolActivity>().size)
+    }
+
+    @Test
     fun malformedActivityEventDowngradesOnlyActivityPresentation() {
         val projection = initialActivityProjection(
             originKey = "https://hermes.test",
@@ -467,6 +551,23 @@ class AgentActivityTest {
     }
 
     @Test
+    fun snapshotReasoningWithoutDisclosureProofIsOmitted() {
+        val items = decodeGatewayActivity(
+            Json.parseToJsonElement(
+                """
+                [
+                  {"role":"assistant","reasoning":"<provider-reasoning>"},
+                  {"role":"assistant","reasoning":"<effort-only>","reasoning_effort":"high"},
+                  {"role":"assistant","reasoning":"<explicitly-hidden>","show_reasoning":false,"verbose":true}
+                ]
+                """.trimIndent(),
+            ).jsonArray,
+        )
+
+        assertTrue(items.isEmpty())
+    }
+
+    @Test
     fun reasoningRequiresTheExplicitStreamAndNeverUsesProviderThinkingContent() {
         var projection = initialActivityProjection(
             originKey = "https://hermes.test",
@@ -527,6 +628,67 @@ class AgentActivityTest {
         )
         assertEquals(1, snapshotItems.size)
         assertEquals("<server-summary>", snapshotItems.single().let { (it as ServerReasoningActivity).text.text })
+    }
+
+    @Test
+    fun unsafeToolNameMarkersFailClosedAcrossSnapshotsAndLegacyRows() {
+        val elements = Json.parseToJsonElement(
+            """
+            [
+              {"role":"tool","name":"secret_operation","metadata":{"sensitive":true},"output":"<tool-output>"}
+            ]
+            """.trimIndent(),
+        ).jsonArray
+
+        val activity = decodeGatewayActivity(elements).single() as ToolActivity
+        val message = decodeGatewayMessages(elements).single()
+
+        assertEquals("Tool activity", safeToolName("secret_operation", unsafe = true))
+        assertEquals("Tool activity", activity.name)
+        assertEquals("Tool activity", message.toolName)
+        assertFalse(activity.name.contains("secret_operation"))
+        assertFalse(message.toolName.orEmpty().contains("secret_operation"))
+    }
+
+    @Test
+    fun sanitizerRedactsHeadersQueriesTokensAndPrivateKeyBlocks() {
+        val bearer = "synthetic-" + "bearer-token"
+        val cookie = "synthetic-" + "cookie-value"
+        val sessionToken = "synthetic-" + "session-token"
+        val queryKey = "synthetic-" + "query-key"
+        val queryToken = "synthetic-" + "query-token"
+        val privateBody = "synthetic-" + "private-key"
+        val privateBegin = "-----" + "BEGIN PRIVATE KEY" + "-----"
+        val privateEnd = "-----" + "END PRIVATE KEY" + "-----"
+        val openAiToken = "sk-" + "synthetic-openai-token-1234"
+        val githubToken = "ghp_" + "syntheticgithub1234"
+        val jwtPayload = "syntheticjwtpayload0000000000"
+        val raw = listOf(
+            "Authorization: Bearer $bearer",
+            "Cookie: session=$cookie",
+            "x-hermes-session-token: $sessionToken",
+            "https://hermes.test/?api_key=$queryKey&token=$queryToken",
+            "$privateBegin\n$privateBody\n$privateEnd",
+            openAiToken,
+            githubToken,
+            "eyJ$jwtPayload.syntheticjwtsignature0000000000.syntheticjwtfinal0000000000",
+        ).joinToString("\n")
+
+        val detail = sanitizeActivityDetail(raw, maxCodePoints = 4_000)
+
+        assertTrue(detail.wasRedacted)
+        assertTrue(detail.text.contains("[redacted]"))
+        listOf(
+            bearer,
+            cookie,
+            sessionToken,
+            queryKey,
+            queryToken,
+            privateBody,
+            openAiToken,
+            githubToken,
+            jwtPayload,
+        ).forEach { secret -> assertFalse(detail.text.contains(secret)) }
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
@@ -225,8 +225,8 @@ class AgentActivityTest {
 
         assertEquals(
             listOf(
-                "activity:stored-42:snapshot:tool:0",
-                "activity:stored-42:snapshot:reasoning:1",
+                "activity:stored-42:tool-legacy:terminal:occurrence:1",
+                "activity:stored-42:reasoning:server:occurrence:1",
             ),
             snapshot.items.map(ActivityItem::uiKey),
         )
@@ -256,9 +256,319 @@ class AgentActivityTest {
         assertEquals(ActivityCapabilityState.ToolAndServerReasoning, hidden.capability)
     }
 
+    @Test
+    fun officialToolProgressUpdatesTheCorrelatedCardAndSurvivesCompletion() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.start",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("tool_id", "call-progress")
+                },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.progress",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("tool_id", "call-progress")
+                    put("progress", "<tool-progress>")
+                },
+            ),
+            now = now,
+        )
+
+        val running = projection.items.filterIsInstance<ToolActivity>().single()
+        assertEquals(ToolPhase.Running, running.phase)
+        assertEquals("<tool-progress>", running.progress?.text)
+        assertEquals("call-progress", running.callId)
+
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.complete",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("tool_id", "call-progress")
+                    put("output", "<tool-output>")
+                },
+            ),
+            now = now,
+        )
+        val completed = projection.items.filterIsInstance<ToolActivity>().single()
+        assertEquals(ToolPhase.Completed, completed.phase)
+        assertEquals("<tool-progress>", completed.progress?.text)
+        assertEquals("<tool-output>", completed.output?.text)
+    }
+
+    @Test
+    fun missingIdOfficialEventsUseLegacyCorrelationInsteadOfExactId() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.start",
+                sessionId = "runtime-7",
+                payload = buildJsonObject { put("name", "terminal") },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.complete",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("output", "<legacy-output>")
+                },
+            ),
+            now = now,
+        )
+
+        val tool = projection.items.filterIsInstance<ToolActivity>().single()
+        assertEquals(ToolPhase.Completed, tool.phase)
+        assertEquals(CorrelationQuality.LegacyName, tool.correlation)
+        assertEquals(ActivitySource.Legacy, projection.source)
+        assertEquals(ActivityCapabilityState.LegacyToolOnly, projection.capability)
+    }
+
+    @Test
+    fun explicitEventReplayIsIgnoredButAReusedToolIdGetsAnotherOccurrence() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val start = event(
+            type = "tool.start",
+            sessionId = "runtime-7",
+            payload = buildJsonObject {
+                put("name", "terminal")
+                put("tool_call_id", "reused-call")
+            },
+        ).copy(eventId = "event-start-1")
+        projection = reduceActivityEvent(projection, start, now = now)
+        projection = reduceActivityEvent(projection, start, now = now)
+        val complete = event(
+            type = "tool.complete",
+            sessionId = "runtime-7",
+            payload = buildJsonObject {
+                put("name", "terminal")
+                put("tool_call_id", "reused-call")
+            },
+        ).copy(eventId = "event-complete-1")
+        projection = reduceActivityEvent(projection, complete, now = now)
+        projection = reduceActivityEvent(projection, complete, now = now)
+        projection = reduceActivityEvent(
+            projection,
+            start.copy(eventId = "event-start-2"),
+            now = now,
+        )
+
+        val tools = projection.items.filterIsInstance<ToolActivity>()
+        assertEquals(2, tools.size)
+        assertEquals(listOf(ToolPhase.Completed, ToolPhase.Started), tools.map(ToolActivity::phase))
+        assertEquals(2, tools.map(ActivityItem::uiKey).toSet().size)
+    }
+
+    @Test
+    fun malformedActivityEventDowngradesOnlyActivityPresentation() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val updated = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.future_variant",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {},
+            ),
+            now = now,
+        )
+
+        assertEquals(ActivityCapabilityState.Unsupported, updated.capability)
+        assertEquals(ActivityPresentationState.Unavailable, updated.presentation)
+        assertEquals(1, updated.malformedEventCount)
+        assertEquals(projection.items, updated.items)
+    }
+
+    @Test
+    fun incompleteToolCardsSettleAsInterruptedOrFailed() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.start",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("tool_call_id", "call-interrupted")
+                },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event("message.complete", "runtime-7", buildJsonObject { put("status", "complete") }),
+            now = now,
+        )
+        assertEquals(
+            ToolPhase.Interrupted,
+            projection.items.filterIsInstance<ToolActivity>().single().phase,
+        )
+
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "tool.start",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("name", "terminal")
+                    put("tool_call_id", "call-failed")
+                },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event("message.error", "runtime-7", buildJsonObject {}),
+            now = now,
+        )
+        assertEquals(
+            ToolPhase.Failed,
+            projection.items.filterIsInstance<ToolActivity>().last().phase,
+        )
+    }
+
+    @Test
+    fun reasoningRequiresTheExplicitStreamAndNeverUsesProviderThinkingContent() {
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.delta",
+                sessionId = "runtime-7",
+                payload = buildJsonObject { put("text", "<unmarked-thinking>") },
+            ),
+            now = now,
+        )
+        assertTrue(projection.items.isEmpty())
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.delta",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("text", "<server-stream>")
+                    put("verbose", true)
+                },
+            ),
+            now = now,
+        )
+        projection = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.delta",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("text", "<server-stream>")
+                    put("verbose", true)
+                },
+            ),
+            now = now,
+        )
+        assertEquals(1, projection.items.filterIsInstance<ServerReasoningActivity>().size)
+        assertEquals(
+            "<server-stream>",
+            projection.items.filterIsInstance<ServerReasoningActivity>().single().text.text,
+        )
+
+        val snapshotItems = decodeGatewayActivity(
+            Json.parseToJsonElement(
+                """
+                [
+                  {"role":"assistant","reasoning_content":"<private-thinking>"},
+                  {"role":"assistant","reasoning":"<think>hidden</think>","verbose":true},
+                  {"role":"assistant","reasoning":"<server-summary>","verbose":true}
+                ]
+                """.trimIndent(),
+            ).jsonArray,
+        )
+        assertEquals(1, snapshotItems.size)
+        assertEquals("<server-summary>", snapshotItems.single().let { (it as ServerReasoningActivity).text.text })
+    }
+
+    @Test
+    fun redactionCoversSessionTokensAndBoundedActivityKeepsLatestHundredItems() {
+        val detail = sanitizeActivityDetail(
+            "session_token=synthetic-session-token x-hermes-session-token:synthetic-header-token",
+            500,
+        )
+        assertTrue(detail.wasRedacted)
+        assertFalse(detail.text.contains("synthetic-session-token"))
+        assertFalse(detail.text.contains("synthetic-header-token"))
+
+        var projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        repeat(105) { index ->
+            projection = reduceActivityEvent(
+                projection,
+                event(
+                    type = "tool.start",
+                    sessionId = "runtime-7",
+                    payload = buildJsonObject {
+                        put("name", "terminal")
+                        put("tool_call_id", "call-$index")
+                    },
+                ),
+                now = now,
+            )
+        }
+        val tools = projection.items.filterIsInstance<ToolActivity>()
+        assertEquals(100, tools.size)
+        assertEquals("call-5", tools.first().callId)
+        assertEquals("call-104", tools.last().callId)
+    }
+
     private fun event(
         type: String,
         sessionId: String,
         payload: kotlinx.serialization.json.JsonObject,
     ): GatewayEvent = GatewayEvent(type = type, sessionId = sessionId, payload = payload)
+
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/AgentActivityTest.kt
@@ -185,6 +185,49 @@ class AgentActivityTest {
     }
 
     @Test
+    fun explicitShowReasoningFalseSuppressesVerboseSummaryAndDelta() {
+        val projection = initialActivityProjection(
+            originKey = "https://hermes.test",
+            profile = "default",
+            storedSessionId = "stored-42",
+            runtimeSessionId = "runtime-7",
+        )
+        val summary = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.available",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("text", "<hidden-summary>")
+                    put("show_reasoning", false)
+                    put("verbose", true)
+                },
+            ),
+            now = now,
+        )
+        val delta = reduceActivityEvent(
+            projection,
+            event(
+                type = "reasoning.delta",
+                sessionId = "runtime-7",
+                payload = buildJsonObject {
+                    put("text", "<hidden-delta>")
+                    put("show_reasoning", false)
+                    put("verbose", true)
+                },
+            ),
+            now = now,
+        )
+
+        assertEquals(projection, summary)
+        assertEquals(projection, delta)
+        assertTrue(summary.items.isEmpty())
+        assertTrue(delta.items.isEmpty())
+        assertEquals(ActivityCapabilityState.Unknown, summary.capability)
+        assertEquals(ActivityCapabilityState.Unknown, delta.capability)
+    }
+
+    @Test
     fun snapshotDecoderKeepsToolDetailsAndServerReasoningAsDifferentItems() {
         val items = decodeGatewayActivity(
             Json.parseToJsonElement(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCardsTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCardsTest.kt
@@ -4,6 +4,7 @@ import dev.hazydreams.hermesceleste.network.ReasoningPhase
 import dev.hazydreams.hermesceleste.network.ToolPhase
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AgentActivityCardsTest {
@@ -29,5 +30,17 @@ class AgentActivityCardsTest {
 
         assertEquals("Displayed output, selectable displayed detail", description)
         assertFalse(description.contains("<private-detail>"))
+    }
+
+    @Test
+    fun activityPhaseAnnouncementsAreEmittedOncePerCardAndDisplayedPhase() {
+        val tracker = ActivityPhaseAnnouncementTracker()
+
+        assertTrue(tracker.consume("activity-ui:tool-1", "tool:running"))
+        assertFalse(tracker.consume("activity-ui:tool-1", "tool:running"))
+        assertTrue(tracker.consume("activity-ui:tool-1", "tool:completed"))
+        assertFalse(tracker.consume("activity-ui:tool-1", "tool:completed"))
+        assertTrue(tracker.consume("activity-ui:tool-2", "tool:running"))
+        assertFalse(tracker.consume("", "tool:running"))
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCardsTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/conversation/AgentActivityCardsTest.kt
@@ -1,0 +1,33 @@
+package dev.hazydreams.hermesceleste.ui.conversation
+
+import dev.hazydreams.hermesceleste.network.ReasoningPhase
+import dev.hazydreams.hermesceleste.network.ToolPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class AgentActivityCardsTest {
+    @Test
+    fun toolAnnouncementsUseStableAccessiblePhaseNames() {
+        assertEquals("running", activityAnnouncementPhase(ToolPhase.Started))
+        assertEquals("running", activityAnnouncementPhase(ToolPhase.Running))
+        assertEquals("completed", activityAnnouncementPhase(ToolPhase.Completed))
+        assertEquals("error", activityAnnouncementPhase(ToolPhase.Failed))
+        assertEquals("interrupted", activityAnnouncementPhase(ToolPhase.Interrupted))
+    }
+
+    @Test
+    fun reasoningAnnouncementsDescribeTheDisplayedLifecycle() {
+        assertEquals("streaming", reasoningAnnouncementPhase(ReasoningPhase.Streaming))
+        assertEquals("complete", reasoningAnnouncementPhase(ReasoningPhase.Complete))
+        assertEquals("unavailable", reasoningAnnouncementPhase(ReasoningPhase.Unavailable))
+    }
+
+    @Test
+    fun selectableDetailSemanticsExposeOnlyTheSafeLabel() {
+        val description = activityDetailContentDescription("Displayed output")
+
+        assertEquals("Displayed output, selectable displayed detail", description)
+        assertFalse(description.contains("<private-detail>"))
+    }
+}


### PR DESCRIPTION
## Summary

- present session-scoped tool and server-reasoning activity without exposing raw gateway, RPC, cancellation, or exception text
- fail closed when Hermes sends `show_reasoning: false`, including summary, delta, and snapshot decoding
- persist origin/profile/session-scoped disclosure choices with verified writes, rollback, and typed Retry or Sign-in recovery actions
- isolate in-flight activity operations by owned session identity, deduplicate accessibility phase announcements, and preserve legacy transcript tool rows unless every row is safely covered
- stabilize asynchronous host tests with observable gateway/state waits and real ViewModel lifecycle disposal

## Host validation

- `testDebugUnitTest`: 113 tests, 0 failures, 0 errors, 1 skipped
- `lintDebug`: `BUILD SUCCESSFUL`
- `git diff --check origin/main...HEAD`: passed
- branch diff contains no milestone specs, accepted screenshot PNGs, APKs, or `AGENTS.md` changes

## Pending validation

- Android instrumentation and TalkBack verification
- owner review of screenshot references; no accepted PNG was changed
- physical-device runtime validation
- GitHub Actions / APK validation
