### PR TITLE
feat: improve conversation browsing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,11 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
 
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
     screenshotTestImplementation(composeBom)
     screenshotTestImplementation("androidx.compose.ui:ui-tooling")
     screenshotTestImplementation("com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha16")

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/SessionListAnnouncementsTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/SessionListAnnouncementsTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import dev.hazydreams.hermesceleste.SessionCatalogState
 import dev.hazydreams.hermesceleste.SessionCatalogStatus
 import dev.hazydreams.hermesceleste.SessionScope
+import dev.hazydreams.hermesceleste.keyFor
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.sessions.SessionListScreen
@@ -77,10 +78,51 @@ class SessionListAnnouncementsTest {
         composeRule.onNodeWithText("Clear search").assertExists()
     }
 
+    @Test
+    fun reconnectingAnnouncementIsAPoliteLiveRegionAndKeepsRetry() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.Reconnecting,
+                scope = scope,
+                rows = listOf(knownSession),
+            ),
+            message = "Reconnecting conversation scope…",
+        )
+        composeRule.onNodeWithText("Retry").assertExists()
+    }
+
+    @Test
+    fun actionAnnouncementIsAPoliteLiveRegion() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.ActionInFlight,
+                scope = scope,
+                rows = listOf(knownSession),
+            ),
+            message = "Saving conversation…",
+            loadingMessage = "Saving conversation…",
+        )
+    }
+
+    @Test
+    fun openingAnnouncementIsAPoliteLiveRegionAndKeepsCancel() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.Opening,
+                scope = scope,
+                rows = listOf(knownSession),
+                openingKey = requireNotNull(knownSession.keyFor(scope.originKey)),
+            ),
+            message = "Opening conversation…",
+        )
+        composeRule.onNodeWithText("Cancel").assertExists()
+    }
+
     private fun assertAnnouncement(
         state: SessionCatalogState,
         message: String,
         query: String = "",
+        loadingMessage: String? = null,
     ) {
         composeRule.setContent {
             HermesCelesteTheme {
@@ -88,7 +130,7 @@ class SessionListAnnouncementsTest {
                     sessions = state.rows,
                     profiles = listOf(DashboardProfile(name = "default", isDefault = true)),
                     selectedProfile = "default",
-                    loadingMessage = null,
+                    loadingMessage = loadingMessage,
                     errorMessage = null,
                     onProfileSelected = {},
                     onNewConversation = {},

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/SessionListAnnouncementsTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/SessionListAnnouncementsTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import dev.hazydreams.hermesceleste.SessionCatalogState
 import dev.hazydreams.hermesceleste.SessionCatalogStatus
 import dev.hazydreams.hermesceleste.SessionScope
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.keyFor
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
@@ -55,9 +56,9 @@ class SessionListAnnouncementsTest {
                 phase = SessionCatalogStatus.Stale,
                 scope = scope,
                 rows = listOf(knownSession),
-                errorMessage = "Hermes is offline.",
+                notice = UiNotice.CatalogUnavailable,
             ),
-            message = "Hermes is offline.",
+            message = UiNotice.CatalogUnavailable.message,
         )
         composeRule.onNodeWithText("Retry").assertExists()
     }
@@ -131,7 +132,7 @@ class SessionListAnnouncementsTest {
                     profiles = listOf(DashboardProfile(name = "default", isDefault = true)),
                     selectedProfile = "default",
                     loadingMessage = loadingMessage,
-                    errorMessage = null,
+                    notice = null,
                     onProfileSelected = {},
                     onNewConversation = {},
                     onSessionSelected = {},

--- a/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/SessionListAnnouncementsTest.kt
+++ b/app/src/androidTest/java/dev/hazydreams/hermesceleste/ui/SessionListAnnouncementsTest.kt
@@ -1,0 +1,128 @@
+package dev.hazydreams.hermesceleste.ui
+
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import dev.hazydreams.hermesceleste.SessionCatalogState
+import dev.hazydreams.hermesceleste.SessionCatalogStatus
+import dev.hazydreams.hermesceleste.SessionScope
+import dev.hazydreams.hermesceleste.network.DashboardProfile
+import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.ui.sessions.SessionListScreen
+
+@RunWith(AndroidJUnit4::class)
+class SessionListAnnouncementsTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun loadingAnnouncementIsAPoliteLiveRegion() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.Loading,
+                scope = scope,
+            ),
+            message = "Loading conversations…",
+        )
+    }
+
+    @Test
+    fun refreshAnnouncementIsAPoliteLiveRegion() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.Refreshing,
+                scope = scope,
+                rows = listOf(knownSession),
+            ),
+            message = "Refreshing conversations…",
+        )
+    }
+
+    @Test
+    fun staleAnnouncementIsAPoliteLiveRegionAndKeepsRetry() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.Stale,
+                scope = scope,
+                rows = listOf(knownSession),
+                errorMessage = "Hermes is offline.",
+            ),
+            message = "Hermes is offline.",
+        )
+        composeRule.onNodeWithText("Retry").assertExists()
+    }
+
+    @Test
+    fun noResultsAnnouncementIsAPoliteLiveRegionAndKeepsClearAction() {
+        assertAnnouncement(
+            state = SessionCatalogState(
+                phase = SessionCatalogStatus.Ready,
+                scope = scope,
+                rows = listOf(knownSession),
+                query = "missing",
+                queryResults = emptyList(),
+            ),
+            query = "missing",
+            message = "No loaded conversation matches that search.",
+        )
+        composeRule.onNodeWithText("Clear search").assertExists()
+    }
+
+    private fun assertAnnouncement(
+        state: SessionCatalogState,
+        message: String,
+        query: String = "",
+    ) {
+        composeRule.setContent {
+            HermesCelesteTheme {
+                SessionListScreen(
+                    sessions = state.rows,
+                    profiles = listOf(DashboardProfile(name = "default", isDefault = true)),
+                    selectedProfile = "default",
+                    loadingMessage = null,
+                    errorMessage = null,
+                    onProfileSelected = {},
+                    onNewConversation = {},
+                    onSessionSelected = {},
+                    onSettings = {},
+                    catalogState = state,
+                    query = query,
+                    onQueryChange = {},
+                    onRefresh = {},
+                    onRetry = {},
+                )
+            }
+        }
+        composeRule
+            .onNodeWithText(message, useUnmergedTree = true)
+            .assertExists()
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.LiveRegion,
+                    LiveRegionMode.Polite,
+                ),
+            )
+    }
+
+    private companion object {
+        val scope = requireNotNull(SessionScope.from("https://hermes.example", "default"))
+        val knownSession = StoredSession(
+            id = "stored-42",
+            title = "Shared conversation",
+            preview = "Synthetic preview",
+            startedAt = 1.0,
+            messageCount = 3,
+            source = "desktop",
+            profile = "default",
+        )
+    }
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -108,7 +108,6 @@ private data class OpeningToken(
     val key: SessionKey,
     val connectionAttempt: Long,
     val originGeneration: Long,
-    val profileGeneration: Long,
     val previousState: CelesteUiState,
     val previousKey: SessionKey?,
     val previousRuntimeId: String?,
@@ -198,7 +197,6 @@ internal class CelesteViewModel(
         // Profile selection is deliberately creation-only. session.list is not
         // profile-scoped on the mounted Hermes contract, so changing this
         // control must not relabel, filter, or refresh the loaded catalog.
-        cancelOpening()
         cancelNewConversation()
         profileGeneration += 1
         mutableState.value = mutableState.value.copy(selectedProfile = selected.name)
@@ -250,7 +248,6 @@ internal class CelesteViewModel(
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
         val attempt = beginConnectionAttempt()
-        val selectedProfileGeneration = profileGeneration
         val initialScope = SessionScope.unscoped(connection.baseUrl)
         dashboard.clearAuthentication()
         mutableState.value = snapshot.copy(
@@ -295,7 +292,6 @@ internal class CelesteViewModel(
                     selectedCredential = selectedCredential,
                     preferredProfile = snapshot.selectedProfile,
                 )
-                if (profileGeneration != selectedProfileGeneration) throw CancellationException()
                 val descriptor = when {
                     connection.authRequired -> SavedConnectionDescriptor(
                         baseUrl = connection.baseUrl,
@@ -329,7 +325,7 @@ internal class CelesteViewModel(
                 }
                 RememberedDashboard(loaded, descriptor, persistenceError)
             }.onSuccess { remembered ->
-                if (!isCurrentConnectionAttempt(attempt) || profileGeneration != selectedProfileGeneration) return@onSuccess
+                if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
                 credential = remembered.loaded.credential
                 currentDescriptor = remembered.descriptor
                 publishConnectedDashboard(
@@ -343,7 +339,7 @@ internal class CelesteViewModel(
                     },
                 )
             }.onFailure { error ->
-                if (!isCurrentConnectionAttempt(attempt) || profileGeneration != selectedProfileGeneration) return@onFailure
+                if (!isCurrentConnectionAttempt(attempt)) return@onFailure
                 dashboard.clearAuthentication()
                 mutableState.value = mutableState.value.copy(
                     connectionPhase = ConnectionPhase.ManualSetup,
@@ -638,7 +634,9 @@ internal class CelesteViewModel(
         sessionToken: String = "",
         errorMessage: String? = null,
     ) {
-        val selectedProfile = loaded.selectedProfile
+        val selectedProfile = loaded.profiles.firstOrNull {
+            it.name.equals(mutableState.value.selectedProfile, ignoreCase = true)
+        }?.name ?: loaded.selectedProfile
         val scope = SessionScope.unscoped(mutableState.value.probe?.baseUrl.orEmpty())
         catalogScope = scope
         val catalog = if (scope == null) {
@@ -735,7 +733,6 @@ internal class CelesteViewModel(
         val rows = nextCatalog.rows
         val scope = nextCatalog.scope
         val originAtStart = originGeneration
-        val profileAtStart = profileGeneration
         val catalogRequestAtStart = catalogRequestGeneration
         val connectionAttemptAtStart = connectionAttempt
         sessionSearchJob = viewModelScope.launch {
@@ -747,7 +744,6 @@ internal class CelesteViewModel(
             if (
                 generation != sessionQueryGeneration ||
                 originAtStart != originGeneration ||
-                profileAtStart != profileGeneration ||
                 catalogRequestAtStart != catalogRequestGeneration ||
                 connectionAttemptAtStart != connectionAttempt ||
                 current.sessionCatalog.scope != scope ||
@@ -792,7 +788,6 @@ internal class CelesteViewModel(
         val request = SessionCatalogRequest(
             scope = scope,
             originGeneration = originGeneration,
-            profileGeneration = profileGeneration,
             requestGeneration = ++catalogRequestGeneration,
             connectionAttempt = connectionAttempt,
         )
@@ -895,7 +890,6 @@ internal class CelesteViewModel(
             key = key,
             connectionAttempt = attempt,
             originGeneration = originGeneration,
-            profileGeneration = profileGeneration,
             previousState = snapshot,
             previousKey = activeSessionKey,
             previousRuntimeId = currentRuntimeSessionId,
@@ -960,10 +954,20 @@ internal class CelesteViewModel(
                 )
             } catch (error: Throwable) {
                 if (openingToken?.id == activeToken.id) {
-                    rollbackOpening(
-                        activeToken,
-                        error.message?.takeIf { error !is CancellationException },
-                    )
+                    if (error is AuthenticationRejected) {
+                        activeToken.previousGateway
+                            ?.takeUnless { it === activeToken.candidateGateway }
+                            ?.close()
+                        invalidateReusableAuthentication(
+                            descriptor = currentDescriptor,
+                            probe = connection,
+                        )
+                    } else {
+                        rollbackOpening(
+                            activeToken,
+                            error.message?.takeIf { error !is CancellationException },
+                        )
+                    }
                 }
             } finally {
                 if (openingToken?.id == activeToken.id && errorCandidateIsClosed(activeToken)) {
@@ -986,8 +990,7 @@ internal class CelesteViewModel(
             gateway === token.candidateGateway &&
             activeSessionKey == token.key &&
             connectionAttempt == token.connectionAttempt &&
-            originGeneration == token.originGeneration &&
-            profileGeneration == token.profileGeneration
+            originGeneration == token.originGeneration
 
     private fun errorCandidateIsClosed(token: OpeningToken): Boolean =
         token.candidateGateway != null && token.candidateGateway !== gateway

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -87,6 +87,7 @@ internal data class CelesteUiState(
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
     val errorMessage: String? = null,
+    val conversationNavigationToken: Long = 0L,
 )
 
 private data class LoadedDashboard(
@@ -100,6 +101,20 @@ private data class RememberedDashboard(
     val loaded: LoadedDashboard,
     val descriptor: SavedConnectionDescriptor,
     val persistenceError: Throwable?,
+)
+
+private data class OpeningToken(
+    val id: Long,
+    val key: SessionKey,
+    val connectionAttempt: Long,
+    val originGeneration: Long,
+    val profileGeneration: Long,
+    val previousState: CelesteUiState,
+    val previousKey: SessionKey?,
+    val previousRuntimeId: String?,
+    val previousCanResume: Boolean,
+    val previousGateway: GatewayConnection?,
+    val candidateGateway: GatewayConnection? = null,
 )
 
 internal class CelesteViewModel(
@@ -133,6 +148,13 @@ internal class CelesteViewModel(
     private var reconnectAttempts = 0
     private var reconciling = false
     private var currentSessionCanResume = true
+    private var activeSessionKey: SessionKey? = null
+    private var openingToken: OpeningToken? = null
+    private var openingJob: Job? = null
+    private var newConversationJob: Job? = null
+    private var newConversationToken: Long? = null
+    private var newConversationPreviousState: CelesteUiState? = null
+    private var operationGeneration = 0L
     private val bufferedEvents = mutableListOf<GatewayEvent>()
 
     init {
@@ -171,32 +193,15 @@ internal class CelesteViewModel(
         val selected = mutableState.value.profiles.firstOrNull {
             it.name.equals(name, ignoreCase = true)
         } ?: return
-        val snapshot = mutableState.value
-        if (snapshot.selectedProfile.equals(selected.name, ignoreCase = true)) return
+        if (mutableState.value.selectedProfile.equals(selected.name, ignoreCase = true)) return
 
+        // Profile selection is deliberately creation-only. session.list is not
+        // profile-scoped on the mounted Hermes contract, so changing this
+        // control must not relabel, filter, or refresh the loaded catalog.
+        cancelOpening()
+        cancelNewConversation()
         profileGeneration += 1
-        val nextScope = snapshot.probe?.baseUrl?.let {
-            SessionScope.from(it, selected.name)
-        }
-        val hadCatalogRequest = catalogJob?.isActive == true
-        catalogScope = nextScope
-        mutableState.value = snapshot.copy(
-            selectedProfile = selected.name,
-            sessionCatalog = snapshot.sessionCatalog.copy(
-                scope = nextScope,
-                query = "",
-                queryResults = null,
-                queryInFlight = false,
-            ),
-            sessionQuery = "",
-        )
-        cancelSessionSearch()
-        // A response already in hand is valid for the unscoped catalog. If a
-        // request was still loading, restart it only to avoid stranding its
-        // old profile-generation token.
-        if (hadCatalogRequest && credential != null && snapshot.probe != null) {
-            refreshSessionCatalog()
-        }
+        mutableState.value = mutableState.value.copy(selectedProfile = selected.name)
     }
 
     fun findDashboard() {
@@ -246,7 +251,7 @@ internal class CelesteViewModel(
         val connection = snapshot.probe ?: return
         val attempt = beginConnectionAttempt()
         val selectedProfileGeneration = profileGeneration
-        val initialScope = SessionScope.from(connection.baseUrl, snapshot.selectedProfile)
+        val initialScope = SessionScope.unscoped(connection.baseUrl)
         dashboard.clearAuthentication()
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.LoadingSessions,
@@ -634,10 +639,7 @@ internal class CelesteViewModel(
         errorMessage: String? = null,
     ) {
         val selectedProfile = loaded.selectedProfile
-        val scope = SessionScope.from(
-            origin = mutableState.value.probe?.baseUrl.orEmpty(),
-            profile = selectedProfile,
-        )
+        val scope = SessionScope.unscoped(mutableState.value.probe?.baseUrl.orEmpty())
         catalogScope = scope
         val catalog = if (scope == null) {
             SessionCatalogState(phase = SessionCatalogStatus.Error, errorMessage = "Hermes returned no catalog scope.")
@@ -680,7 +682,24 @@ internal class CelesteViewModel(
         errorMessage = errorMessage,
     )
 
+    private fun invalidatePendingOperations() {
+        val pendingOpening = openingToken
+        openingToken = null
+        openingJob?.cancel()
+        openingJob = null
+        val candidateGateway = pendingOpening?.candidateGateway
+        if (candidateGateway != null && candidateGateway !== gateway && candidateGateway !== pendingOpening.previousGateway) {
+            candidateGateway.close()
+        }
+
+        newConversationToken = null
+        newConversationPreviousState = null
+        newConversationJob?.cancel()
+        newConversationJob = null
+    }
+
     private fun beginConnectionAttempt(): Long {
+        invalidatePendingOperations()
         connectionAttempt += 1
         originGeneration += 1
         profileGeneration += 1
@@ -765,7 +784,7 @@ internal class CelesteViewModel(
         val snapshot = mutableState.value
         val probe = snapshot.probe ?: return
         val activeCredential = credential ?: return
-        val scope = SessionScope.from(probe.baseUrl, snapshot.selectedProfile) ?: return
+        val scope = SessionScope.unscoped(probe.baseUrl) ?: return
         val refreshing = snapshot.sessionCatalog.scope == scope && snapshot.sessions != null
         sessionQueryGeneration += 1
         cancelSessionSearch()
@@ -823,12 +842,11 @@ internal class CelesteViewModel(
     private fun isCurrentCatalogRequest(request: SessionCatalogRequest): Boolean {
         val current = mutableState.value
         return request.originGeneration == originGeneration &&
-            request.profileGeneration == profileGeneration &&
             request.requestGeneration == catalogRequestGeneration &&
             request.connectionAttempt == connectionAttempt &&
             request.scope == catalogScope &&
             current.probe?.baseUrl?.let {
-                SessionScope.from(it, current.selectedProfile)
+                SessionScope.unscoped(it)
             } == request.scope &&
             credential != null
     }
@@ -842,9 +860,7 @@ internal class CelesteViewModel(
 
     private fun markCatalogReconnecting() {
         val snapshot = mutableState.value
-        val scope = snapshot.probe?.baseUrl?.let {
-            SessionScope.from(it, snapshot.selectedProfile)
-        } ?: return
+        val scope = snapshot.probe?.baseUrl?.let(SessionScope::unscoped) ?: return
         val keepRows = snapshot.sessions != null && snapshot.sessionCatalog.scope == scope
         sessionQueryGeneration += 1
         cancelSessionSearch()
@@ -864,52 +880,166 @@ internal class CelesteViewModel(
     }
 
     fun openSession(summary: StoredSession) {
+        if (openingToken != null) return
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
-        val scope = catalogScope ?: SessionScope.from(connection.baseUrl, snapshot.selectedProfile) ?: return
+        val scope = catalogScope ?: SessionScope.unscoped(connection.baseUrl) ?: return
         val key = summary.keyFor(scope.originKey) ?: return
         if (snapshot.sessionCatalog.rows.none { it.keyFor(scope.originKey) == key }) return
+
         val attempt = connectionAttempt
+        val previousGateway = gateway
+        val token = OpeningToken(
+            id = ++operationGeneration,
+            key = key,
+            connectionAttempt = attempt,
+            originGeneration = originGeneration,
+            profileGeneration = profileGeneration,
+            previousState = snapshot,
+            previousKey = activeSessionKey,
+            previousRuntimeId = currentRuntimeSessionId,
+            previousCanResume = currentSessionCanResume,
+            previousGateway = previousGateway,
+        )
+        openingToken = token
+        reconnectJob?.cancel()
+        reconnectJob = null
         currentSessionCanResume = true
+        val openingCatalog = SessionCatalogReducer.opening(snapshot.sessionCatalog, key)
         mutableState.value = snapshot.copy(
-            activeSummary = summary,
-            messages = emptyList(),
-            streamingText = "",
-            draft = "",
-            turnState = TurnState.Synchronizing,
+            sessions = openingCatalog.rows,
+            sessionCatalog = openingCatalog,
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
             errorMessage = null,
         )
-        closeGateway()
 
-        val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
-        gateway = newGateway
-        observeGateway(newGateway)
-        viewModelScope.launch {
-            runCatching {
+        val newGateway = runCatching {
+            dashboard.createGateway(connection.baseUrl, activeCredential)
+        }.getOrElse { error ->
+            rollbackOpening(token, error.message ?: "Could not open that Hermes conversation.")
+            return
+        }
+        val activeToken = token.copy(candidateGateway = newGateway)
+        openingToken = activeToken
+        if (newGateway === previousGateway) {
+            closeGateway()
+            gateway = newGateway
+            observeGateway(newGateway)
+        } else {
+            detachGatewayObservers()
+            gateway = newGateway
+            observeGateway(newGateway)
+        }
+        activeSessionKey = key
+        openingJob = viewModelScope.launch {
+            try {
                 newGateway.connect()
-                if (gateway !== newGateway || connectionAttempt != attempt) {
-                    throw CancellationException("The Hermes conversation scope changed while opening.")
+                check(isCurrentOpening(activeToken)) {
+                    "The Hermes conversation scope changed while opening."
                 }
-                reconcile(newGateway, summary.id)
-            }.onSuccess {
-                if (gateway !== newGateway || connectionAttempt != attempt) return@onSuccess
-                reconnectAttempts = 0
-                mutableState.value = mutableState.value.copy(loadingMessage = null)
-            }.onFailure { error ->
-                if (gateway !== newGateway || connectionAttempt != attempt) return@onFailure
-                mutableState.value = mutableState.value.copy(
-                    loadingMessage = null,
-                    errorMessage = error.message ?: "Could not open that Hermes conversation.",
-                    turnState = TurnState.Reconnecting,
+                reconcile(newGateway, key)
+                check(isCurrentOpening(activeToken)) {
+                    "The Hermes conversation scope changed while opening."
+                }
+                if (previousGateway != null && previousGateway !== newGateway) previousGateway.close()
+                val openedCatalog = SessionCatalogReducer.openingSucceeded(
+                    mutableState.value.sessionCatalog,
                 )
-                scheduleReconnect(wasRunning = false)
+                openingToken = null
+                openingJob = null
+                reconnectAttempts = 0
+                mutableState.value = mutableState.value.copy(
+                    sessions = openedCatalog.rows,
+                    sessionCatalog = openedCatalog,
+                    activeSummary = summary,
+                    draft = "",
+                    loadingMessage = null,
+                    errorMessage = null,
+                    conversationNavigationToken = mutableState.value.conversationNavigationToken + 1,
+                )
+            } catch (error: Throwable) {
+                if (openingToken?.id == activeToken.id) {
+                    rollbackOpening(
+                        activeToken,
+                        error.message?.takeIf { error !is CancellationException },
+                    )
+                }
+            } finally {
+                if (openingToken?.id == activeToken.id && errorCandidateIsClosed(activeToken)) {
+                    openingToken = null
+                }
+                if (openingJob?.isCompleted == true) openingJob = null
             }
         }
     }
 
+    fun cancelOpening() {
+        val token = openingToken ?: return
+        openingJob?.cancel()
+        rollbackOpening(token, null)
+    }
+
+    private fun isCurrentOpening(token: OpeningToken): Boolean =
+        openingToken?.id == token.id &&
+            token.candidateGateway != null &&
+            gateway === token.candidateGateway &&
+            activeSessionKey == token.key &&
+            connectionAttempt == token.connectionAttempt &&
+            originGeneration == token.originGeneration &&
+            profileGeneration == token.profileGeneration
+
+    private fun errorCandidateIsClosed(token: OpeningToken): Boolean =
+        token.candidateGateway != null && token.candidateGateway !== gateway
+
+    private fun rollbackOpening(token: OpeningToken, message: String?) {
+        if (openingToken?.id != token.id) return
+        val candidate = token.candidateGateway
+        if (candidate != null && gateway === candidate) {
+            detachGatewayObservers()
+            if (token.previousGateway != null && token.previousGateway !== candidate) {
+                gateway = token.previousGateway
+                observeGateway(token.previousGateway)
+            } else {
+                gateway = null
+            }
+            if (candidate !== token.previousGateway) candidate.close()
+        } else if (candidate != null && candidate !== token.previousGateway) {
+            candidate.close()
+        }
+        activeSessionKey = token.previousKey
+        currentRuntimeSessionId = if (token.previousGateway != null && token.previousGateway === candidate) {
+            null
+        } else {
+            token.previousRuntimeId
+        }
+        currentSessionCanResume = token.previousCanResume
+        val restoredCatalog = if (message == null) {
+            SessionCatalogReducer.openingCancelled(token.previousState.sessionCatalog)
+        } else {
+            SessionCatalogReducer.openingFailed(token.previousState.sessionCatalog, message)
+        }
+        openingToken = null
+        openingJob = null
+        mutableState.value = token.previousState.copy(
+            sessions = restoredCatalog.rows,
+            sessionCatalog = restoredCatalog,
+            loadingMessage = null,
+            errorMessage = message ?: token.previousState.errorMessage,
+            turnState = if (
+                token.previousGateway != null &&
+                token.previousGateway === candidate &&
+                token.previousKey != null
+            ) {
+                TurnState.Reconnecting
+            } else {
+                token.previousState.turnState
+            },
+        )
+    }
+
     fun createNewConversation() {
+        if (openingToken != null || newConversationToken != null) return
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
@@ -917,6 +1047,9 @@ internal class CelesteViewModel(
         val attempt = connectionAttempt
         val selectedProfileGeneration = profileGeneration
         val previousGateway = gateway
+        val operationToken = ++operationGeneration
+        newConversationToken = operationToken
+        newConversationPreviousState = snapshot
         val actionStarted = SessionCatalogReducer.actionStarted(snapshot.sessionCatalog)
         mutableState.value = snapshot.copy(
             sessions = actionStarted.rows,
@@ -932,6 +1065,8 @@ internal class CelesteViewModel(
             dashboard.createGateway(connection.baseUrl, activeCredential)
         }.getOrElse { error ->
             val message = error.message ?: "Could not create a Hermes conversation."
+            newConversationToken = null
+            newConversationPreviousState = null
             mutableState.value = snapshot.copy(
                 sessions = snapshot.sessionCatalog.rows,
                 sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
@@ -945,14 +1080,15 @@ internal class CelesteViewModel(
             newGateway.events.collect { event -> candidateEvents += event }
         }
         var committed = false
-        viewModelScope.launch {
+        newConversationJob = viewModelScope.launch {
             try {
                 newGateway.connect()
                 val created = newGateway.createSession(selectedProfile)
                 if (
                     connectionAttempt != attempt ||
                     profileGeneration != selectedProfileGeneration ||
-                    mutableState.value.selectedProfile != selectedProfile
+                    mutableState.value.selectedProfile != selectedProfile ||
+                    newConversationToken != operationToken
                 ) {
                     throw CancellationException("The Hermes profile changed while creating the conversation.")
                 }
@@ -967,8 +1103,10 @@ internal class CelesteViewModel(
                     observeGateway(newGateway)
                 }
                 currentRuntimeSessionId = created.runtimeSessionId
-                currentStoredSessionId = created.storedSessionId
                 currentSessionCanResume = false
+                activeSessionKey = requireNotNull(
+                    SessionKey.from(connection.baseUrl, selectedProfile, created.storedSessionId),
+                )
                 val summary = StoredSession(
                     id = created.storedSessionId,
                     title = "New conversation",
@@ -997,11 +1135,13 @@ internal class CelesteViewModel(
                     errorMessage = null,
                 )
                 committed = true
+                newConversationToken = null
+                newConversationPreviousState = null
                 reconnectAttempts = 0
                 events.forEach(::applyEvent)
             } catch (error: Throwable) {
                 if (
-                    error !is CancellationException &&
+                    newConversationToken == operationToken &&
                     connectionAttempt == attempt &&
                     profileGeneration == selectedProfileGeneration &&
                     mutableState.value.selectedProfile == selectedProfile
@@ -1020,12 +1160,48 @@ internal class CelesteViewModel(
                             errorMessage = message,
                         )
                     }
+                } else if (newConversationToken == operationToken) {
+                    rollbackNewConversation(
+                        snapshot = snapshot,
+                        message = error.message?.takeIf { error !is CancellationException },
+                    )
                 }
             } finally {
                 candidateEventsJob.cancel()
                 if (!committed && newGateway !== previousGateway) newGateway.close()
+                if (newConversationToken == operationToken) newConversationToken = null
+                if (newConversationToken == null) newConversationPreviousState = null
+                if (newConversationJob?.isCompleted == true) newConversationJob = null
             }
         }
+    }
+
+    private fun cancelNewConversation() {
+        val snapshot = newConversationPreviousState ?: return
+        newConversationJob?.cancel()
+        rollbackNewConversation(snapshot, null)
+    }
+
+    private fun rollbackNewConversation(snapshot: CelesteUiState, message: String?) {
+        if (newConversationPreviousState == null && newConversationToken == null) return
+        val restoredCatalog = SessionCatalogReducer.actionFailed(
+            snapshot.sessionCatalog,
+            message ?: "New conversation cancelled.",
+        )
+        val current = mutableState.value
+        mutableState.value = current.copy(
+            sessions = restoredCatalog.rows,
+            sessionCatalog = restoredCatalog,
+            activeSummary = snapshot.activeSummary,
+            messages = snapshot.messages,
+            streamingText = snapshot.streamingText,
+            draft = snapshot.draft,
+            turnState = snapshot.turnState,
+            loadingMessage = null,
+            errorMessage = message,
+        )
+        newConversationToken = null
+        newConversationPreviousState = null
     }
 
     fun leaveConversation() {
@@ -1065,6 +1241,7 @@ internal class CelesteViewModel(
         // prompt.submit creates the durable row before work begins. From this point on,
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
+        val activeKey = activeSessionKey
         viewModelScope.launch {
             runCatching { activeGateway.submitPrompt(runtimeId, text) }
                 .onSuccess {
@@ -1081,8 +1258,8 @@ internal class CelesteViewModel(
                     mutableState.value = mutableState.value.copy(
                         errorMessage = error.message ?: "Hermes could not send that message.",
                     )
-                    if (gateway === activeGateway) {
-                        runCatching { reconcile(activeGateway, currentStoredSessionId ?: return@launch) }
+                    if (gateway === activeGateway && activeKey != null) {
+                        runCatching { reconcile(activeGateway, activeKey) }
                     }
                 }
         }
@@ -1099,7 +1276,8 @@ internal class CelesteViewModel(
         viewModelScope.launch {
             runCatching {
                 activeGateway.interruptSession(runtimeId)
-                reconcile(activeGateway, currentStoredSessionId ?: return@launch)
+                val activeKey = activeSessionKey ?: return@runCatching
+                reconcile(activeGateway, activeKey)
             }.onFailure { error ->
                 mutableState.value = mutableState.value.copy(
                     errorMessage = error.message ?: "Hermes could not stop that turn.",
@@ -1109,7 +1287,7 @@ internal class CelesteViewModel(
     }
 
     fun reconnectNow() {
-        if (gateway == null || mutableState.value.activeSummary == null) return
+        if (gateway == null || activeSessionKey == null) return
         reconnectJob?.cancel()
         reconnectJob = null
         reconnectAttempts = 0
@@ -1141,7 +1319,7 @@ internal class CelesteViewModel(
             }
             return
         }
-        val storedSessionId = currentStoredSessionId
+        val activeKey = activeSessionKey
         if (foregroundCheckJob?.isActive == true || reconciling) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
             markCatalogReconnecting()
@@ -1155,8 +1333,8 @@ internal class CelesteViewModel(
                     params = buildJsonObject { put("limit", 1) },
                     timeoutMillis = 8_000,
                 )
-                if (currentSessionCanResume && storedSessionId != null) {
-                    reconcile(activeGateway, storedSessionId)
+                if (currentSessionCanResume && activeKey != null) {
+                    reconcile(activeGateway, activeKey)
                 }
             }
             if (health.isSuccess && gateway === activeGateway) {
@@ -1176,9 +1354,16 @@ internal class CelesteViewModel(
     }
 
     private var currentRuntimeSessionId: String? = null
-    private var currentStoredSessionId: String? = null
+
+    private fun detachGatewayObservers() {
+        gatewayEventsJob?.cancel()
+        gatewayEventsJob = null
+        gatewayStateJob?.cancel()
+        gatewayStateJob = null
+    }
 
     private fun observeGateway(activeGateway: GatewayConnection) {
+        detachGatewayObservers()
         gatewayEventsJob = viewModelScope.launch {
             activeGateway.events.collect { event ->
                 if (gateway !== activeGateway) return@collect
@@ -1205,13 +1390,17 @@ internal class CelesteViewModel(
         }
     }
 
-    private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
+    private suspend fun reconcile(activeGateway: GatewayConnection, key: SessionKey) {
         reconciling = true
         bufferedEvents.clear()
         try {
-            val resumed = activeGateway.resumeStoredSession(storedSessionId)
-            if (gateway !== activeGateway) return
-            applyResumedSession(resumed)
+            val resumed = activeGateway.resumeStoredSession(key.durableId, key.profile)
+            if (gateway !== activeGateway || activeSessionKey != key) {
+                bufferedEvents.clear()
+                reconciling = false
+                return
+            }
+            applyResumedSession(key, resumed)
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false
@@ -1223,9 +1412,12 @@ internal class CelesteViewModel(
         }
     }
 
-    private fun applyResumedSession(resumed: ResumedSession) {
+    private fun applyResumedSession(key: SessionKey, resumed: ResumedSession) {
+        val resumedId = resumed.storedSessionId.trim()
+        if (resumedId.isNotBlank() && resumedId != key.durableId) {
+            throw IOException("Hermes resumed a different stored conversation.")
+        }
         currentRuntimeSessionId = resumed.runtimeSessionId
-        currentStoredSessionId = resumed.storedSessionId
         currentSessionCanResume = true
         val streamingSuffix = unpersistedInflightText(
             inflight = resumed.inflightAssistantText,
@@ -1402,18 +1594,28 @@ internal class CelesteViewModel(
 
     private suspend fun recreateBlankSession(
         activeGateway: GatewayConnection,
-        profile: String,
+        activeKey: SessionKey,
     ) {
         reconciling = true
         bufferedEvents.clear()
         try {
-            val created = activeGateway.createSession(profile)
-            if (gateway !== activeGateway) return
-            currentRuntimeSessionId = created.runtimeSessionId
-            currentStoredSessionId = created.storedSessionId
+            val created = activeGateway.createSession(activeKey.profile)
+            if (gateway !== activeGateway || this.activeSessionKey != activeKey) return
+            val returnedProfile = created.profile?.takeIf(String::isNotBlank)
+            if (returnedProfile != null && !returnedProfile.equals(activeKey.profile, ignoreCase = true)) {
+                throw IOException("Hermes recreated this conversation in $returnedProfile instead of ${activeKey.profile}.")
+            }
+            val replacementKey = requireNotNull(
+                SessionKey.from(activeKey.originKey, activeKey.profile, created.storedSessionId),
+            )
             val previousSummary = mutableState.value.activeSummary
                 ?: throw IOException("No draft conversation is open.")
-            val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
+            this.activeSessionKey = replacementKey
+            currentRuntimeSessionId = created.runtimeSessionId
+            val updatedSummary = previousSummary.copy(
+                id = replacementKey.durableId,
+                profile = replacementKey.profile,
+            )
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
                 turnState = TurnState.Idle,
@@ -1432,11 +1634,11 @@ internal class CelesteViewModel(
 
     private fun scheduleReconnect(wasRunning: Boolean, immediate: Boolean = false) {
         val activeGateway = gateway ?: return
-        val storedSessionId = currentStoredSessionId ?: mutableState.value.activeSummary?.id ?: return
+        val activeKey = activeSessionKey ?: return
         if (reconnectJob?.isActive == true) return
         mutableState.value = mutableState.value.copy(turnState = TurnState.Reconnecting)
         reconnectJob = viewModelScope.launch {
-            while (gateway === activeGateway) {
+            while (gateway === activeGateway && this@CelesteViewModel.activeSessionKey == activeKey) {
                 val delayMillis = if (immediate && reconnectAttempts == 0) {
                     0L
                 } else {
@@ -1446,9 +1648,9 @@ internal class CelesteViewModel(
                 val result = runCatching {
                     activeGateway.connect()
                     if (currentSessionCanResume) {
-                        reconcile(activeGateway, storedSessionId)
+                        reconcile(activeGateway, activeKey)
                     } else {
-                        recreateBlankSession(activeGateway, mutableState.value.selectedProfile)
+                        recreateBlankSession(activeGateway, activeKey)
                     }
                 }
                 if (result.isSuccess) {
@@ -1458,6 +1660,7 @@ internal class CelesteViewModel(
                     return@launch
                 }
                 val failure = result.exceptionOrNull()
+                if (failure is CancellationException) throw failure
                 if (failure is AuthenticationRejected) {
                     val descriptor = currentDescriptor
                     reconnectJob = null
@@ -1482,15 +1685,12 @@ internal class CelesteViewModel(
         reconnectJob = null
         foregroundCheckJob?.cancel()
         foregroundCheckJob = null
-        gatewayEventsJob?.cancel()
-        gatewayEventsJob = null
-        gatewayStateJob?.cancel()
-        gatewayStateJob = null
+        detachGatewayObservers()
         reconciling = false
         bufferedEvents.clear()
         currentRuntimeSessionId = null
-        currentStoredSessionId = null
         currentSessionCanResume = true
+        activeSessionKey = null
         activeGateway?.close()
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -33,6 +33,7 @@ import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,9 +42,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+
+private const val SESSION_SEARCH_DEBOUNCE_MILLIS = 250L
 
 internal enum class TurnState {
     Synchronizing,
@@ -55,6 +59,7 @@ internal enum class TurnState {
 internal enum class ConnectionPhase {
     CheckingSavedConnection,
     ManualSetup,
+    LoadingSessions,
     Restoring,
     RestoreFailed,
     AuthenticationRequired,
@@ -120,6 +125,8 @@ internal class CelesteViewModel(
     private var catalogRequestGeneration = 0L
     private var catalogScope: SessionScope? = null
     private var catalogJob: Job? = null
+    private var sessionSearchJob: Job? = null
+    private var sessionQueryGeneration = 0L
     private val connectionStoreMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
@@ -155,11 +162,7 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(draft = value)
     }
 
-    /**
-     * The current Hermes session.list contract is not verified as profile-filtered.
-     * Keep this selector scoped to the next new conversation and leave the
-     * server-ordered catalog intact rather than inventing a wire parameter.
-     */
+    /** The loaded catalog is bounded to the selected profile; no all-profile mode exists in Phase 1. */
     fun selectProfile(name: String) {
         val selected = mutableState.value.profiles.firstOrNull {
             it.name.equals(name, ignoreCase = true)
@@ -168,10 +171,17 @@ internal class CelesteViewModel(
         if (snapshot.selectedProfile.equals(selected.name, ignoreCase = true)) return
 
         profileGeneration += 1
-        mutableState.value = snapshot.copy(selectedProfile = selected.name)
-        // If a catalog read was in flight, restart it under the new profile
-        // generation so the old completion cannot strand the loading state.
-        if (catalogJob?.isActive == true && credential != null) refreshSessionCatalog()
+        mutableState.value = snapshot.copy(
+            selectedProfile = selected.name,
+            sessions = emptyList(),
+            sessionCatalog = SessionCatalogState(
+                phase = SessionCatalogStatus.Loading,
+                scope = snapshot.probe?.baseUrl?.let { SessionScope.from(it, selected.name) },
+            ),
+            sessionQuery = "",
+        )
+        cancelSessionSearch()
+        if (credential != null && snapshot.probe != null) refreshSessionCatalog()
     }
 
     fun findDashboard() {
@@ -221,11 +231,22 @@ internal class CelesteViewModel(
         val connection = snapshot.probe ?: return
         val attempt = beginConnectionAttempt()
         val selectedProfileGeneration = profileGeneration
+        val initialScope = SessionScope.from(connection.baseUrl, snapshot.selectedProfile)
         dashboard.clearAuthentication()
         mutableState.value = snapshot.copy(
-            connectionPhase = ConnectionPhase.ManualSetup,
-            sessions = null,
-            sessionCatalog = SessionCatalogState(),
+            connectionPhase = ConnectionPhase.LoadingSessions,
+            sessions = emptyList(),
+            sessionCatalog = if (initialScope == null) {
+                SessionCatalogState(
+                    phase = SessionCatalogStatus.Error,
+                    errorMessage = "Hermes returned no catalog scope.",
+                )
+            } else {
+                SessionCatalogState(
+                    phase = SessionCatalogStatus.Loading,
+                    scope = initialScope,
+                )
+            },
             sessionQuery = "",
             loadingMessage = "Loading your conversations…",
             errorMessage = null,
@@ -305,6 +326,14 @@ internal class CelesteViewModel(
                 if (!isCurrentConnectionAttempt(attempt) || profileGeneration != selectedProfileGeneration) return@onFailure
                 dashboard.clearAuthentication()
                 mutableState.value = mutableState.value.copy(
+                    connectionPhase = ConnectionPhase.ManualSetup,
+                    sessions = null,
+                    sessionCatalog = SessionCatalogState(
+                        phase = SessionCatalogStatus.Error,
+                        scope = initialScope,
+                        errorMessage = error.message ?: "Could not load Hermes conversations.",
+                    ),
+                    sessionQuery = "",
                     errorMessage = error.message ?: "Could not load Hermes conversations.",
                     password = "",
                     sessionToken = "",
@@ -562,6 +591,12 @@ internal class CelesteViewModel(
         descriptor: SavedConnectionDescriptor?,
         probe: DashboardProbeResult? = null,
     ) {
+        sessionQueryGeneration += 1
+        cancelSessionSearch()
+        catalogRequestGeneration += 1
+        catalogJob?.cancel()
+        catalogJob = null
+        catalogScope = null
         credential = null
         currentDescriptor = null
         dashboard.clearAuthentication()
@@ -583,8 +618,9 @@ internal class CelesteViewModel(
         errorMessage: String? = null,
     ) {
         val selectedProfile = loaded.selectedProfile
-        val scope = SessionScope.allProfiles(
+        val scope = SessionScope.from(
             origin = mutableState.value.probe?.baseUrl.orEmpty(),
+            profile = selectedProfile,
         )
         catalogScope = scope
         val catalog = if (scope == null) {
@@ -621,7 +657,7 @@ internal class CelesteViewModel(
         errorMessage: String? = null,
     ): CelesteUiState = CelesteUiState(
         connectionPhase = phase,
-        dashboardUrl = descriptor?.baseUrl.orEmpty(),
+        dashboardUrl = descriptor?.baseUrl ?: probe?.baseUrl.orEmpty(),
         probe = probe,
         savedAuthMode = descriptor?.authMode,
         username = descriptor?.username.orEmpty(),
@@ -633,6 +669,8 @@ internal class CelesteViewModel(
         originGeneration += 1
         profileGeneration += 1
         catalogRequestGeneration += 1
+        sessionQueryGeneration += 1
+        cancelSessionSearch()
         catalogJob?.cancel()
         catalogJob = null
         catalogScope = null
@@ -649,15 +687,50 @@ internal class CelesteViewModel(
     private fun isCurrentConnectionAttempt(attempt: Long): Boolean = connectionAttempt == attempt
 
     fun updateSessionQuery(value: String) {
+        val generation = ++sessionQueryGeneration
+        cancelSessionSearch()
         val snapshot = mutableState.value
         val nextCatalog = snapshot.sessionCatalog.withQuery(value)
         mutableState.value = snapshot.copy(
             sessionQuery = value,
             sessionCatalog = nextCatalog,
         )
+        if (value.isBlank()) return
+
+        val rows = nextCatalog.rows
+        val scope = nextCatalog.scope
+        val originAtStart = originGeneration
+        val profileAtStart = profileGeneration
+        val catalogRequestAtStart = catalogRequestGeneration
+        val connectionAttemptAtStart = connectionAttempt
+        sessionSearchJob = viewModelScope.launch {
+            delay(SESSION_SEARCH_DEBOUNCE_MILLIS)
+            val results = withContext(Dispatchers.Default) {
+                searchLoadedSessions(rows, value)
+            }
+            val current = mutableState.value
+            if (
+                generation != sessionQueryGeneration ||
+                originAtStart != originGeneration ||
+                profileAtStart != profileGeneration ||
+                catalogRequestAtStart != catalogRequestGeneration ||
+                connectionAttemptAtStart != connectionAttempt ||
+                current.sessionCatalog.scope != scope ||
+                current.sessionQuery != value
+            ) return@launch
+            mutableState.value = current.copy(
+                sessionCatalog = current.sessionCatalog.withSearchResults(value, results),
+            )
+            if (generation == sessionQueryGeneration) sessionSearchJob = null
+        }
     }
 
     fun clearSessionQuery() = updateSessionQuery("")
+
+    private fun cancelSessionSearch() {
+        sessionSearchJob?.cancel()
+        sessionSearchJob = null
+    }
 
     fun openConversationBrowser() {
         if (mutableState.value.sessions != null) refreshSessionCatalog()
@@ -667,13 +740,15 @@ internal class CelesteViewModel(
         if (mutableState.value.sessions != null) refreshSessionCatalog()
     }
 
-    /** Refreshes one server-authoritative, profile-scoped loaded window. */
+    /** Refreshes the server-authoritative loaded window for one selected profile. */
     fun refreshSessionCatalog() {
         val snapshot = mutableState.value
         val probe = snapshot.probe ?: return
         val activeCredential = credential ?: return
-        val scope = SessionScope.allProfiles(probe.baseUrl) ?: return
+        val scope = SessionScope.from(probe.baseUrl, snapshot.selectedProfile) ?: return
         val refreshing = snapshot.sessionCatalog.scope == scope && snapshot.sessions != null
+        sessionQueryGeneration += 1
+        cancelSessionSearch()
         catalogJob?.cancel()
         val request = SessionCatalogRequest(
             scope = scope,
@@ -689,25 +764,39 @@ internal class CelesteViewModel(
             sessionCatalog = started,
         )
         catalogJob = viewModelScope.launch {
-            runCatching {
-                dashboard.listSessions(
+            try {
+                val rows = dashboard.listSessions(
                     baseUrl = probe.baseUrl,
                     credential = activeCredential,
                 )
-            }.onSuccess { rows ->
-                if (!isCurrentCatalogRequest(request)) return@onSuccess
-                publishCatalog(SessionCatalogReducer.succeeded(mutableState.value.sessionCatalog, request, rows))
-            }.onFailure { error ->
-                if (!isCurrentCatalogRequest(request)) return@onFailure
+                if (!isCurrentCatalogRequest(request)) return@launch
                 publishCatalog(
-                    SessionCatalogReducer.failed(
+                    SessionCatalogReducer.succeeded(
                         mutableState.value.sessionCatalog,
                         request,
-                        error.message ?: "Could not refresh Hermes conversations.",
+                        rows,
                     ),
                 )
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                if (!isCurrentCatalogRequest(request)) return@launch
+                if (error is AuthenticationRejected) {
+                    invalidateReusableAuthentication(
+                        descriptor = currentDescriptor,
+                        probe = probe,
+                    )
+                } else {
+                    publishCatalog(
+                        SessionCatalogReducer.failed(
+                            mutableState.value.sessionCatalog,
+                            request,
+                            error.message ?: "Could not refresh Hermes conversations.",
+                        ),
+                    )
+                }
+            } finally {
+                if (isCurrentCatalogRequest(request)) catalogJob = null
             }
-            if (isCurrentCatalogRequest(request)) catalogJob = null
         }
     }
 
@@ -718,7 +807,9 @@ internal class CelesteViewModel(
             request.requestGeneration == catalogRequestGeneration &&
             request.connectionAttempt == connectionAttempt &&
             request.scope == catalogScope &&
-            current.probe?.baseUrl?.let { SessionScope.allProfiles(it) } == request.scope &&
+            current.probe?.baseUrl?.let {
+                SessionScope.from(it, current.selectedProfile)
+            } == request.scope &&
             credential != null
     }
 
@@ -729,11 +820,34 @@ internal class CelesteViewModel(
         )
     }
 
+    private fun markCatalogReconnecting() {
+        val snapshot = mutableState.value
+        val scope = snapshot.probe?.baseUrl?.let {
+            SessionScope.from(it, snapshot.selectedProfile)
+        } ?: return
+        val keepRows = snapshot.sessions != null && snapshot.sessionCatalog.scope == scope
+        sessionQueryGeneration += 1
+        cancelSessionSearch()
+        catalogRequestGeneration += 1
+        catalogJob?.cancel()
+        catalogJob = null
+        catalogScope = scope
+        val reconnecting = SessionCatalogReducer.reconnecting(
+            state = snapshot.sessionCatalog,
+            scope = scope,
+            keepRows = keepRows,
+        )
+        mutableState.value = snapshot.copy(
+            sessions = reconnecting.rows,
+            sessionCatalog = reconnecting,
+        )
+    }
+
     fun openSession(summary: StoredSession) {
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
-        val scope = catalogScope ?: SessionScope.allProfiles(connection.baseUrl) ?: return
+        val scope = catalogScope ?: SessionScope.from(connection.baseUrl, snapshot.selectedProfile) ?: return
         val key = summary.keyFor(scope.originKey) ?: return
         if (!scope.accepts(key)) return
         if (snapshot.sessionCatalog.rows.none { it.keyFor(scope.originKey) == key }) return
@@ -783,28 +897,33 @@ internal class CelesteViewModel(
         val selectedProfile = snapshot.selectedProfile
         val attempt = connectionAttempt
         val selectedProfileGeneration = profileGeneration
-        closeGateway()
+        val previousGateway = gateway
         mutableState.value = snapshot.copy(
-            activeSummary = null,
-            messages = emptyList(),
-            streamingText = "",
-            draft = "",
+            // Keep the previous projection until Hermes accepts the new session.
+            // This is deliberately not a synthetic catalog row or a persisted draft.
             turnState = TurnState.Synchronizing,
             loadingMessage = "Starting a new $selectedProfile conversation…",
             errorMessage = null,
         )
 
-        val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
-        gateway = newGateway
-        observeGateway(newGateway)
+        val newGateway = runCatching {
+            dashboard.createGateway(connection.baseUrl, activeCredential)
+        }.getOrElse { error ->
+            mutableState.value = snapshot.copy(
+                errorMessage = error.message ?: "Could not create a Hermes conversation.",
+            )
+            return
+        }
+        val candidateEvents = mutableListOf<GatewayEvent>()
+        val candidateEventsJob = viewModelScope.launch {
+            newGateway.events.collect { event -> candidateEvents += event }
+        }
+        var committed = false
         viewModelScope.launch {
-            runCatching {
+            try {
                 newGateway.connect()
-                reconciling = true
-                bufferedEvents.clear()
                 val created = newGateway.createSession(selectedProfile)
                 if (
-                    gateway !== newGateway ||
                     connectionAttempt != attempt ||
                     profileGeneration != selectedProfileGeneration ||
                     mutableState.value.selectedProfile != selectedProfile
@@ -814,6 +933,12 @@ internal class CelesteViewModel(
                 val returnedProfile = created.profile?.takeIf(String::isNotBlank)
                 if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
                     throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
+                }
+                val events = candidateEvents.toList()
+                if (newGateway !== previousGateway) {
+                    closeGateway()
+                    gateway = newGateway
+                    observeGateway(newGateway)
                 }
                 currentRuntimeSessionId = created.runtimeSessionId
                 currentStoredSessionId = created.storedSessionId
@@ -827,37 +952,32 @@ internal class CelesteViewModel(
                     source = "android",
                     profile = selectedProfile,
                 )
-                val events = bufferedEvents.toList()
-                bufferedEvents.clear()
-                reconciling = false
                 mutableState.value = mutableState.value.copy(
                     activeSummary = summary,
+                    messages = emptyList(),
+                    streamingText = "",
+                    draft = "",
                     turnState = TurnState.Idle,
                     loadingMessage = null,
                     errorMessage = null,
                 )
-                events.forEach(::applyEvent)
-            }.onSuccess {
-                if (
-                    gateway !== newGateway ||
-                    connectionAttempt != attempt ||
-                    profileGeneration != selectedProfileGeneration ||
-                    mutableState.value.selectedProfile != selectedProfile
-                ) return@onSuccess
+                committed = true
                 reconnectAttempts = 0
-            }.onFailure { error ->
+                events.forEach(::applyEvent)
+            } catch (error: Throwable) {
                 if (
-                    gateway !== newGateway ||
-                    connectionAttempt != attempt ||
-                    profileGeneration != selectedProfileGeneration ||
-                    mutableState.value.selectedProfile != selectedProfile
-                ) return@onFailure
-                if (gateway === newGateway) closeGateway()
-                mutableState.value = mutableState.value.copy(
-                    turnState = TurnState.Idle,
-                    loadingMessage = null,
-                    errorMessage = error.message ?: "Could not create a Hermes conversation.",
-                )
+                    error !is CancellationException &&
+                    connectionAttempt == attempt &&
+                    profileGeneration == selectedProfileGeneration &&
+                    mutableState.value.selectedProfile == selectedProfile
+                ) {
+                    mutableState.value = snapshot.copy(
+                        errorMessage = error.message ?: "Could not create a Hermes conversation.",
+                    )
+                }
+            } finally {
+                candidateEventsJob.cancel()
+                if (!committed && newGateway !== previousGateway) newGateway.close()
             }
         }
     }
@@ -975,9 +1095,10 @@ internal class CelesteViewModel(
             }
             return
         }
-        val storedSessionId = currentStoredSessionId ?: return
+        val storedSessionId = currentStoredSessionId
         if (foregroundCheckJob?.isActive == true || reconciling) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
+            markCatalogReconnecting()
             reconnectNow()
             return
         }
@@ -988,10 +1109,15 @@ internal class CelesteViewModel(
                     params = buildJsonObject { put("limit", 1) },
                     timeoutMillis = 8_000,
                 )
-                if (currentSessionCanResume) reconcile(activeGateway, storedSessionId)
+                if (currentSessionCanResume && storedSessionId != null) {
+                    reconcile(activeGateway, storedSessionId)
+                }
             }
-            if (health.isFailure && gateway === activeGateway) {
+            if (health.isSuccess && gateway === activeGateway) {
+                refreshSessionCatalog()
+            } else if (health.isFailure && gateway === activeGateway) {
                 val wasRunning = mutableState.value.turnState == TurnState.Running
+                markCatalogReconnecting()
                 activeGateway.close()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
@@ -1022,6 +1148,7 @@ internal class CelesteViewModel(
                 if (gateway !== activeGateway) return@collect
                 if (connectionState is GatewayConnectionState.Disconnected) {
                     val wasRunning = mutableState.value.turnState == TurnState.Running
+                    markCatalogReconnecting()
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
                         errorMessage = connectionState.reason,
@@ -1281,6 +1408,7 @@ internal class CelesteViewModel(
                 if (result.isSuccess) {
                     reconnectAttempts = 0
                     reconnectJob = null
+                    refreshSessionCatalog()
                     return@launch
                 }
                 val failure = result.exceptionOrNull()
@@ -1325,6 +1453,8 @@ internal class CelesteViewModel(
         connectionJob = null
         catalogJob?.cancel()
         catalogJob = null
+        sessionSearchJob?.cancel()
+        sessionSearchJob = null
         closeGateway()
         dashboard.clearAuthentication()
         super.onCleared()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -18,6 +18,11 @@ import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardService
 import dev.hazydreams.hermesceleste.network.DashboardUrlPolicy
 import dev.hazydreams.hermesceleste.network.GatewayConnection
+import dev.hazydreams.hermesceleste.network.GatewayRpcException
+import dev.hazydreams.hermesceleste.network.InvalidDashboardResponse
+import dev.hazydreams.hermesceleste.network.ProfileSessionList
+import dev.hazydreams.hermesceleste.network.RateLimited
+import dev.hazydreams.hermesceleste.network.TransportUnavailable
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
@@ -48,7 +53,72 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 private const val SESSION_SEARCH_DEBOUNCE_MILLIS = 250L
-private const val AUTHENTICATION_REQUIRED_MESSAGE = "Hermes needs sign-in."
+
+internal enum class UiNotice(val message: String) {
+    DashboardUnavailable("Could not reach the Hermes dashboard."),
+    SessionsUnavailable("Could not load Hermes conversations."),
+    SavedConnectionUnavailable("Celeste could not read the saved connection. Sign in again."),
+    PersistenceUnavailable("Connected, but Celeste could not remember this connection."),
+    PersistenceRefreshUnavailable("Connected, but Celeste could not refresh the saved sign-in."),
+    SignOutUnavailable("Celeste could not remove the saved sign-in. Try Forget connection."),
+    ForgetUnavailable("Celeste could not remove the saved connection. Try again."),
+    RestoreUnavailable("Could not reconnect to Hermes."),
+    CatalogUnavailable("Could not refresh Hermes conversations."),
+    ConversationUnavailable("Could not open that Hermes conversation."),
+    PreviousConversationUnavailable("Could not restore the previous Hermes conversation."),
+    NewConversationUnavailable("Could not create a Hermes conversation."),
+    SendUnavailable("Hermes could not send that message."),
+    InterruptUnavailable("Hermes could not stop that turn."),
+    Reconnecting("Reconnecting to Hermes…"),
+    AuthenticationRequired("Hermes needs sign-in."),
+    RateLimited("Hermes is busy right now. Try again shortly."),
+    InvalidResponse("Hermes returned an unexpected response. Try again."),
+    HermesReportedError("Hermes reported an error."),
+}
+
+/**
+ * Convert transport/protocol failures to fixed product copy at the application
+ * boundary. Exception messages and server-provided error text never enter UI
+ * state; ordinary coroutine cancellation remains silent.
+ */
+internal fun uiNoticeFor(error: Throwable, fallback: UiNotice): UiNotice? {
+    if (findCause(error) { cause ->
+            cause is CancellationException && cause !is kotlinx.coroutines.TimeoutCancellationException
+        } != null
+    ) {
+        return null
+    }
+    return when (val typed = findCause(error) { cause ->
+        cause is AuthenticationRejected ||
+            cause is RateLimited ||
+            cause is InvalidDashboardResponse ||
+            cause is TransportUnavailable ||
+            cause is GatewayRpcException
+    }) {
+        is AuthenticationRejected -> UiNotice.AuthenticationRequired
+        is RateLimited -> UiNotice.RateLimited
+        is InvalidDashboardResponse -> UiNotice.InvalidResponse
+        is GatewayRpcException -> when (typed.code) {
+            401, 403 -> UiNotice.AuthenticationRequired
+            429 -> UiNotice.RateLimited
+            else -> fallback
+        }
+        else -> fallback
+    }
+}
+
+private fun findCause(
+    error: Throwable,
+    predicate: (Throwable) -> Boolean,
+): Throwable? {
+    val seen = mutableSetOf<Throwable>()
+    var current: Throwable? = error
+    while (current != null && seen.add(current)) {
+        if (predicate(current)) return current
+        current = current.cause
+    }
+    return null
+}
 
 internal enum class TurnState {
     Synchronizing,
@@ -80,13 +150,14 @@ internal data class CelesteUiState(
     val sessionQuery: String = "",
     val profiles: List<DashboardProfile> = listOf(DashboardProfile(name = "default", isDefault = true)),
     val selectedProfile: String = "default",
+    val profileOwnershipVerified: Boolean = false,
     val activeSummary: StoredSession? = null,
     val messages: List<ConversationMessage> = emptyList(),
     val streamingText: String = "",
     val draft: String = "",
     val turnState: TurnState = TurnState.Idle,
     val loadingMessage: String? = null,
-    val errorMessage: String? = null,
+    val notice: UiNotice? = null,
     val conversationNavigationToken: Long = 0L,
 )
 
@@ -95,6 +166,7 @@ private data class LoadedDashboard(
     val sessions: List<StoredSession>,
     val profiles: List<DashboardProfile>,
     val selectedProfile: String,
+    val profileOwnershipVerified: Boolean,
 )
 
 private data class RememberedDashboard(
@@ -150,6 +222,7 @@ internal class CelesteViewModel(
     private var activeSessionKey: SessionKey? = null
     private var openingToken: OpeningToken? = null
     private var openingJob: Job? = null
+    private var openingRollbackJob: Job? = null
     private var newConversationJob: Job? = null
     private var newConversationToken: Long? = null
     private var newConversationPreviousState: CelesteUiState? = null
@@ -164,7 +237,7 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             dashboardUrl = value,
             probe = null,
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -222,7 +295,7 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             loadingMessage = "Finding Hermes…",
-            errorMessage = null,
+            notice = null,
         )
         connectionJob = viewModelScope.launch {
             runCatching { dashboard.probe(rawUrl) }
@@ -236,7 +309,7 @@ internal class CelesteViewModel(
                 .onFailure { error ->
                     if (!isCurrentConnectionAttempt(attempt)) return@onFailure
                     mutableState.value = mutableState.value.copy(
-                        errorMessage = error.message ?: "Could not reach the Hermes dashboard.",
+                        notice = UiNotice.DashboardUnavailable,
                     )
                 }
             if (!isCurrentConnectionAttempt(attempt)) return@launch
@@ -256,7 +329,7 @@ internal class CelesteViewModel(
             sessionCatalog = if (initialScope == null) {
                 SessionCatalogState(
                     phase = SessionCatalogStatus.Error,
-                    errorMessage = "Hermes returned no catalog scope.",
+                    notice = UiNotice.SessionsUnavailable,
                 )
             } else {
                 SessionCatalogState(
@@ -266,14 +339,22 @@ internal class CelesteViewModel(
             },
             sessionQuery = "",
             loadingMessage = "Loading your conversations…",
-            errorMessage = null,
+            notice = null,
         )
+        var attemptedDescriptor: SavedConnectionDescriptor? = currentDescriptor
         connectionJob = viewModelScope.launch {
             runCatching {
                 val passwordProvider = connection.providers.firstOrNull { it.supportsPassword }
                 val selectedCredential = if (connection.authRequired) {
                     passwordProvider
                         ?: error("This dashboard requires browser sign-in, which is not in this build yet.")
+                    attemptedDescriptor = SavedConnectionDescriptor(
+                        baseUrl = connection.baseUrl,
+                        authMode = SavedAuthMode.ProviderSession,
+                        provider = passwordProvider.name,
+                        username = snapshot.username,
+                        expectsSecret = true,
+                    )
                     dashboard.passwordLogin(
                         baseUrl = connection.baseUrl,
                         provider = passwordProvider.name,
@@ -284,8 +365,22 @@ internal class CelesteViewModel(
                 } else {
                     snapshot.sessionToken
                         .takeIf(String::isNotBlank)
-                        ?.let(GatewayCredential::StaticToken)
-                        ?: GatewayCredential.None
+                        ?.let {
+                            attemptedDescriptor = SavedConnectionDescriptor(
+                                baseUrl = connection.baseUrl,
+                                authMode = SavedAuthMode.StaticToken,
+                                expectsSecret = true,
+                            )
+                            GatewayCredential.StaticToken(it)
+                        }
+                        ?: run {
+                            attemptedDescriptor = SavedConnectionDescriptor(
+                                baseUrl = connection.baseUrl,
+                                authMode = SavedAuthMode.Open,
+                                expectsSecret = false,
+                            )
+                            GatewayCredential.None
+                        }
                 }
                 val loaded = loadDashboard(
                     baseUrl = connection.baseUrl,
@@ -332,28 +427,35 @@ internal class CelesteViewModel(
                     loaded = remembered.loaded,
                     password = "",
                     sessionToken = "",
-                    errorMessage = if (remembered.persistenceError == null) {
+                    notice = if (remembered.persistenceError == null) {
                         null
                     } else {
-                        "Connected, but Celeste could not remember this connection."
+                        UiNotice.PersistenceUnavailable
                     },
                 )
             }.onFailure { error ->
                 if (!isCurrentConnectionAttempt(attempt)) return@onFailure
-                dashboard.clearAuthentication()
-                mutableState.value = mutableState.value.copy(
-                    connectionPhase = ConnectionPhase.ManualSetup,
-                    sessions = null,
-                    sessionCatalog = SessionCatalogState(
-                        phase = SessionCatalogStatus.Error,
-                        scope = initialScope,
-                        errorMessage = error.message ?: "Could not load Hermes conversations.",
-                    ),
-                    sessionQuery = "",
-                    errorMessage = error.message ?: "Could not load Hermes conversations.",
-                    password = "",
-                    sessionToken = "",
-                )
+                if (error is AuthenticationRejected) {
+                    invalidateReusableAuthentication(
+                        descriptor = attemptedDescriptor ?: currentDescriptor,
+                        probe = connection,
+                    )
+                } else {
+                    dashboard.clearAuthentication()
+                    mutableState.value = mutableState.value.copy(
+                        connectionPhase = ConnectionPhase.ManualSetup,
+                        sessions = null,
+                        sessionCatalog = SessionCatalogState(
+                            phase = SessionCatalogStatus.Error,
+                            scope = initialScope,
+                            notice = UiNotice.SessionsUnavailable,
+                        ),
+                        sessionQuery = "",
+                        notice = UiNotice.SessionsUnavailable,
+                        password = "",
+                        sessionToken = "",
+                    )
+                }
             }
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = mutableState.value.copy(loadingMessage = null)
@@ -371,7 +473,7 @@ internal class CelesteViewModel(
             messages = emptyList(),
             streamingText = "",
             draft = "",
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -407,7 +509,7 @@ internal class CelesteViewModel(
             password = "",
             sessionToken = "",
             loadingMessage = "Signing out…",
-            errorMessage = null,
+            notice = null,
         )
         connectionJob = viewModelScope.launch {
             val (error, saved) = connectionStoreMutex.withLock {
@@ -422,9 +524,7 @@ internal class CelesteViewModel(
             currentDescriptor = saved?.descriptor
             mutableState.value = manualState(
                 descriptor = saved?.descriptor,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved sign-in. Try Forget connection."
-                },
+                notice = if (error == null) null else UiNotice.SignOutUnavailable,
             )
         }
     }
@@ -451,9 +551,7 @@ internal class CelesteViewModel(
             if (!isCurrentConnectionAttempt(attempt)) return@launch
             mutableState.value = CelesteUiState(
                 connectionPhase = ConnectionPhase.ManualSetup,
-                errorMessage = if (error == null) null else {
-                    "Celeste could not remove the saved connection. Try again."
-                },
+                notice = if (error == null) null else UiNotice.ForgetUnavailable,
             )
         }
     }
@@ -474,7 +572,7 @@ internal class CelesteViewModel(
             val saved = savedResult.getOrElse {
                 mutableState.value = manualState(
                     descriptor = null,
-                    errorMessage = "Celeste could not read the saved connection. Sign in again.",
+                    notice = UiNotice.SavedConnectionUnavailable,
                 )
                 return@launch
             }
@@ -561,9 +659,7 @@ internal class CelesteViewModel(
             )
             publishConnectedDashboard(
                 loaded,
-                errorMessage = if (persistenceError == null) null else {
-                    "Connected, but Celeste could not refresh the saved sign-in."
-                },
+                notice = if (persistenceError == null) null else UiNotice.PersistenceRefreshUnavailable,
             )
         }.onFailure { error ->
             if (!isCurrentConnectionAttempt(attempt)) return@onFailure
@@ -581,7 +677,7 @@ internal class CelesteViewModel(
                     dashboardUrl = descriptor.baseUrl,
                     savedAuthMode = descriptor.authMode,
                     username = descriptor.username.orEmpty(),
-                    errorMessage = error.message ?: "Could not reconnect to Hermes.",
+                    notice = UiNotice.RestoreUnavailable,
                 )
             }
         }
@@ -599,8 +695,18 @@ internal class CelesteViewModel(
             ?: profiles.firstOrNull(DashboardProfile::isDefault)?.name
             ?: profiles.firstOrNull()?.name
             ?: "default"
-        val sessions = dashboard.listSessions(baseUrl, selectedCredential)
-        return LoadedDashboard(selectedCredential, sessions, profiles, selectedProfile)
+        val profileSessionList = dashboard.listProfileSessions(
+            baseUrl = baseUrl,
+            credential = selectedCredential,
+            profile = "all",
+        )
+        return LoadedDashboard(
+            credential = selectedCredential,
+            sessions = profileSessionList.sessions,
+            profiles = profiles,
+            selectedProfile = selectedProfile,
+            profileOwnershipVerified = profileSessionList.profileOwnershipVerified,
+        )
     }
 
     private suspend fun invalidateReusableAuthentication(
@@ -624,7 +730,7 @@ internal class CelesteViewModel(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
             probe = probe,
-            errorMessage = AUTHENTICATION_REQUIRED_MESSAGE,
+            notice = UiNotice.AuthenticationRequired,
         )
     }
 
@@ -632,7 +738,7 @@ internal class CelesteViewModel(
         loaded: LoadedDashboard,
         password: String = "",
         sessionToken: String = "",
-        errorMessage: String? = null,
+        notice: UiNotice? = null,
     ) {
         val selectedProfile = loaded.profiles.firstOrNull {
             it.name.equals(mutableState.value.selectedProfile, ignoreCase = true)
@@ -640,7 +746,7 @@ internal class CelesteViewModel(
         val scope = SessionScope.unscoped(mutableState.value.probe?.baseUrl.orEmpty())
         catalogScope = scope
         val catalog = if (scope == null) {
-            SessionCatalogState(phase = SessionCatalogStatus.Error, errorMessage = "Hermes returned no catalog scope.")
+            SessionCatalogState(phase = SessionCatalogStatus.Error, notice = UiNotice.CatalogUnavailable)
         } else {
             val rows = SessionCatalogReducer.filterAuthoritativeRows(scope, loaded.sessions)
             SessionCatalogState(
@@ -657,12 +763,13 @@ internal class CelesteViewModel(
             sessionQuery = "",
             profiles = loaded.profiles,
             selectedProfile = selectedProfile,
+            profileOwnershipVerified = loaded.profileOwnershipVerified,
             activeSummary = null,
             messages = emptyList(),
             password = password,
             sessionToken = sessionToken,
             loadingMessage = null,
-            errorMessage = errorMessage,
+            notice = notice,
         )
     }
 
@@ -670,14 +777,14 @@ internal class CelesteViewModel(
         descriptor: SavedConnectionDescriptor? = null,
         phase: ConnectionPhase = ConnectionPhase.ManualSetup,
         probe: DashboardProbeResult? = null,
-        errorMessage: String? = null,
+        notice: UiNotice? = null,
     ): CelesteUiState = CelesteUiState(
         connectionPhase = phase,
         dashboardUrl = descriptor?.baseUrl ?: probe?.baseUrl.orEmpty(),
         probe = probe,
         savedAuthMode = descriptor?.authMode,
         username = descriptor?.username.orEmpty(),
-        errorMessage = errorMessage,
+        notice = notice,
     )
 
     private fun invalidatePendingOperations() {
@@ -685,6 +792,8 @@ internal class CelesteViewModel(
         openingToken = null
         openingJob?.cancel()
         openingJob = null
+        openingRollbackJob?.cancel()
+        openingRollbackJob = null
         val candidateGateway = pendingOpening?.candidateGateway
         if (candidateGateway != null && candidateGateway !== gateway && candidateGateway !== pendingOpening.previousGateway) {
             candidateGateway.close()
@@ -711,6 +820,7 @@ internal class CelesteViewModel(
             sessions = null,
             sessionCatalog = SessionCatalogState(),
             sessionQuery = "",
+            profileOwnershipVerified = false,
         )
         connectionJob?.cancel()
         connectionJob = null
@@ -799,10 +909,11 @@ internal class CelesteViewModel(
         )
         catalogJob = viewModelScope.launch {
             try {
-                val rows = dashboard.listSessions(
+                val rows = dashboard.listProfileSessions(
                     baseUrl = probe.baseUrl,
                     credential = activeCredential,
-                )
+                    profile = "all",
+                ).sessions
                 if (!isCurrentCatalogRequest(request)) return@launch
                 publishCatalog(
                     SessionCatalogReducer.succeeded(
@@ -824,7 +935,8 @@ internal class CelesteViewModel(
                         SessionCatalogReducer.failed(
                             mutableState.value.sessionCatalog,
                             request,
-                            error.message ?: "Could not refresh Hermes conversations.",
+                            uiNoticeFor(error, UiNotice.CatalogUnavailable)
+                                ?: return@launch,
                         ),
                     )
                 }
@@ -905,13 +1017,13 @@ internal class CelesteViewModel(
             sessions = openingCatalog.rows,
             sessionCatalog = openingCatalog,
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
-            errorMessage = null,
+            notice = null,
         )
 
         val newGateway = runCatching {
             dashboard.createGateway(connection.baseUrl, activeCredential)
         }.getOrElse { error ->
-            rollbackOpening(token, error.message ?: "Could not open that Hermes conversation.")
+            rollbackOpening(token, UiNotice.ConversationUnavailable)
             return
         }
         val activeToken = token.copy(candidateGateway = newGateway)
@@ -949,7 +1061,7 @@ internal class CelesteViewModel(
                     activeSummary = summary,
                     draft = "",
                     loadingMessage = null,
-                    errorMessage = null,
+                    notice = null,
                     conversationNavigationToken = mutableState.value.conversationNavigationToken + 1,
                 )
             } catch (error: Throwable) {
@@ -965,7 +1077,7 @@ internal class CelesteViewModel(
                     } else {
                         rollbackOpening(
                             activeToken,
-                            error.message?.takeIf { error !is CancellationException },
+                            if (error is CancellationException) null else UiNotice.ConversationUnavailable,
                         )
                     }
                 }
@@ -995,51 +1107,95 @@ internal class CelesteViewModel(
     private fun errorCandidateIsClosed(token: OpeningToken): Boolean =
         token.candidateGateway != null && token.candidateGateway !== gateway
 
-    private fun rollbackOpening(token: OpeningToken, message: String?) {
+    private fun rollbackOpening(token: OpeningToken, notice: UiNotice?) {
         if (openingToken?.id != token.id) return
         val candidate = token.candidateGateway
-        if (candidate != null && gateway === candidate) {
-            detachGatewayObservers()
-            if (token.previousGateway != null && token.previousGateway !== candidate) {
-                gateway = token.previousGateway
-                observeGateway(token.previousGateway)
-            } else {
-                gateway = null
-            }
-            if (candidate !== token.previousGateway) candidate.close()
-        } else if (candidate != null && candidate !== token.previousGateway) {
-            candidate.close()
-        }
+        detachGatewayObservers()
+        if (candidate != null && candidate !== token.previousGateway) candidate.close()
+        gateway = token.previousGateway
         activeSessionKey = token.previousKey
-        currentRuntimeSessionId = if (token.previousGateway != null && token.previousGateway === candidate) {
-            null
-        } else {
-            token.previousRuntimeId
-        }
+        currentRuntimeSessionId = token.previousRuntimeId
         currentSessionCanResume = token.previousCanResume
-        val restoredCatalog = if (message == null) {
+        val restoredCatalog = if (notice == null) {
             SessionCatalogReducer.openingCancelled(token.previousState.sessionCatalog)
         } else {
-            SessionCatalogReducer.openingFailed(token.previousState.sessionCatalog, message)
+            SessionCatalogReducer.openingFailed(
+                token.previousState.sessionCatalog,
+                notice,
+            )
         }
         openingToken = null
         openingJob = null
+        val previousGateway = token.previousGateway
+        val previousKey = token.previousKey
+        if (previousGateway != null && previousKey != null) {
+            // Arm the previous collector before publishing the rollback. Any
+            // event received while its snapshot is loading is buffered and
+            // replayed after the authoritative resume response.
+            reconciling = true
+            bufferedEvents.clear()
+            observeGateway(previousGateway)
+        }
         mutableState.value = token.previousState.copy(
             sessions = restoredCatalog.rows,
             sessionCatalog = restoredCatalog,
             loadingMessage = null,
-            errorMessage = message ?: token.previousState.errorMessage,
+            notice = notice ?: token.previousState.notice,
             turnState = if (
                 token.previousGateway != null &&
-                token.previousGateway === candidate &&
                 token.previousKey != null
             ) {
-                TurnState.Reconnecting
+                TurnState.Synchronizing
             } else {
                 token.previousState.turnState
             },
         )
+        if (previousGateway != null && previousKey != null) {
+            openingRollbackJob?.cancel()
+            val wasRunning = token.previousState.turnState == TurnState.Running
+            openingRollbackJob = viewModelScope.launch {
+                try {
+                    if (previousGateway.state.value != GatewayConnectionState.Connected) {
+                        previousGateway.connect()
+                    }
+                    if (!isCurrentOpeningRollback(token, previousGateway, previousKey)) return@launch
+                    reconcile(
+                        activeGateway = previousGateway,
+                        key = previousKey,
+                        preserveBufferedEvents = true,
+                    )
+                    if (!isCurrentOpeningRollback(token, previousGateway, previousKey)) return@launch
+                    mutableState.value = mutableState.value.copy(
+                        loadingMessage = null,
+                        notice = notice ?: mutableState.value.notice,
+                    )
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    reconciling = false
+                    bufferedEvents.clear()
+                    if (!isCurrentOpeningRollback(token, previousGateway, previousKey)) return@launch
+                    mutableState.value = mutableState.value.copy(
+                        turnState = TurnState.Reconnecting,
+                        notice = UiNotice.PreviousConversationUnavailable,
+                    )
+                    scheduleReconnect(wasRunning = wasRunning, immediate = true)
+                } finally {
+                    openingRollbackJob = null
+                }
+            }
+        }
     }
+
+    private fun isCurrentOpeningRollback(
+        token: OpeningToken,
+        previousGateway: GatewayConnection,
+        previousKey: SessionKey,
+    ): Boolean = openingToken == null &&
+        gateway === previousGateway &&
+        activeSessionKey == previousKey &&
+        connectionAttempt == token.connectionAttempt &&
+        originGeneration == token.originGeneration
 
     fun createNewConversation() {
         if (openingToken != null || newConversationToken != null) return
@@ -1061,20 +1217,22 @@ internal class CelesteViewModel(
             // This is deliberately not a synthetic catalog row or a persisted draft.
             turnState = TurnState.Synchronizing,
             loadingMessage = "Starting a new $selectedProfile conversation…",
-            errorMessage = null,
+            notice = null,
         )
 
         val newGateway = runCatching {
             dashboard.createGateway(connection.baseUrl, activeCredential)
         }.getOrElse { error ->
-            val message = error.message ?: "Could not create a Hermes conversation."
             newConversationToken = null
             newConversationPreviousState = null
             mutableState.value = snapshot.copy(
                 sessions = snapshot.sessionCatalog.rows,
-                sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
+                sessionCatalog = SessionCatalogReducer.actionFailed(
+                    snapshot.sessionCatalog,
+                    UiNotice.NewConversationUnavailable,
+                ),
                 loadingMessage = null,
-                errorMessage = message,
+                notice = UiNotice.NewConversationUnavailable,
             )
             return
         }
@@ -1126,7 +1284,7 @@ internal class CelesteViewModel(
                         } else {
                             SessionCatalogStatus.Ready
                         },
-                        errorMessage = null,
+                        notice = null,
                         request = null,
                     ),
                     activeSummary = summary,
@@ -1135,7 +1293,7 @@ internal class CelesteViewModel(
                     draft = "",
                     turnState = TurnState.Idle,
                     loadingMessage = null,
-                    errorMessage = null,
+                    notice = null,
                 )
                 committed = true
                 newConversationToken = null
@@ -1155,18 +1313,27 @@ internal class CelesteViewModel(
                             probe = connection,
                         )
                     } else {
-                        val message = error.message ?: "Could not create a Hermes conversation."
+                        val notice = if (error is CancellationException) {
+                            null
+                        } else {
+                            UiNotice.NewConversationUnavailable
+                        }
+                        val failedCatalog = if (notice == null) {
+                            SessionCatalogReducer.actionCancelled(snapshot.sessionCatalog)
+                        } else {
+                            SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, notice)
+                        }
                         mutableState.value = snapshot.copy(
                             sessions = snapshot.sessionCatalog.rows,
-                            sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
+                            sessionCatalog = failedCatalog,
                             loadingMessage = null,
-                            errorMessage = message,
+                            notice = notice,
                         )
                     }
                 } else if (newConversationToken == operationToken) {
                     rollbackNewConversation(
                         snapshot = snapshot,
-                        message = error.message?.takeIf { error !is CancellationException },
+                        notice = if (error is CancellationException) null else UiNotice.NewConversationUnavailable,
                     )
                 }
             } finally {
@@ -1185,12 +1352,13 @@ internal class CelesteViewModel(
         rollbackNewConversation(snapshot, null)
     }
 
-    private fun rollbackNewConversation(snapshot: CelesteUiState, message: String?) {
+    private fun rollbackNewConversation(snapshot: CelesteUiState, notice: UiNotice?) {
         if (newConversationPreviousState == null && newConversationToken == null) return
-        val restoredCatalog = SessionCatalogReducer.actionFailed(
-            snapshot.sessionCatalog,
-            message ?: "New conversation cancelled.",
-        )
+        val restoredCatalog = if (notice == null) {
+            SessionCatalogReducer.actionCancelled(snapshot.sessionCatalog)
+        } else {
+            SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, notice)
+        }
         val current = mutableState.value
         mutableState.value = current.copy(
             sessions = restoredCatalog.rows,
@@ -1201,7 +1369,7 @@ internal class CelesteViewModel(
             draft = snapshot.draft,
             turnState = snapshot.turnState,
             loadingMessage = null,
-            errorMessage = message,
+            notice = notice,
         )
         newConversationToken = null
         newConversationPreviousState = null
@@ -1216,7 +1384,7 @@ internal class CelesteViewModel(
             draft = "",
             turnState = TurnState.Idle,
             loadingMessage = null,
-            errorMessage = null,
+            notice = null,
         )
         refreshSessionCatalog()
     }
@@ -1225,6 +1393,7 @@ internal class CelesteViewModel(
         val activeGateway = gateway ?: return
         val snapshot = mutableState.value
         val runtimeId = currentRuntimeSessionId ?: return
+        val activeKey = activeSessionKey ?: return
         val text = snapshot.draft.trim()
         if (text.isBlank() || snapshot.turnState != TurnState.Idle) return
 
@@ -1239,51 +1408,63 @@ internal class CelesteViewModel(
             streamingText = "",
             draft = "",
             turnState = TurnState.Running,
-            errorMessage = null,
+            notice = null,
         )
         // prompt.submit creates the durable row before work begins. From this point on,
         // uncertain delivery must reconcile by stored ID and must never create/resend.
         currentSessionCanResume = true
-        val activeKey = activeSessionKey
         viewModelScope.launch {
-            runCatching { activeGateway.submitPrompt(runtimeId, text) }
-                .onSuccess {
-                    mutableState.value = mutableState.value.copy(
-                        messages = mutableState.value.messages.map { message ->
-                            if (message.id == localId) message.copy(pending = false) else message
-                        },
-                    )
-                    // prompt.submit is the first durable write for a blank
-                    // runtime; the catalog learns its row only from Hermes.
-                    refreshSessionCatalog()
+            try {
+                activeGateway.submitPrompt(runtimeId, text)
+                if (!isCurrentSession(activeGateway, activeKey, runtimeId)) return@launch
+                mutableState.value = mutableState.value.copy(
+                    messages = mutableState.value.messages.map { message ->
+                        if (message.id == localId) message.copy(pending = false) else message
+                    },
+                )
+                // prompt.submit is the first durable write for a blank
+                // runtime; the catalog learns its row only from Hermes.
+                refreshSessionCatalog()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrentSession(activeGateway, activeKey, runtimeId)) return@launch
+                val notice = uiNoticeFor(error, UiNotice.SendUnavailable) ?: return@launch
+                mutableState.value = mutableState.value.copy(notice = notice)
+                try {
+                    reconcile(activeGateway, activeKey)
+                } catch (reconciliationError: CancellationException) {
+                    throw reconciliationError
+                } catch (_: Throwable) {
+                    // The fixed send notice is already visible; a later
+                    // reconnect will reconcile the authoritative snapshot.
                 }
-                .onFailure { error ->
-                    mutableState.value = mutableState.value.copy(
-                        errorMessage = error.message ?: "Hermes could not send that message.",
-                    )
-                    if (gateway === activeGateway && activeKey != null) {
-                        runCatching { reconcile(activeGateway, activeKey) }
-                    }
-                }
+            }
         }
     }
 
     fun interrupt() {
         val activeGateway = gateway ?: return
         val runtimeId = currentRuntimeSessionId ?: return
+        val activeKey = activeSessionKey ?: return
         if (mutableState.value.turnState != TurnState.Running) return
         mutableState.value = mutableState.value.copy(
             turnState = TurnState.Synchronizing,
-            errorMessage = null,
+            notice = null,
         )
         viewModelScope.launch {
-            runCatching {
+            try {
                 activeGateway.interruptSession(runtimeId)
-                val activeKey = activeSessionKey ?: return@runCatching
+                if (!isCurrentSession(activeGateway, activeKey, runtimeId)) return@launch
                 reconcile(activeGateway, activeKey)
-            }.onFailure { error ->
+                if (!isCurrentSession(activeGateway, activeKey, runtimeId)) return@launch
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrentSession(activeGateway, activeKey, runtimeId)) return@launch
+                val notice = uiNoticeFor(error, UiNotice.InterruptUnavailable) ?: return@launch
                 mutableState.value = mutableState.value.copy(
-                    errorMessage = error.message ?: "Hermes could not stop that turn.",
+                    notice = notice,
                 )
             }
         }
@@ -1322,7 +1503,7 @@ internal class CelesteViewModel(
             }
             return
         }
-        val activeKey = activeSessionKey
+        val activeKey = activeSessionKey ?: return
         if (foregroundCheckJob?.isActive == true || reconciling) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
             markCatalogReconnecting()
@@ -1330,33 +1511,46 @@ internal class CelesteViewModel(
             return
         }
         foregroundCheckJob = viewModelScope.launch {
-            val health = runCatching {
+            try {
                 activeGateway.request(
                     method = "session.list",
                     params = buildJsonObject { put("limit", 1) },
                     timeoutMillis = 8_000,
                 )
-                if (currentSessionCanResume && activeKey != null) {
+                if (!isCurrentSession(activeGateway, activeKey)) return@launch
+                if (currentSessionCanResume) {
                     reconcile(activeGateway, activeKey)
                 }
-            }
-            if (health.isSuccess && gateway === activeGateway) {
+                if (!isCurrentSession(activeGateway, activeKey)) return@launch
                 refreshSessionCatalog()
-            } else if (health.isFailure && gateway === activeGateway) {
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                if (!isCurrentSession(activeGateway, activeKey)) return@launch
                 val wasRunning = mutableState.value.turnState == TurnState.Running
                 markCatalogReconnecting()
                 activeGateway.close()
+                val notice = uiNoticeFor(error, UiNotice.Reconnecting) ?: return@launch
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
-                    errorMessage = health.exceptionOrNull()?.message ?: "Reconnecting to Hermes…",
+                    notice = notice,
                 )
                 scheduleReconnect(wasRunning = wasRunning, immediate = true)
+            } finally {
+                if (isCurrentSession(activeGateway, activeKey)) foregroundCheckJob = null
             }
-            foregroundCheckJob = null
         }
     }
 
     private var currentRuntimeSessionId: String? = null
+
+    private fun isCurrentSession(
+        activeGateway: GatewayConnection,
+        activeKey: SessionKey,
+        runtimeId: String? = null,
+    ): Boolean = gateway === activeGateway &&
+        activeSessionKey == activeKey &&
+        (runtimeId == null || currentRuntimeSessionId == runtimeId)
 
     private fun detachGatewayObservers() {
         gatewayEventsJob?.cancel()
@@ -1385,7 +1579,7 @@ internal class CelesteViewModel(
                     markCatalogReconnecting()
                     mutableState.value = mutableState.value.copy(
                         turnState = TurnState.Reconnecting,
-                        errorMessage = connectionState.reason,
+                        notice = UiNotice.Reconnecting,
                     )
                     scheduleReconnect(wasRunning)
                 }
@@ -1393,9 +1587,15 @@ internal class CelesteViewModel(
         }
     }
 
-    private suspend fun reconcile(activeGateway: GatewayConnection, key: SessionKey) {
-        reconciling = true
-        bufferedEvents.clear()
+    private suspend fun reconcile(
+        activeGateway: GatewayConnection,
+        key: SessionKey,
+        preserveBufferedEvents: Boolean = false,
+    ) {
+        if (!preserveBufferedEvents) {
+            reconciling = true
+            bufferedEvents.clear()
+        }
         try {
             val resumed = activeGateway.resumeStoredSession(key.durableId, key.profile)
             if (gateway !== activeGateway || activeSessionKey != key) {
@@ -1434,7 +1634,7 @@ internal class CelesteViewModel(
             } else {
                 TurnState.Idle
             },
-            errorMessage = null,
+            notice = null,
         )
     }
 
@@ -1447,7 +1647,7 @@ internal class CelesteViewModel(
                 mutableState.value = mutableState.value.copy(
                     streamingText = "",
                     turnState = TurnState.Running,
-                    errorMessage = null,
+                    notice = null,
                 )
             }
 
@@ -1484,10 +1684,10 @@ internal class CelesteViewModel(
                 finalizeAssistant(content, keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = if (status == "error") {
-                        event.payload.string("error") ?: "Hermes could not finish that response."
+                    notice = if (status == "error") {
+                        UiNotice.HermesReportedError
                     } else {
-                        mutableState.value.errorMessage
+                        mutableState.value.notice
                     },
                 )
             }
@@ -1496,7 +1696,7 @@ internal class CelesteViewModel(
                 finalizeAssistant(keepRunning = false)
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
-                    errorMessage = event.payload.string("message") ?: "Hermes reported an error.",
+                    notice = UiNotice.HermesReportedError,
                 )
             }
 
@@ -1622,7 +1822,7 @@ internal class CelesteViewModel(
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
                 turnState = TurnState.Idle,
-                errorMessage = null,
+                notice = null,
             )
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
@@ -1657,6 +1857,7 @@ internal class CelesteViewModel(
                     }
                 }
                 if (result.isSuccess) {
+                    if (!isCurrentSession(activeGateway, activeKey)) return@launch
                     reconnectAttempts = 0
                     reconnectJob = null
                     refreshSessionCatalog()
@@ -1664,7 +1865,8 @@ internal class CelesteViewModel(
                 }
                 val failure = result.exceptionOrNull()
                 if (failure is CancellationException) throw failure
-                if (failure is AuthenticationRejected) {
+                if (!isCurrentSession(activeGateway, activeKey)) return@launch
+                if (findCause(failure ?: return@launch) { it is AuthenticationRejected } != null) {
                     val descriptor = currentDescriptor
                     reconnectJob = null
                     closeGateway()
@@ -1672,9 +1874,10 @@ internal class CelesteViewModel(
                     return@launch
                 }
                 reconnectAttempts += 1
+                val notice = uiNoticeFor(failure ?: return@launch, UiNotice.Reconnecting) ?: return@launch
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Reconnecting,
-                    errorMessage = failure?.message ?: "Reconnecting to Hermes…",
+                    notice = notice,
                 )
             }
             reconnectJob = null

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -1006,13 +1006,20 @@ internal class CelesteViewModel(
                     profileGeneration == selectedProfileGeneration &&
                     mutableState.value.selectedProfile == selectedProfile
                 ) {
-                    val message = error.message ?: "Could not create a Hermes conversation."
-                    mutableState.value = snapshot.copy(
-                        sessions = snapshot.sessionCatalog.rows,
-                        sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
-                        loadingMessage = null,
-                        errorMessage = message,
-                    )
+                    if (error is AuthenticationRejected) {
+                        invalidateReusableAuthentication(
+                            descriptor = currentDescriptor,
+                            probe = connection,
+                        )
+                    } else {
+                        val message = error.message ?: "Could not create a Hermes conversation."
+                        mutableState.value = snapshot.copy(
+                            sessions = snapshot.sessionCatalog.rows,
+                            sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
+                            loadingMessage = null,
+                            errorMessage = message,
+                        )
+                    }
                 }
             } finally {
                 candidateEventsJob.cancel()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -70,6 +70,8 @@ internal data class CelesteUiState(
     val password: String = "",
     val sessionToken: String = "",
     val sessions: List<StoredSession>? = null,
+    val sessionCatalog: SessionCatalogState = SessionCatalogState(),
+    val sessionQuery: String = "",
     val profiles: List<DashboardProfile> = listOf(DashboardProfile(name = "default", isDefault = true)),
     val selectedProfile: String = "default",
     val activeSummary: StoredSession? = null,
@@ -85,6 +87,7 @@ private data class LoadedDashboard(
     val credential: GatewayCredential,
     val sessions: List<StoredSession>,
     val profiles: List<DashboardProfile>,
+    val selectedProfile: String,
 )
 
 private data class RememberedDashboard(
@@ -112,6 +115,11 @@ internal class CelesteViewModel(
     private var foregroundCheckJob: Job? = null
     private var connectionJob: Job? = null
     private var connectionAttempt = 0L
+    private var originGeneration = 0L
+    private var profileGeneration = 0L
+    private var catalogRequestGeneration = 0L
+    private var catalogScope: SessionScope? = null
+    private var catalogJob: Job? = null
     private val connectionStoreMutex = Mutex()
     private var currentDescriptor: SavedConnectionDescriptor? = null
     private var reconnectAttempts = 0
@@ -147,9 +155,23 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(draft = value)
     }
 
+    /**
+     * The current Hermes session.list contract is not verified as profile-filtered.
+     * Keep this selector scoped to the next new conversation and leave the
+     * server-ordered catalog intact rather than inventing a wire parameter.
+     */
     fun selectProfile(name: String) {
-        if (mutableState.value.profiles.none { it.name == name }) return
-        mutableState.value = mutableState.value.copy(selectedProfile = name)
+        val selected = mutableState.value.profiles.firstOrNull {
+            it.name.equals(name, ignoreCase = true)
+        } ?: return
+        val snapshot = mutableState.value
+        if (snapshot.selectedProfile.equals(selected.name, ignoreCase = true)) return
+
+        profileGeneration += 1
+        mutableState.value = snapshot.copy(selectedProfile = selected.name)
+        // If a catalog read was in flight, restart it under the new profile
+        // generation so the old completion cannot strand the loading state.
+        if (catalogJob?.isActive == true && credential != null) refreshSessionCatalog()
     }
 
     fun findDashboard() {
@@ -163,6 +185,10 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             sessions = null,
+            sessionCatalog = SessionCatalogState(),
+            sessionQuery = "",
+            profiles = listOf(DashboardProfile(name = "default", isDefault = true)),
+            selectedProfile = "default",
             activeSummary = null,
             messages = emptyList(),
             streamingText = "",
@@ -194,9 +220,13 @@ internal class CelesteViewModel(
         val snapshot = mutableState.value
         val connection = snapshot.probe ?: return
         val attempt = beginConnectionAttempt()
+        val selectedProfileGeneration = profileGeneration
         dashboard.clearAuthentication()
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
+            sessions = null,
+            sessionCatalog = SessionCatalogState(),
+            sessionQuery = "",
             loadingMessage = "Loading your conversations…",
             errorMessage = null,
         )
@@ -219,7 +249,12 @@ internal class CelesteViewModel(
                         ?.let(GatewayCredential::StaticToken)
                         ?: GatewayCredential.None
                 }
-                val loaded = loadDashboard(connection.baseUrl, selectedCredential)
+                val loaded = loadDashboard(
+                    baseUrl = connection.baseUrl,
+                    selectedCredential = selectedCredential,
+                    preferredProfile = snapshot.selectedProfile,
+                )
+                if (profileGeneration != selectedProfileGeneration) throw CancellationException()
                 val descriptor = when {
                     connection.authRequired -> SavedConnectionDescriptor(
                         baseUrl = connection.baseUrl,
@@ -253,7 +288,7 @@ internal class CelesteViewModel(
                 }
                 RememberedDashboard(loaded, descriptor, persistenceError)
             }.onSuccess { remembered ->
-                if (!isCurrentConnectionAttempt(attempt)) return@onSuccess
+                if (!isCurrentConnectionAttempt(attempt) || profileGeneration != selectedProfileGeneration) return@onSuccess
                 credential = remembered.loaded.credential
                 currentDescriptor = remembered.descriptor
                 publishConnectedDashboard(
@@ -267,7 +302,7 @@ internal class CelesteViewModel(
                     },
                 )
             }.onFailure { error ->
-                if (!isCurrentConnectionAttempt(attempt)) return@onFailure
+                if (!isCurrentConnectionAttempt(attempt) || profileGeneration != selectedProfileGeneration) return@onFailure
                 dashboard.clearAuthentication()
                 mutableState.value = mutableState.value.copy(
                     errorMessage = error.message ?: "Could not load Hermes conversations.",
@@ -318,6 +353,8 @@ internal class CelesteViewModel(
         mutableState.value = snapshot.copy(
             connectionPhase = ConnectionPhase.ManualSetup,
             sessions = null,
+            sessionCatalog = SessionCatalogState(),
+            sessionQuery = "",
             activeSummary = null,
             messages = emptyList(),
             streamingText = "",
@@ -508,10 +545,17 @@ internal class CelesteViewModel(
     private suspend fun loadDashboard(
         baseUrl: String,
         selectedCredential: GatewayCredential,
+        preferredProfile: String = mutableState.value.selectedProfile,
     ): LoadedDashboard {
-        val sessions = dashboard.listSessions(baseUrl, selectedCredential)
         val profiles = dashboard.listProfiles(baseUrl, selectedCredential)
-        return LoadedDashboard(selectedCredential, sessions, profiles)
+        val selectedProfile = profiles.firstOrNull {
+            it.name.equals(preferredProfile, ignoreCase = true)
+        }?.name
+            ?: profiles.firstOrNull(DashboardProfile::isDefault)?.name
+            ?: profiles.firstOrNull()?.name
+            ?: "default"
+        val sessions = dashboard.listSessions(baseUrl, selectedCredential)
+        return LoadedDashboard(selectedCredential, sessions, profiles, selectedProfile)
     }
 
     private suspend fun invalidateReusableAuthentication(
@@ -538,15 +582,27 @@ internal class CelesteViewModel(
         sessionToken: String = "",
         errorMessage: String? = null,
     ) {
-        val selectedProfile = mutableState.value.selectedProfile
-            .takeIf { selected -> loaded.profiles.any { it.name == selected } }
-            ?: loaded.profiles.firstOrNull(DashboardProfile::isDefault)?.name
-            ?: loaded.profiles.firstOrNull()?.name
-            ?: "default"
+        val selectedProfile = loaded.selectedProfile
+        val scope = SessionScope.allProfiles(
+            origin = mutableState.value.probe?.baseUrl.orEmpty(),
+        )
+        catalogScope = scope
+        val catalog = if (scope == null) {
+            SessionCatalogState(phase = SessionCatalogStatus.Error, errorMessage = "Hermes returned no catalog scope.")
+        } else {
+            val rows = SessionCatalogReducer.filterAuthoritativeRows(scope, loaded.sessions)
+            SessionCatalogState(
+                phase = if (rows.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
+                scope = scope,
+                rows = rows,
+            )
+        }
         mutableState.value = mutableState.value.copy(
             connectionPhase = ConnectionPhase.Connected,
             savedAuthMode = currentDescriptor?.authMode,
-            sessions = loaded.sessions,
+            sessions = catalog.rows,
+            sessionCatalog = catalog,
+            sessionQuery = "",
             profiles = loaded.profiles,
             selectedProfile = selectedProfile,
             activeSummary = null,
@@ -574,6 +630,17 @@ internal class CelesteViewModel(
 
     private fun beginConnectionAttempt(): Long {
         connectionAttempt += 1
+        originGeneration += 1
+        profileGeneration += 1
+        catalogRequestGeneration += 1
+        catalogJob?.cancel()
+        catalogJob = null
+        catalogScope = null
+        mutableState.value = mutableState.value.copy(
+            sessions = null,
+            sessionCatalog = SessionCatalogState(),
+            sessionQuery = "",
+        )
         connectionJob?.cancel()
         connectionJob = null
         return connectionAttempt
@@ -581,12 +648,98 @@ internal class CelesteViewModel(
 
     private fun isCurrentConnectionAttempt(attempt: Long): Boolean = connectionAttempt == attempt
 
-    fun openSession(summary: StoredSession) {
-        val connection = mutableState.value.probe ?: return
+    fun updateSessionQuery(value: String) {
+        val snapshot = mutableState.value
+        val nextCatalog = snapshot.sessionCatalog.withQuery(value)
+        mutableState.value = snapshot.copy(
+            sessionQuery = value,
+            sessionCatalog = nextCatalog,
+        )
+    }
+
+    fun clearSessionQuery() = updateSessionQuery("")
+
+    fun openConversationBrowser() {
+        if (mutableState.value.sessions != null) refreshSessionCatalog()
+    }
+
+    fun closeConversationBrowser() {
+        if (mutableState.value.sessions != null) refreshSessionCatalog()
+    }
+
+    /** Refreshes one server-authoritative, profile-scoped loaded window. */
+    fun refreshSessionCatalog() {
+        val snapshot = mutableState.value
+        val probe = snapshot.probe ?: return
         val activeCredential = credential ?: return
-        closeGateway()
-        currentSessionCanResume = true
+        val scope = SessionScope.allProfiles(probe.baseUrl) ?: return
+        val refreshing = snapshot.sessionCatalog.scope == scope && snapshot.sessions != null
+        catalogJob?.cancel()
+        val request = SessionCatalogRequest(
+            scope = scope,
+            originGeneration = originGeneration,
+            profileGeneration = profileGeneration,
+            requestGeneration = ++catalogRequestGeneration,
+            connectionAttempt = connectionAttempt,
+        )
+        catalogScope = scope
+        val started = SessionCatalogReducer.begin(snapshot.sessionCatalog, request, refreshing)
+        mutableState.value = snapshot.copy(
+            sessions = started.rows,
+            sessionCatalog = started,
+        )
+        catalogJob = viewModelScope.launch {
+            runCatching {
+                dashboard.listSessions(
+                    baseUrl = probe.baseUrl,
+                    credential = activeCredential,
+                )
+            }.onSuccess { rows ->
+                if (!isCurrentCatalogRequest(request)) return@onSuccess
+                publishCatalog(SessionCatalogReducer.succeeded(mutableState.value.sessionCatalog, request, rows))
+            }.onFailure { error ->
+                if (!isCurrentCatalogRequest(request)) return@onFailure
+                publishCatalog(
+                    SessionCatalogReducer.failed(
+                        mutableState.value.sessionCatalog,
+                        request,
+                        error.message ?: "Could not refresh Hermes conversations.",
+                    ),
+                )
+            }
+            if (isCurrentCatalogRequest(request)) catalogJob = null
+        }
+    }
+
+    private fun isCurrentCatalogRequest(request: SessionCatalogRequest): Boolean {
+        val current = mutableState.value
+        return request.originGeneration == originGeneration &&
+            request.profileGeneration == profileGeneration &&
+            request.requestGeneration == catalogRequestGeneration &&
+            request.connectionAttempt == connectionAttempt &&
+            request.scope == catalogScope &&
+            current.probe?.baseUrl?.let { SessionScope.allProfiles(it) } == request.scope &&
+            credential != null
+    }
+
+    private fun publishCatalog(catalog: SessionCatalogState) {
         mutableState.value = mutableState.value.copy(
+            sessions = catalog.rows,
+            sessionCatalog = catalog,
+        )
+    }
+
+    fun openSession(summary: StoredSession) {
+        val snapshot = mutableState.value
+        val connection = snapshot.probe ?: return
+        val activeCredential = credential ?: return
+        val scope = catalogScope ?: SessionScope.allProfiles(connection.baseUrl) ?: return
+        val key = summary.keyFor(scope.originKey) ?: return
+        if (!scope.accepts(key)) return
+        if (snapshot.sessionCatalog.rows.none { it.keyFor(scope.originKey) == key }) return
+        val attempt = connectionAttempt
+        currentSessionCanResume = true
+        mutableState.value = snapshot.copy(
             activeSummary = summary,
             messages = emptyList(),
             streamingText = "",
@@ -595,6 +748,7 @@ internal class CelesteViewModel(
             loadingMessage = "Opening ${summary.title.ifBlank { "conversation" }}…",
             errorMessage = null,
         )
+        closeGateway()
 
         val newGateway = dashboard.createGateway(connection.baseUrl, activeCredential)
         gateway = newGateway
@@ -602,11 +756,16 @@ internal class CelesteViewModel(
         viewModelScope.launch {
             runCatching {
                 newGateway.connect()
+                if (gateway !== newGateway || connectionAttempt != attempt) {
+                    throw CancellationException("The Hermes conversation scope changed while opening.")
+                }
                 reconcile(newGateway, summary.id)
             }.onSuccess {
+                if (gateway !== newGateway || connectionAttempt != attempt) return@onSuccess
                 reconnectAttempts = 0
                 mutableState.value = mutableState.value.copy(loadingMessage = null)
             }.onFailure { error ->
+                if (gateway !== newGateway || connectionAttempt != attempt) return@onFailure
                 mutableState.value = mutableState.value.copy(
                     loadingMessage = null,
                     errorMessage = error.message ?: "Could not open that Hermes conversation.",
@@ -622,6 +781,8 @@ internal class CelesteViewModel(
         val connection = snapshot.probe ?: return
         val activeCredential = credential ?: return
         val selectedProfile = snapshot.selectedProfile
+        val attempt = connectionAttempt
+        val selectedProfileGeneration = profileGeneration
         closeGateway()
         mutableState.value = snapshot.copy(
             activeSummary = null,
@@ -642,7 +803,14 @@ internal class CelesteViewModel(
                 reconciling = true
                 bufferedEvents.clear()
                 val created = newGateway.createSession(selectedProfile)
-                if (gateway !== newGateway) throw IOException("The Hermes connection changed while creating the conversation.")
+                if (
+                    gateway !== newGateway ||
+                    connectionAttempt != attempt ||
+                    profileGeneration != selectedProfileGeneration ||
+                    mutableState.value.selectedProfile != selectedProfile
+                ) {
+                    throw CancellationException("The Hermes profile changed while creating the conversation.")
+                }
                 val returnedProfile = created.profile?.takeIf(String::isNotBlank)
                 if (returnedProfile != null && !returnedProfile.equals(selectedProfile, ignoreCase = true)) {
                     throw IOException("Hermes created this conversation in $returnedProfile instead of $selectedProfile.")
@@ -663,8 +831,6 @@ internal class CelesteViewModel(
                 bufferedEvents.clear()
                 reconciling = false
                 mutableState.value = mutableState.value.copy(
-                    sessions = listOf(summary) + mutableState.value.sessions.orEmpty()
-                        .filterNot { it.id == summary.id },
                     activeSummary = summary,
                     turnState = TurnState.Idle,
                     loadingMessage = null,
@@ -672,8 +838,20 @@ internal class CelesteViewModel(
                 )
                 events.forEach(::applyEvent)
             }.onSuccess {
+                if (
+                    gateway !== newGateway ||
+                    connectionAttempt != attempt ||
+                    profileGeneration != selectedProfileGeneration ||
+                    mutableState.value.selectedProfile != selectedProfile
+                ) return@onSuccess
                 reconnectAttempts = 0
             }.onFailure { error ->
+                if (
+                    gateway !== newGateway ||
+                    connectionAttempt != attempt ||
+                    profileGeneration != selectedProfileGeneration ||
+                    mutableState.value.selectedProfile != selectedProfile
+                ) return@onFailure
                 if (gateway === newGateway) closeGateway()
                 mutableState.value = mutableState.value.copy(
                     turnState = TurnState.Idle,
@@ -695,6 +873,7 @@ internal class CelesteViewModel(
             loadingMessage = null,
             errorMessage = null,
         )
+        refreshSessionCatalog()
     }
 
     fun sendMessage() {
@@ -728,6 +907,9 @@ internal class CelesteViewModel(
                             if (message.id == localId) message.copy(pending = false) else message
                         },
                     )
+                    // prompt.submit is the first durable write for a blank
+                    // runtime; the catalog learns its row only from Hermes.
+                    refreshSessionCatalog()
                 }
                 .onFailure { error ->
                     mutableState.value = mutableState.value.copy(
@@ -786,7 +968,13 @@ internal class CelesteViewModel(
     }
 
     fun onForeground() {
-        val activeGateway = gateway ?: return
+        val activeGateway = gateway
+        if (activeGateway == null) {
+            if (mutableState.value.sessions != null && catalogJob?.isActive != true) {
+                refreshSessionCatalog()
+            }
+            return
+        }
         val storedSessionId = currentStoredSessionId ?: return
         if (foregroundCheckJob?.isActive == true || reconciling) return
         if (activeGateway.state.value != GatewayConnectionState.Connected) {
@@ -1043,7 +1231,6 @@ internal class CelesteViewModel(
         activeGateway: GatewayConnection,
         profile: String,
     ) {
-        val previousStoredId = currentStoredSessionId
         reconciling = true
         bufferedEvents.clear()
         try {
@@ -1056,9 +1243,6 @@ internal class CelesteViewModel(
             val updatedSummary = previousSummary.copy(id = created.storedSessionId, profile = profile)
             mutableState.value = mutableState.value.copy(
                 activeSummary = updatedSummary,
-                sessions = mutableState.value.sessions?.map { session ->
-                    if (session.id == previousStoredId) updatedSummary else session
-                },
                 turnState = TurnState.Idle,
                 errorMessage = null,
             )
@@ -1139,6 +1323,8 @@ internal class CelesteViewModel(
     override fun onCleared() {
         connectionJob?.cancel()
         connectionJob = null
+        catalogJob?.cancel()
+        catalogJob = null
         closeGateway()
         dashboard.clearAuthentication()
         super.onCleared()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 private const val SESSION_SEARCH_DEBOUNCE_MILLIS = 250L
+private const val AUTHENTICATION_REQUIRED_MESSAGE = "Hermes needs sign-in."
 
 internal enum class TurnState {
     Synchronizing,
@@ -162,7 +163,10 @@ internal class CelesteViewModel(
         mutableState.value = mutableState.value.copy(draft = value)
     }
 
-    /** The loaded catalog is bounded to the selected profile; no all-profile mode exists in Phase 1. */
+    /**
+     * The selected profile is the creation target. session.list has no
+     * verified profile filter, so changing it keeps the loaded catalog intact.
+     */
     fun selectProfile(name: String) {
         val selected = mutableState.value.profiles.firstOrNull {
             it.name.equals(name, ignoreCase = true)
@@ -171,17 +175,28 @@ internal class CelesteViewModel(
         if (snapshot.selectedProfile.equals(selected.name, ignoreCase = true)) return
 
         profileGeneration += 1
+        val nextScope = snapshot.probe?.baseUrl?.let {
+            SessionScope.from(it, selected.name)
+        }
+        val hadCatalogRequest = catalogJob?.isActive == true
+        catalogScope = nextScope
         mutableState.value = snapshot.copy(
             selectedProfile = selected.name,
-            sessions = emptyList(),
-            sessionCatalog = SessionCatalogState(
-                phase = SessionCatalogStatus.Loading,
-                scope = snapshot.probe?.baseUrl?.let { SessionScope.from(it, selected.name) },
+            sessionCatalog = snapshot.sessionCatalog.copy(
+                scope = nextScope,
+                query = "",
+                queryResults = null,
+                queryInFlight = false,
             ),
             sessionQuery = "",
         )
         cancelSessionSearch()
-        if (credential != null && snapshot.probe != null) refreshSessionCatalog()
+        // A response already in hand is valid for the unscoped catalog. If a
+        // request was still loading, restart it only to avoid stranding its
+        // old profile-generation token.
+        if (hadCatalogRequest && credential != null && snapshot.probe != null) {
+            refreshSessionCatalog()
+        }
     }
 
     fun findDashboard() {
@@ -591,6 +606,7 @@ internal class CelesteViewModel(
         descriptor: SavedConnectionDescriptor?,
         probe: DashboardProbeResult? = null,
     ) {
+        closeGateway()
         sessionQueryGeneration += 1
         cancelSessionSearch()
         catalogRequestGeneration += 1
@@ -607,7 +623,7 @@ internal class CelesteViewModel(
             descriptor = descriptor,
             phase = ConnectionPhase.AuthenticationRequired,
             probe = probe,
-            errorMessage = "Saved sign-in is no longer valid. Sign in again.",
+            errorMessage = AUTHENTICATION_REQUIRED_MESSAGE,
         )
     }
 
@@ -740,7 +756,11 @@ internal class CelesteViewModel(
         if (mutableState.value.sessions != null) refreshSessionCatalog()
     }
 
-    /** Refreshes the server-authoritative loaded window for one selected profile. */
+    /**
+     * Refreshes the server-authoritative loaded window. The selected profile
+     * controls new conversation creation only; it is not sent as an invented
+     * session.list filter.
+     */
     fun refreshSessionCatalog() {
         val snapshot = mutableState.value
         val probe = snapshot.probe ?: return
@@ -849,7 +869,6 @@ internal class CelesteViewModel(
         val activeCredential = credential ?: return
         val scope = catalogScope ?: SessionScope.from(connection.baseUrl, snapshot.selectedProfile) ?: return
         val key = summary.keyFor(scope.originKey) ?: return
-        if (!scope.accepts(key)) return
         if (snapshot.sessionCatalog.rows.none { it.keyFor(scope.originKey) == key }) return
         val attempt = connectionAttempt
         currentSessionCanResume = true
@@ -898,7 +917,10 @@ internal class CelesteViewModel(
         val attempt = connectionAttempt
         val selectedProfileGeneration = profileGeneration
         val previousGateway = gateway
+        val actionStarted = SessionCatalogReducer.actionStarted(snapshot.sessionCatalog)
         mutableState.value = snapshot.copy(
+            sessions = actionStarted.rows,
+            sessionCatalog = actionStarted,
             // Keep the previous projection until Hermes accepts the new session.
             // This is deliberately not a synthetic catalog row or a persisted draft.
             turnState = TurnState.Synchronizing,
@@ -909,8 +931,12 @@ internal class CelesteViewModel(
         val newGateway = runCatching {
             dashboard.createGateway(connection.baseUrl, activeCredential)
         }.getOrElse { error ->
+            val message = error.message ?: "Could not create a Hermes conversation."
             mutableState.value = snapshot.copy(
-                errorMessage = error.message ?: "Could not create a Hermes conversation.",
+                sessions = snapshot.sessionCatalog.rows,
+                sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
+                loadingMessage = null,
+                errorMessage = message,
             )
             return
         }
@@ -953,6 +979,15 @@ internal class CelesteViewModel(
                     profile = selectedProfile,
                 )
                 mutableState.value = mutableState.value.copy(
+                    sessionCatalog = snapshot.sessionCatalog.copy(
+                        phase = if (snapshot.sessionCatalog.rows.isEmpty()) {
+                            SessionCatalogStatus.Empty
+                        } else {
+                            SessionCatalogStatus.Ready
+                        },
+                        errorMessage = null,
+                        request = null,
+                    ),
                     activeSummary = summary,
                     messages = emptyList(),
                     streamingText = "",
@@ -971,8 +1006,12 @@ internal class CelesteViewModel(
                     profileGeneration == selectedProfileGeneration &&
                     mutableState.value.selectedProfile == selectedProfile
                 ) {
+                    val message = error.message ?: "Could not create a Hermes conversation."
                     mutableState.value = snapshot.copy(
-                        errorMessage = error.message ?: "Could not create a Hermes conversation.",
+                        sessions = snapshot.sessionCatalog.rows,
+                        sessionCatalog = SessionCatalogReducer.actionFailed(snapshot.sessionCatalog, message),
+                        loadingMessage = null,
+                        errorMessage = message,
                     )
                 }
             } finally {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
@@ -33,12 +33,14 @@ internal data class SessionKey(
 
 internal data class SessionScope(
     val originKey: String,
-    val profile: String,
+    val profile: String? = null,
 ) {
     init {
         require(originKey.isNotBlank()) { "A catalog scope needs an origin." }
-        require(profile.isNotBlank()) { "A catalog scope needs a profile." }
     }
+
+    val isProfileScoped: Boolean
+        get() = !profile.isNullOrBlank()
 
     companion object {
         fun from(origin: String, profile: String): SessionScope? {
@@ -47,10 +49,16 @@ internal data class SessionScope(
             if (normalizedOrigin.isBlank() || normalizedProfile.isBlank()) return null
             return SessionScope(normalizedOrigin, normalizedProfile)
         }
+
+        fun unscoped(origin: String): SessionScope? {
+            val normalizedOrigin = normalizeOrigin(origin)
+            if (normalizedOrigin.isBlank()) return null
+            return SessionScope(normalizedOrigin)
+        }
     }
 
     fun accepts(key: SessionKey): Boolean =
-        key.originKey == originKey && key.profile == profile
+        key.originKey == originKey && (profile == null || key.profile == profile)
 }
 
 /** Captures every generation that must still be current before a list publishes. */
@@ -89,6 +97,7 @@ internal data class SessionCatalogState(
     val request: SessionCatalogRequest? = null,
     val queryResults: List<StoredSession>? = null,
     val queryInFlight: Boolean = false,
+    val openingKey: SessionKey? = null,
 ) {
     val filteredRows: List<StoredSession>
         get() = queryResults ?: searchLoadedSessions(rows, query)
@@ -148,6 +157,7 @@ internal object SessionCatalogReducer {
             request = request,
             queryResults = if (state.query.isBlank()) null else if (keepRows) state.filteredRows else emptyList(),
             queryInFlight = false,
+            openingKey = null,
         )
     }
 
@@ -163,6 +173,7 @@ internal object SessionCatalogReducer {
         request = null,
         queryResults = if (state.query.isBlank()) null else if (keepRows && state.scope == scope) state.filteredRows else emptyList(),
         queryInFlight = false,
+        openingKey = null,
     )
 
     fun succeeded(
@@ -179,6 +190,7 @@ internal object SessionCatalogReducer {
             request = null,
             queryResults = if (state.query.isBlank()) null else searchLoadedSessions(filtered, state.query),
             queryInFlight = false,
+            openingKey = null,
         )
     }
 
@@ -193,14 +205,51 @@ internal object SessionCatalogReducer {
             errorMessage = message,
             request = null,
             queryInFlight = false,
+            openingKey = null,
         )
     }
+
+    fun opening(state: SessionCatalogState, key: SessionKey): SessionCatalogState = state.copy(
+        phase = SessionCatalogStatus.Opening,
+        errorMessage = null,
+        request = null,
+        queryInFlight = false,
+        openingKey = key,
+    )
+
+    fun openingSucceeded(state: SessionCatalogState): SessionCatalogState = state.copy(
+        phase = if (state.rows.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
+        errorMessage = null,
+        request = null,
+        queryInFlight = false,
+        openingKey = null,
+    )
+
+    fun openingFailed(
+        state: SessionCatalogState,
+        message: String,
+    ): SessionCatalogState = state.copy(
+        phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
+        errorMessage = message,
+        request = null,
+        queryInFlight = false,
+        openingKey = null,
+    )
+
+    fun openingCancelled(state: SessionCatalogState): SessionCatalogState = state.copy(
+        phase = if (state.rows.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
+        errorMessage = null,
+        request = null,
+        queryInFlight = false,
+        openingKey = null,
+    )
 
     fun actionStarted(state: SessionCatalogState): SessionCatalogState = state.copy(
         phase = SessionCatalogStatus.ActionInFlight,
         errorMessage = null,
         request = null,
         queryInFlight = false,
+        openingKey = null,
     )
 
     fun actionFailed(
@@ -211,21 +260,32 @@ internal object SessionCatalogReducer {
         errorMessage = message,
         request = null,
         queryInFlight = false,
+        openingKey = null,
     )
 
     /**
-     * Phase 1 has no verified profile filter on session.list. Keep every row
-     * with a verified profile in the server response order; omit ambiguous
-     * rows instead of assigning them to the selected creation profile.
+     * Hermes session.list is origin-scoped but currently does not identify the
+     * owning profile. Keep every durable row in server order for an unscoped
+     * response, including rows with unknown ownership. A genuinely
+     * profile-scoped response may publish only rows with matching verified
+     * ownership. Unknown rows are never reassigned to the creation target.
      */
     internal fun filterAuthoritativeRows(
         scope: SessionScope,
         rows: List<StoredSession>,
     ): List<StoredSession> {
-        val seen = linkedSetOf<SessionKey>()
+        val origin = normalizeOrigin(scope.originKey)
+        if (origin.isBlank()) return emptyList()
+        val seen = linkedSetOf<String>()
         return rows.filter { row ->
-            val key = row.keyFor(scope.originKey) ?: return@filter false
-            seen.add(key)
+            val rowId = row.id.trim()
+            if (rowId.isBlank()) return@filter false
+            if (scope.isProfileScoped) {
+                val key = row.keyFor(origin) ?: return@filter false
+                if (!scope.accepts(key)) return@filter false
+            }
+            val profileIdentity = normalizeProfile(row.profile).ifBlank { UNKNOWN_PROFILE }
+            seen.add("$origin\u0000$profileIdentity\u0000$rowId")
         }
     }
 }
@@ -265,6 +325,16 @@ internal class SessionAliasIndex {
 
 internal fun StoredSession.keyFor(origin: String): SessionKey? =
     SessionKey.from(origin, profile, id)
+
+internal fun StoredSession.catalogRowKey(origin: String): String? {
+    val normalizedOrigin = normalizeOrigin(origin)
+    val normalizedId = id.trim()
+    if (normalizedOrigin.isBlank() || normalizedId.isBlank()) return null
+    val profileIdentity = normalizeProfile(profile).ifBlank { UNKNOWN_PROFILE }
+    return "$normalizedOrigin\u0000$profileIdentity\u0000$normalizedId"
+}
+
+private const val UNKNOWN_PROFILE = "<unknown-profile>"
 
 internal fun normalizeProfile(value: String): String =
     value.trim().lowercase(Locale.ROOT)

--- a/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
@@ -41,20 +41,16 @@ internal data class SessionScope(
     }
 
     companion object {
-        const val ALL_PROFILES = "*"
-
         fun from(origin: String, profile: String): SessionScope? {
             val normalizedOrigin = normalizeOrigin(origin)
             val normalizedProfile = normalizeProfile(profile)
             if (normalizedOrigin.isBlank() || normalizedProfile.isBlank()) return null
             return SessionScope(normalizedOrigin, normalizedProfile)
         }
-
-        fun allProfiles(origin: String): SessionScope? = from(origin, ALL_PROFILES)
     }
 
     fun accepts(key: SessionKey): Boolean =
-        key.originKey == originKey && (profile == ALL_PROFILES || key.profile == profile)
+        key.originKey == originKey && key.profile == profile
 }
 
 /** Captures every generation that must still be current before a list publishes. */
@@ -91,27 +87,44 @@ internal data class SessionCatalogState(
     val errorMessage: String? = null,
     val query: String = "",
     val request: SessionCatalogRequest? = null,
+    val queryResults: List<StoredSession>? = null,
+    val queryInFlight: Boolean = false,
 ) {
     val filteredRows: List<StoredSession>
-        get() = searchLoadedSessions(rows, query)
+        get() = queryResults ?: searchLoadedSessions(rows, query)
 
     /** No-results is a presentation state over a still-authoritative window. */
     val status: SessionCatalogStatus
         get() = if (
             query.isNotBlank() &&
+            !queryInFlight &&
             filteredRows.isEmpty() &&
-            phase in setOf(
-                SessionCatalogStatus.Ready,
-                SessionCatalogStatus.Refreshing,
-                SessionCatalogStatus.Stale,
-            )
+            phase == SessionCatalogStatus.Ready
         ) {
             SessionCatalogStatus.NoResults
         } else {
             phase
         }
 
-    fun withQuery(value: String): SessionCatalogState = copy(query = value)
+    fun withQuery(value: String): SessionCatalogState = if (query == value) {
+        this
+    } else {
+        copy(
+            query = value,
+            queryResults = if (value.isBlank()) null else emptyList(),
+            queryInFlight = value.isNotBlank(),
+        )
+    }
+
+    fun withSearchResults(value: String, results: List<StoredSession>): SessionCatalogState =
+        if (query != value) {
+            this
+        } else {
+            copy(
+                queryResults = results,
+                queryInFlight = false,
+            )
+        }
 }
 
 /**
@@ -126,12 +139,15 @@ internal object SessionCatalogReducer {
         refreshing: Boolean,
     ): SessionCatalogState {
         val keepRows = refreshing && state.scope == request.scope
+        val nextRows = if (keepRows) state.rows else emptyList()
         return state.copy(
             phase = if (refreshing) SessionCatalogStatus.Refreshing else SessionCatalogStatus.Loading,
             scope = request.scope,
-            rows = if (keepRows) state.rows else emptyList(),
+            rows = nextRows,
             errorMessage = null,
             request = request,
+            queryResults = if (state.query.isBlank()) null else if (keepRows) state.filteredRows else emptyList(),
+            queryInFlight = false,
         )
     }
 
@@ -145,6 +161,8 @@ internal object SessionCatalogReducer {
         rows = if (keepRows && state.scope == scope) state.rows else emptyList(),
         errorMessage = null,
         request = null,
+        queryResults = if (state.query.isBlank()) null else if (keepRows && state.scope == scope) state.filteredRows else emptyList(),
+        queryInFlight = false,
     )
 
     fun succeeded(
@@ -159,6 +177,8 @@ internal object SessionCatalogReducer {
             rows = filtered,
             errorMessage = null,
             request = null,
+            queryResults = if (state.query.isBlank()) null else searchLoadedSessions(filtered, state.query),
+            queryInFlight = false,
         )
     }
 
@@ -172,6 +192,7 @@ internal object SessionCatalogReducer {
             phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
             errorMessage = message,
             request = null,
+            queryInFlight = false,
         )
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
@@ -196,6 +196,28 @@ internal object SessionCatalogReducer {
         )
     }
 
+    fun actionStarted(state: SessionCatalogState): SessionCatalogState = state.copy(
+        phase = SessionCatalogStatus.ActionInFlight,
+        errorMessage = null,
+        request = null,
+        queryInFlight = false,
+    )
+
+    fun actionFailed(
+        state: SessionCatalogState,
+        message: String,
+    ): SessionCatalogState = state.copy(
+        phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
+        errorMessage = message,
+        request = null,
+        queryInFlight = false,
+    )
+
+    /**
+     * Phase 1 has no verified profile filter on session.list. Keep every row
+     * with a verified profile in the server response order; omit ambiguous
+     * rows instead of assigning them to the selected creation profile.
+     */
     internal fun filterAuthoritativeRows(
         scope: SessionScope,
         rows: List<StoredSession>,
@@ -203,7 +225,7 @@ internal object SessionCatalogReducer {
         val seen = linkedSetOf<SessionKey>()
         return rows.filter { row ->
             val key = row.keyFor(scope.originKey) ?: return@filter false
-            scope.accepts(key) && seen.add(key)
+            seen.add(key)
         }
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
@@ -91,7 +91,7 @@ internal data class SessionCatalogState(
     val phase: SessionCatalogStatus = SessionCatalogStatus.NotReady,
     val scope: SessionScope? = null,
     val rows: List<StoredSession> = emptyList(),
-    val errorMessage: String? = null,
+    val notice: UiNotice? = null,
     val query: String = "",
     val request: SessionCatalogRequest? = null,
     val queryResults: List<StoredSession>? = null,
@@ -152,7 +152,7 @@ internal object SessionCatalogReducer {
             phase = if (refreshing) SessionCatalogStatus.Refreshing else SessionCatalogStatus.Loading,
             scope = request.scope,
             rows = nextRows,
-            errorMessage = null,
+            notice = null,
             request = request,
             queryResults = if (state.query.isBlank()) null else if (keepRows) state.filteredRows else emptyList(),
             queryInFlight = false,
@@ -168,7 +168,7 @@ internal object SessionCatalogReducer {
         phase = SessionCatalogStatus.Reconnecting,
         scope = scope,
         rows = if (keepRows && state.scope == scope) state.rows else emptyList(),
-        errorMessage = null,
+        notice = null,
         request = null,
         queryResults = if (state.query.isBlank()) null else if (keepRows && state.scope == scope) state.filteredRows else emptyList(),
         queryInFlight = false,
@@ -185,7 +185,7 @@ internal object SessionCatalogReducer {
         return state.copy(
             phase = if (filtered.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
             rows = filtered,
-            errorMessage = null,
+            notice = null,
             request = null,
             queryResults = if (state.query.isBlank()) null else searchLoadedSessions(filtered, state.query),
             queryInFlight = false,
@@ -196,12 +196,12 @@ internal object SessionCatalogReducer {
     fun failed(
         state: SessionCatalogState,
         request: SessionCatalogRequest,
-        message: String,
+        notice: UiNotice,
     ): SessionCatalogState {
         if (state.request != request || state.scope != request.scope) return state
         return state.copy(
             phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
-            errorMessage = message,
+            notice = notice,
             request = null,
             queryInFlight = false,
             openingKey = null,
@@ -210,7 +210,7 @@ internal object SessionCatalogReducer {
 
     fun opening(state: SessionCatalogState, key: SessionKey): SessionCatalogState = state.copy(
         phase = SessionCatalogStatus.Opening,
-        errorMessage = null,
+        notice = null,
         request = null,
         queryInFlight = false,
         openingKey = key,
@@ -218,7 +218,7 @@ internal object SessionCatalogReducer {
 
     fun openingSucceeded(state: SessionCatalogState): SessionCatalogState = state.copy(
         phase = if (state.rows.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
-        errorMessage = null,
+        notice = null,
         request = null,
         queryInFlight = false,
         openingKey = null,
@@ -226,10 +226,10 @@ internal object SessionCatalogReducer {
 
     fun openingFailed(
         state: SessionCatalogState,
-        message: String,
+        notice: UiNotice,
     ): SessionCatalogState = state.copy(
         phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
-        errorMessage = message,
+        notice = notice,
         request = null,
         queryInFlight = false,
         openingKey = null,
@@ -237,7 +237,7 @@ internal object SessionCatalogReducer {
 
     fun openingCancelled(state: SessionCatalogState): SessionCatalogState = state.copy(
         phase = if (state.rows.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
-        errorMessage = null,
+        notice = null,
         request = null,
         queryInFlight = false,
         openingKey = null,
@@ -245,7 +245,7 @@ internal object SessionCatalogReducer {
 
     fun actionStarted(state: SessionCatalogState): SessionCatalogState = state.copy(
         phase = SessionCatalogStatus.ActionInFlight,
-        errorMessage = null,
+        notice = null,
         request = null,
         queryInFlight = false,
         openingKey = null,
@@ -253,10 +253,18 @@ internal object SessionCatalogReducer {
 
     fun actionFailed(
         state: SessionCatalogState,
-        message: String,
+        notice: UiNotice,
     ): SessionCatalogState = state.copy(
         phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
-        errorMessage = message,
+        notice = notice,
+        request = null,
+        queryInFlight = false,
+        openingKey = null,
+    )
+
+    fun actionCancelled(state: SessionCatalogState): SessionCatalogState = state.copy(
+        phase = if (state.rows.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
+        notice = null,
         request = null,
         queryInFlight = false,
         openingKey = null,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
@@ -65,7 +65,6 @@ internal data class SessionScope(
 internal data class SessionCatalogRequest(
     val scope: SessionScope,
     val originGeneration: Long,
-    val profileGeneration: Long,
     val requestGeneration: Long,
     val connectionAttempt: Long,
 )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/SessionCatalog.kt
@@ -1,0 +1,242 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.network.StoredSession
+import java.util.Locale
+
+/**
+ * The identity used by the conversation catalog. A runtime gateway id is
+ * deliberately absent: it is only valid for one live attachment.
+ */
+internal data class SessionKey(
+    val originKey: String,
+    val profile: String,
+    val durableId: String,
+) {
+    init {
+        require(originKey.isNotBlank()) { "A session key needs an origin." }
+        require(profile.isNotBlank()) { "A session key needs a profile." }
+        require(durableId.isNotBlank()) { "A session key needs a durable session id." }
+    }
+
+    companion object {
+        fun from(origin: String, profile: String, durableId: String): SessionKey? {
+            val normalizedOrigin = normalizeOrigin(origin)
+            val normalizedProfile = normalizeProfile(profile)
+            val normalizedId = durableId.trim()
+            if (normalizedOrigin.isBlank() || normalizedProfile.isBlank() || normalizedId.isBlank()) {
+                return null
+            }
+            return SessionKey(normalizedOrigin, normalizedProfile, normalizedId)
+        }
+    }
+}
+
+internal data class SessionScope(
+    val originKey: String,
+    val profile: String,
+) {
+    init {
+        require(originKey.isNotBlank()) { "A catalog scope needs an origin." }
+        require(profile.isNotBlank()) { "A catalog scope needs a profile." }
+    }
+
+    companion object {
+        const val ALL_PROFILES = "*"
+
+        fun from(origin: String, profile: String): SessionScope? {
+            val normalizedOrigin = normalizeOrigin(origin)
+            val normalizedProfile = normalizeProfile(profile)
+            if (normalizedOrigin.isBlank() || normalizedProfile.isBlank()) return null
+            return SessionScope(normalizedOrigin, normalizedProfile)
+        }
+
+        fun allProfiles(origin: String): SessionScope? = from(origin, ALL_PROFILES)
+    }
+
+    fun accepts(key: SessionKey): Boolean =
+        key.originKey == originKey && (profile == ALL_PROFILES || key.profile == profile)
+}
+
+/** Captures every generation that must still be current before a list publishes. */
+internal data class SessionCatalogRequest(
+    val scope: SessionScope,
+    val originGeneration: Long,
+    val profileGeneration: Long,
+    val requestGeneration: Long,
+    val connectionAttempt: Long,
+)
+
+internal enum class SessionCatalogStatus {
+    NotReady,
+    Loading,
+    Ready,
+    Refreshing,
+    Empty,
+    NoResults,
+    Stale,
+    Error,
+    Reconnecting,
+    Opening,
+    ActionInFlight,
+}
+
+/**
+ * In-memory authoritative projection state. It is intentionally not
+ * serializable or persisted; Hermes remains the catalog and transcript owner.
+ */
+internal data class SessionCatalogState(
+    val phase: SessionCatalogStatus = SessionCatalogStatus.NotReady,
+    val scope: SessionScope? = null,
+    val rows: List<StoredSession> = emptyList(),
+    val errorMessage: String? = null,
+    val query: String = "",
+    val request: SessionCatalogRequest? = null,
+) {
+    val filteredRows: List<StoredSession>
+        get() = searchLoadedSessions(rows, query)
+
+    /** No-results is a presentation state over a still-authoritative window. */
+    val status: SessionCatalogStatus
+        get() = if (
+            query.isNotBlank() &&
+            filteredRows.isEmpty() &&
+            phase in setOf(
+                SessionCatalogStatus.Ready,
+                SessionCatalogStatus.Refreshing,
+                SessionCatalogStatus.Stale,
+            )
+        ) {
+            SessionCatalogStatus.NoResults
+        } else {
+            phase
+        }
+
+    fun withQuery(value: String): SessionCatalogState = copy(query = value)
+}
+
+/**
+ * Pure reducer for catalog transitions. ViewModel/network code supplies the
+ * generation token; stale responses are rejected here as well as at the call
+ * site so a future mutation or alternative caller cannot publish across scope.
+ */
+internal object SessionCatalogReducer {
+    fun begin(
+        state: SessionCatalogState,
+        request: SessionCatalogRequest,
+        refreshing: Boolean,
+    ): SessionCatalogState {
+        val keepRows = refreshing && state.scope == request.scope
+        return state.copy(
+            phase = if (refreshing) SessionCatalogStatus.Refreshing else SessionCatalogStatus.Loading,
+            scope = request.scope,
+            rows = if (keepRows) state.rows else emptyList(),
+            errorMessage = null,
+            request = request,
+        )
+    }
+
+    fun reconnecting(
+        state: SessionCatalogState,
+        scope: SessionScope,
+        keepRows: Boolean,
+    ): SessionCatalogState = state.copy(
+        phase = SessionCatalogStatus.Reconnecting,
+        scope = scope,
+        rows = if (keepRows && state.scope == scope) state.rows else emptyList(),
+        errorMessage = null,
+        request = null,
+    )
+
+    fun succeeded(
+        state: SessionCatalogState,
+        request: SessionCatalogRequest,
+        rows: List<StoredSession>,
+    ): SessionCatalogState {
+        if (state.request != request || state.scope != request.scope) return state
+        val filtered = filterAuthoritativeRows(request.scope, rows)
+        return state.copy(
+            phase = if (filtered.isEmpty()) SessionCatalogStatus.Empty else SessionCatalogStatus.Ready,
+            rows = filtered,
+            errorMessage = null,
+            request = null,
+        )
+    }
+
+    fun failed(
+        state: SessionCatalogState,
+        request: SessionCatalogRequest,
+        message: String,
+    ): SessionCatalogState {
+        if (state.request != request || state.scope != request.scope) return state
+        return state.copy(
+            phase = if (state.rows.isEmpty()) SessionCatalogStatus.Error else SessionCatalogStatus.Stale,
+            errorMessage = message,
+            request = null,
+        )
+    }
+
+    internal fun filterAuthoritativeRows(
+        scope: SessionScope,
+        rows: List<StoredSession>,
+    ): List<StoredSession> {
+        val seen = linkedSetOf<SessionKey>()
+        return rows.filter { row ->
+            val key = row.keyFor(scope.originKey) ?: return@filter false
+            scope.accepts(key) && seen.add(key)
+        }
+    }
+}
+
+/** Only server-supplied alternate identities may be registered here. */
+internal data class VerifiedSessionIdentity(
+    val key: SessionKey,
+    val aliases: Set<String> = emptySet(),
+)
+
+internal class SessionAliasIndex {
+    private val aliasesByKey = linkedMapOf<SessionKey, Set<String>>()
+
+    fun replace(scope: SessionScope, identities: Iterable<VerifiedSessionIdentity>) {
+        aliasesByKey.keys.removeAll { key -> scope.accepts(key) }
+        identities.forEach { identity ->
+            if (scope.accepts(identity.key)) {
+                aliasesByKey[identity.key] = identity.aliases
+                    .map(String::trim)
+                    .filter(String::isNotBlank)
+                    .toSet()
+            }
+        }
+    }
+
+    fun resolve(scope: SessionScope, value: String): SessionKey? {
+        val candidate = value.trim()
+        if (candidate.isBlank()) return null
+        return aliasesByKey.entries.firstOrNull { (key, aliases) ->
+            scope.accepts(key) &&
+                (key.durableId == candidate || candidate in aliases)
+        }?.key
+    }
+
+    fun clear() = aliasesByKey.clear()
+}
+
+internal fun StoredSession.keyFor(origin: String): SessionKey? =
+    SessionKey.from(origin, profile, id)
+
+internal fun normalizeProfile(value: String): String =
+    value.trim().lowercase(Locale.ROOT)
+
+internal fun normalizeOrigin(value: String): String =
+    value.trim().trimEnd('/').lowercase(Locale.ROOT)
+
+internal fun searchLoadedSessions(
+    rows: List<StoredSession>,
+    query: String,
+): List<StoredSession> {
+    val needle = query.trim().lowercase(Locale.ROOT)
+    if (needle.isBlank()) return rows
+    return rows.filter { row ->
+        sequenceOf(row.title, row.preview, row.id, row.profile, row.source)
+            .any { it.lowercase(Locale.ROOT).contains(needle) }
+    }
+}

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -638,6 +638,11 @@ class DashboardClient(
     private fun decodeSession(element: JsonElement): StoredSession? {
         val row = element as? JsonObject ?: return null
         val id = row["id"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank) ?: return null
+        val profile = sequenceOf("profile", "profile_name")
+            .mapNotNull { key ->
+                (row[key] as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
+            }
+            .firstOrNull()
         return StoredSession(
             id = id,
             title = row["title"]?.jsonPrimitive?.contentOrNull.orEmpty(),
@@ -645,9 +650,7 @@ class DashboardClient(
             startedAt = row["started_at"]?.jsonPrimitive?.doubleOrNull ?: 0.0,
             messageCount = row["message_count"]?.jsonPrimitive?.intOrNull ?: 0,
             source = row["source"]?.jsonPrimitive?.contentOrNull.orEmpty(),
-            profile = row["profile"]?.jsonPrimitive?.contentOrNull
-                ?: row["profile_name"]?.jsonPrimitive?.contentOrNull
-                ?: "default",
+            profile = profile.orEmpty(),
         )
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -68,6 +68,19 @@ data class StoredSession(
     val profile: String = "",
 )
 
+/**
+ * Profile-aware catalog response. The WebSocket `session.list` projection does
+ * not include ownership, while `session.resume` requires it. Current Hermes
+ * dashboards expose the authoritative REST projection under
+ * `/api/profiles/sessions`; callers must keep the ownership flag separate from
+ * the rows so an older dashboard fallback cannot be mistaken for verified
+ * profile data.
+ */
+data class ProfileSessionList(
+    val sessions: List<StoredSession>,
+    val profileOwnershipVerified: Boolean,
+)
+
 data class DashboardProfile(
     val name: String,
     val isDefault: Boolean = false,
@@ -127,6 +140,19 @@ interface DashboardService {
         credential: GatewayCredential,
         limit: Int = 200,
     ): List<StoredSession>
+
+    suspend fun listProfileSessions(
+        baseUrl: String,
+        credential: GatewayCredential,
+        profile: String = "all",
+        limit: Int = 200,
+    ): ProfileSessionList = ProfileSessionList(
+        // The legacy WebSocket projection is origin-scoped and does not prove
+        // profile ownership. Keep its rows visible, but never make them
+        // resumable by manufacturing a profile from the creation target.
+        sessions = listSessions(baseUrl, credential, limit).map { it.copy(profile = "") },
+        profileOwnershipVerified = false,
+    )
 
     suspend fun listProfiles(
         baseUrl: String,
@@ -337,6 +363,62 @@ class DashboardClient(
         val authParameter = resolveWebSocketCredential(baseUrl, credential)
         val wsUrl = buildWebSocketUrl(baseUrl, authParameter?.first, authParameter?.second)
         return withTimeout(15_000) { requestSessionList(wsUrl, limit.coerceIn(1, 500)) }
+    }
+
+    override suspend fun listProfileSessions(
+        baseUrl: String,
+        credential: GatewayCredential,
+        profile: String,
+        limit: Int,
+    ): ProfileSessionList = withContext(Dispatchers.IO) {
+        val requestedProfile = profile.trim().ifBlank { "all" }
+        val url = "$baseUrl/api/profiles/sessions".toHttpUrl().newBuilder()
+            .addQueryParameter("limit", limit.coerceIn(1, 500).toString())
+            .addQueryParameter("offset", "0")
+            .addQueryParameter("min_messages", "0")
+            .addQueryParameter("archived", "exclude")
+            .addQueryParameter("order", "recent")
+            .addQueryParameter("profile", requestedProfile)
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json")
+            .apply {
+                if (credential is GatewayCredential.StaticToken) {
+                    header("X-Hermes-Session-Token", credential.value.trim())
+                }
+            }
+            .get()
+            .build()
+        val root = try {
+            executeJson(request, "Hermes profile session list")
+        } catch (error: TransportUnavailable) {
+            // Older dashboards do not expose the profile-aware REST route. Keep
+            // their rows visible, but explicitly mark ownership as unknown so
+            // the browser cannot manufacture a profile for session.resume.
+            if (error.statusCode == 404) {
+                return@withContext ProfileSessionList(
+                    sessions = listSessions(baseUrl, credential, limit)
+                        .map { it.copy(profile = "") },
+                    profileOwnershipVerified = false,
+                )
+            }
+            throw error
+        } as? JsonObject ?: throw InvalidDashboardResponse(
+            "Hermes returned no profile session list.",
+        )
+        // Hermes may return a partial page together with per-profile read
+        // failures. The successful rows remain authoritative and retain their
+        // stamped ownership; a future UI can surface the partial status without
+        // dropping every readable conversation.
+        val rows = root["sessions"] as? JsonArray
+            ?: throw InvalidDashboardResponse("Hermes returned no profile session list.")
+        val sessions = rows.mapNotNull(::decodeSession)
+        ProfileSessionList(
+            sessions = sessions,
+            profileOwnershipVerified = sessions.size == rows.size &&
+                sessions.all { it.profile.isNotBlank() },
+        )
     }
 
     override suspend fun listProfiles(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -64,7 +64,8 @@ data class StoredSession(
     val startedAt: Double,
     val messageCount: Int,
     val source: String,
-    val profile: String = "default",
+    /** Blank means Hermes did not provide authoritative profile ownership. */
+    val profile: String = "",
 )
 
 data class DashboardProfile(
@@ -424,11 +425,16 @@ class DashboardClient(
         baseUrl: String,
         credential: GatewayCredential,
         storedSessionId: String,
+        profile: String,
     ): ResumedSession {
         require(storedSessionId.isNotBlank()) { "Choose a Hermes session to open." }
+        val owningProfile = profile.trim()
+        require(owningProfile.isNotBlank()) { "Hermes did not identify the conversation profile." }
         val authParameter = resolveWebSocketCredential(baseUrl, credential)
         val wsUrl = buildWebSocketUrl(baseUrl, authParameter?.first, authParameter?.second)
-        return withTimeout(20_000) { requestSessionResume(wsUrl, storedSessionId) }
+        return withTimeout(20_000) {
+            requestSessionResume(wsUrl, storedSessionId, owningProfile)
+        }
     }
 
     private suspend fun resolveWebSocketCredential(
@@ -517,6 +523,7 @@ class DashboardClient(
     private suspend fun requestSessionResume(
         wsUrl: String,
         storedSessionId: String,
+        profile: String,
     ): ResumedSession {
         val frame = buildJsonObject {
             put("jsonrpc", "2.0")
@@ -528,6 +535,7 @@ class DashboardClient(
                     put("session_id", storedSessionId)
                     put("cols", 80)
                     put("source", "android")
+                    put("profile", profile)
                 },
             )
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -638,11 +638,11 @@ class DashboardClient(
     private fun decodeSession(element: JsonElement): StoredSession? {
         val row = element as? JsonObject ?: return null
         val id = row["id"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank) ?: return null
-        val profile = sequenceOf("profile", "profile_name")
-            .mapNotNull { key ->
-                (row[key] as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
-            }
-            .firstOrNull()
+        val profile = sessionProfile(row["profile"])
+        val profileName = sessionProfile(row["profile_name"])
+        if (profile != null && profileName != null && !profile.equals(profileName, ignoreCase = true)) {
+            return null
+        }
         return StoredSession(
             id = id,
             title = row["title"]?.jsonPrimitive?.contentOrNull.orEmpty(),
@@ -650,9 +650,12 @@ class DashboardClient(
             startedAt = row["started_at"]?.jsonPrimitive?.doubleOrNull ?: 0.0,
             messageCount = row["message_count"]?.jsonPrimitive?.intOrNull ?: 0,
             source = row["source"]?.jsonPrimitive?.contentOrNull.orEmpty(),
-            profile = profile.orEmpty(),
+            profile = (profile ?: profileName).orEmpty(),
         )
     }
+
+    private fun sessionProfile(element: JsonElement?): String? =
+        (element as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf(String::isNotBlank)
 
     private fun decodeProfile(element: JsonElement): DashboardProfile {
         if (element is JsonPrimitive && element.isString) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -47,14 +47,20 @@ suspend fun GatewayConnection.createSession(profile: String): CreatedSession {
     )
 }
 
-suspend fun GatewayConnection.resumeStoredSession(storedSessionId: String): ResumedSession {
+suspend fun GatewayConnection.resumeStoredSession(
+    storedSessionId: String,
+    profile: String,
+): ResumedSession {
     require(storedSessionId.isNotBlank()) { "Choose a Hermes session to open." }
+    val owningProfile = profile.trim()
+    require(owningProfile.isNotBlank()) { "Hermes did not identify the conversation profile." }
     val result = request(
         method = "session.resume",
         params = buildJsonObject {
             put("session_id", storedSessionId)
             put("cols", 96)
             put("source", "android")
+            put("profile", owningProfile)
         },
         timeoutMillis = 30_000,
     ).asObject("Hermes returned no resumed session.")

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -34,12 +34,13 @@ suspend fun GatewayConnection.createSession(profile: String): CreatedSession {
     val runtimeId = result.string("session_id")
         ?.takeIf(String::isNotBlank)
         ?: throw IOException("Hermes created a conversation without a runtime identity.")
+    val storedId = result.string("stored_session_id")
+        ?.takeIf(String::isNotBlank)
+        ?: throw IOException("Hermes created a conversation without a durable stored identity.")
     val info = result["info"] as? JsonObject
     return CreatedSession(
         runtimeSessionId = runtimeId,
-        storedSessionId = result.string("stored_session_id")
-            ?.takeIf(String::isNotBlank)
-            ?: runtimeId,
+        storedSessionId = storedId,
         profile = result.string("profile")
             ?: result.string("profile_id")
             ?: info?.string("profile_name"),

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -55,6 +56,16 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
     val sessions = ui.sessions
     var destination by rememberSaveable { mutableStateOf(CelesteDestination.Content) }
     var settingsReturnDestination by rememberSaveable { mutableStateOf(CelesteDestination.Content) }
+    var observedConversationNavigationToken by rememberSaveable {
+        mutableStateOf(ui.conversationNavigationToken)
+    }
+
+    LaunchedEffect(ui.conversationNavigationToken) {
+        if (ui.conversationNavigationToken != observedConversationNavigationToken) {
+            observedConversationNavigationToken = ui.conversationNavigationToken
+            destination = CelesteDestination.Content
+        }
+    }
 
     fun openSettings(from: CelesteDestination) {
         settingsReturnDestination = from
@@ -128,13 +139,13 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     onQueryChange = viewModel::updateSessionQuery,
                     onRefresh = viewModel::refreshSessionCatalog,
                     onRetry = viewModel::refreshSessionCatalog,
+                    onCancelOpening = viewModel::cancelOpening,
                     onProfileSelected = viewModel::selectProfile,
                     onNewConversation = {
                         destination = CelesteDestination.Content
                         viewModel.createNewConversation()
                     },
                     onSessionSelected = { session ->
-                        destination = CelesteDestination.Content
                         viewModel.openSession(session)
                     },
                     onSettings = { openSettings(CelesteDestination.Conversations) },
@@ -176,6 +187,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 onQueryChange = viewModel::updateSessionQuery,
                 onRefresh = viewModel::refreshSessionCatalog,
                 onRetry = viewModel::refreshSessionCatalog,
+                onCancelOpening = viewModel::cancelOpening,
                 onProfileSelected = viewModel::selectProfile,
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -119,7 +119,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     -> ConnectionLoadingScreen()
 
                     ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(
-                        errorMessage = ui.errorMessage,
+                        notice = ui.notice,
                         onRetry = viewModel::retrySavedConnection,
                         onSettings = { destination = CelesteDestination.Gateway },
                     )
@@ -133,7 +133,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     profiles = ui.profiles,
                     selectedProfile = ui.selectedProfile,
                     loadingMessage = ui.loadingMessage,
-                    errorMessage = ui.errorMessage,
+                    notice = ui.notice,
                     catalogState = ui.sessionCatalog,
                     query = ui.sessionQuery,
                     onQueryChange = viewModel::updateSessionQuery,
@@ -166,7 +166,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     draft = ui.draft,
                     turnState = ui.turnState,
                     loadingMessage = ui.loadingMessage,
-                    errorMessage = ui.errorMessage,
+                    notice = ui.notice,
                     onDraftChange = viewModel::updateDraft,
                     onSend = viewModel::sendMessage,
                     onInterrupt = viewModel::interrupt,
@@ -181,7 +181,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 profiles = ui.profiles,
                 selectedProfile = ui.selectedProfile,
                 loadingMessage = ui.loadingMessage,
-                errorMessage = ui.errorMessage,
+                notice = ui.notice,
                 catalogState = ui.sessionCatalog,
                 query = ui.sessionQuery,
                 onQueryChange = viewModel::updateSessionQuery,
@@ -201,7 +201,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 ui.connectionPhase == ConnectionPhase.Restoring -> ConnectionLoadingScreen()
 
             ui.connectionPhase == ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(
-                errorMessage = ui.errorMessage,
+                notice = ui.notice,
                 onRetry = viewModel::retrySavedConnection,
                 onSettings = { destination = CelesteDestination.Gateway },
             )
@@ -234,7 +234,7 @@ private fun GatewaySettingsRoute(
             sessionToken = ui.sessionToken,
             connectionPhase = ui.connectionPhase,
             loadingMessage = ui.loadingMessage,
-            errorMessage = ui.errorMessage,
+            notice = ui.notice,
         ),
         actions = GatewaySettingsActions(
             onUsernameChange = viewModel::updateUsername,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -50,14 +50,32 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
     val activeSummary = ui.activeSummary
     val sessions = ui.sessions
     var destination by rememberSaveable { mutableStateOf(CelesteDestination.Content) }
+    var settingsReturnDestination by rememberSaveable { mutableStateOf(CelesteDestination.Content) }
+
+    fun openSettings(from: CelesteDestination) {
+        settingsReturnDestination = from
+        destination = CelesteDestination.Settings
+    }
+
+    fun openBrowser() {
+        if (sessions != null) {
+            destination = CelesteDestination.Conversations
+            viewModel.openConversationBrowser()
+        }
+    }
+
+    fun closeBrowser() {
+        viewModel.closeConversationBrowser()
+        destination = CelesteDestination.Content
+    }
 
     when (destination) {
         CelesteDestination.Settings -> {
-            BackHandler { destination = CelesteDestination.Content }
+            BackHandler { destination = settingsReturnDestination }
             SettingsScreen(
                 dashboardUrl = ui.dashboardUrl,
                 connectionPhase = ui.connectionPhase,
-                onBack = { destination = CelesteDestination.Content },
+                onBack = { destination = settingsReturnDestination },
                 onGateway = { destination = CelesteDestination.Gateway },
             )
         }
@@ -76,6 +94,50 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
             )
         }
 
+        CelesteDestination.Conversations -> {
+            if (sessions == null) {
+                BackHandler { destination = CelesteDestination.Content }
+                when (ui.connectionPhase) {
+                    ConnectionPhase.CheckingSavedConnection,
+                    ConnectionPhase.Restoring,
+                    -> ConnectionLoadingScreen()
+
+                    ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(
+                        errorMessage = ui.errorMessage,
+                        onRetry = viewModel::retrySavedConnection,
+                        onSettings = { destination = CelesteDestination.Gateway },
+                    )
+
+                    else -> GatewaySettingsRoute(ui = ui, viewModel = viewModel, onBack = null)
+                }
+            } else {
+                BackHandler { closeBrowser() }
+                SessionListScreen(
+                    sessions = sessions,
+                    profiles = ui.profiles,
+                    selectedProfile = ui.selectedProfile,
+                    loadingMessage = ui.loadingMessage,
+                    errorMessage = ui.errorMessage,
+                    catalogState = ui.sessionCatalog,
+                    query = ui.sessionQuery,
+                    onQueryChange = viewModel::updateSessionQuery,
+                    onRefresh = viewModel::refreshSessionCatalog,
+                    onRetry = viewModel::refreshSessionCatalog,
+                    onProfileSelected = viewModel::selectProfile,
+                    onNewConversation = {
+                        destination = CelesteDestination.Content
+                        viewModel.createNewConversation()
+                    },
+                    onSessionSelected = { session ->
+                        destination = CelesteDestination.Content
+                        viewModel.openSession(session)
+                    },
+                    onSettings = { openSettings(CelesteDestination.Conversations) },
+                    onBack = ::closeBrowser,
+                )
+            }
+        }
+
         CelesteDestination.Content -> when {
             activeSummary != null -> {
                 BackHandler(onBack = viewModel::leaveConversation)
@@ -92,6 +154,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     onInterrupt = viewModel::interrupt,
                     onReconnect = viewModel::reconnectNow,
                     onBack = viewModel::leaveConversation,
+                    onOpenBrowser = ::openBrowser,
                 )
             }
 
@@ -101,10 +164,15 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 selectedProfile = ui.selectedProfile,
                 loadingMessage = ui.loadingMessage,
                 errorMessage = ui.errorMessage,
+                catalogState = ui.sessionCatalog,
+                query = ui.sessionQuery,
+                onQueryChange = viewModel::updateSessionQuery,
+                onRefresh = viewModel::refreshSessionCatalog,
+                onRetry = viewModel::refreshSessionCatalog,
                 onProfileSelected = viewModel::selectProfile,
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,
-                onSettings = { destination = CelesteDestination.Settings },
+                onSettings = { openSettings(CelesteDestination.Content) },
             )
 
             ui.connectionPhase == ConnectionPhase.CheckingSavedConnection ||
@@ -123,6 +191,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
 
 private enum class CelesteDestination {
     Content,
+    Conversations,
     Settings,
     Gateway,
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.CelesteUiState
 import dev.hazydreams.hermesceleste.CelesteViewModel
 import dev.hazydreams.hermesceleste.ConnectionPhase
+import dev.hazydreams.hermesceleste.TurnState
 import dev.hazydreams.hermesceleste.ui.conversation.ConversationScreen
 import dev.hazydreams.hermesceleste.ui.gateway.ConnectionLoadingScreen
 import dev.hazydreams.hermesceleste.ui.gateway.ConnectionUnavailableScreen
@@ -99,6 +100,7 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 BackHandler { destination = CelesteDestination.Content }
                 when (ui.connectionPhase) {
                     ConnectionPhase.CheckingSavedConnection,
+                    ConnectionPhase.LoadingSessions,
                     ConnectionPhase.Restoring,
                     -> ConnectionLoadingScreen()
 
@@ -134,6 +136,8 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                     },
                     onSettings = { openSettings(CelesteDestination.Conversations) },
                     onBack = ::closeBrowser,
+                    activeSession = activeSummary,
+                    activeSessionRunning = ui.turnState == TurnState.Running,
                 )
             }
         }
@@ -173,9 +177,12 @@ internal fun CelesteRoutes(ui: CelesteUiState, viewModel: CelesteViewModel) {
                 onNewConversation = viewModel::createNewConversation,
                 onSessionSelected = viewModel::openSession,
                 onSettings = { openSettings(CelesteDestination.Content) },
+                activeSession = activeSummary,
+                activeSessionRunning = ui.turnState == TurnState.Running,
             )
 
             ui.connectionPhase == ConnectionPhase.CheckingSavedConnection ||
+                ui.connectionPhase == ConnectionPhase.LoadingSessions ||
                 ui.connectionPhase == ConnectionPhase.Restoring -> ConnectionLoadingScreen()
 
             ui.connectionPhase == ConnectionPhase.RestoreFailed -> ConnectionUnavailableScreen(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/CelesteRoutes.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -358,7 +361,12 @@ internal fun EditorialDivider(modifier: Modifier = Modifier) {
 }
 
 @Composable
-internal fun StatusMessage(message: String, color: Color, showSpinner: Boolean = false) {
+internal fun StatusMessage(
+    message: String,
+    color: Color,
+    showSpinner: Boolean = false,
+    announce: Boolean = false,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(9.dp),
@@ -377,6 +385,11 @@ internal fun StatusMessage(message: String, color: Color, showSpinner: Boolean =
             color = color,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Medium,
+            modifier = if (announce) {
+                Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+            } else {
+                Modifier
+            },
         )
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.TurnState
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -71,7 +72,7 @@ internal fun ConversationScreen(
     draft: String,
     turnState: TurnState,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
     onDraftChange: (String) -> Unit,
     onSend: () -> Unit,
     onInterrupt: () -> Unit,
@@ -150,13 +151,13 @@ internal fun ConversationScreen(
                 }
             }
 
-            if (loadingMessage != null || errorMessage != null) {
+            if (loadingMessage != null || notice != null) {
                 Column(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    notice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -77,6 +77,7 @@ internal fun ConversationScreen(
     onInterrupt: () -> Unit,
     onReconnect: () -> Unit,
     onBack: () -> Unit,
+    onOpenBrowser: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val focusManager = LocalFocusManager.current
@@ -107,6 +108,12 @@ internal fun ConversationScreen(
                     contentPadding = PaddingValues(horizontal = 6.dp, vertical = 8.dp),
                 ) {
                     Text("←  Back", color = CelesteBlue, fontWeight = FontWeight.SemiBold)
+                }
+                TextButton(
+                    onClick = onOpenBrowser,
+                    contentPadding = PaddingValues(horizontal = 6.dp, vertical = 8.dp),
+                ) {
+                    Text("Conversations", color = CelesteBlue, fontWeight = FontWeight.SemiBold)
                 }
                 Spacer(Modifier.weight(1f))
                 if (turnState == TurnState.Running || turnState == TurnState.Synchronizing) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -494,7 +494,9 @@ private fun StatusDot(phase: ConnectionPhase) {
 
 private fun connectionStatusLabel(phase: ConnectionPhase): String = when (phase) {
     ConnectionPhase.Connected -> "Connected"
-    ConnectionPhase.CheckingSavedConnection, ConnectionPhase.Restoring -> "Connecting"
+    ConnectionPhase.CheckingSavedConnection,
+    ConnectionPhase.LoadingSessions,
+    ConnectionPhase.Restoring -> "Connecting"
     ConnectionPhase.RestoreFailed -> "Unavailable"
     ConnectionPhase.AuthenticationRequired -> "Sign in required"
     ConnectionPhase.ManualSetup -> "Not connected"
@@ -502,7 +504,9 @@ private fun connectionStatusLabel(phase: ConnectionPhase): String = when (phase)
 
 private fun connectionStatusColor(phase: ConnectionPhase): Color = when (phase) {
     ConnectionPhase.Connected -> CelesteCoral
-    ConnectionPhase.CheckingSavedConnection, ConnectionPhase.Restoring -> CelesteGoldText
+    ConnectionPhase.CheckingSavedConnection,
+    ConnectionPhase.LoadingSessions,
+    ConnectionPhase.Restoring -> CelesteGoldText
     ConnectionPhase.RestoreFailed -> CelesteError
     ConnectionPhase.AuthenticationRequired -> CelesteGoldText
     ConnectionPhase.ManualSetup -> CelesteMuted

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.ConnectionPhase
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.connection.SavedAuthMode
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
@@ -83,7 +84,7 @@ internal data class GatewaySettingsUiState(
     val sessionToken: String,
     val connectionPhase: ConnectionPhase,
     val loadingMessage: String?,
-    val errorMessage: String?,
+    val notice: UiNotice?,
 )
 
 internal data class GatewaySettingsActions(
@@ -125,7 +126,7 @@ internal fun ConnectionLoadingScreen() {
 
 @Composable
 internal fun ConnectionUnavailableScreen(
-    errorMessage: String?,
+    notice: UiNotice?,
     onRetry: () -> Unit,
     onSettings: () -> Unit,
 ) {
@@ -147,9 +148,9 @@ internal fun ConnectionUnavailableScreen(
                 color = CelesteMuted,
                 style = MaterialTheme.typography.bodyLarge,
             )
-            errorMessage?.let {
+            notice?.let {
                 Spacer(Modifier.height(26.dp))
-                StatusMessage(it, CelesteError)
+                StatusMessage(it.message, CelesteError)
             }
             Spacer(Modifier.height(34.dp))
             CelestePrimaryButton(
@@ -233,7 +234,7 @@ internal fun GatewaySettingsScreen(
     val sessionToken = state.sessionToken
     val connectionPhase = state.connectionPhase
     val loadingMessage = state.loadingMessage
-    val errorMessage = state.errorMessage
+    val notice = state.notice
     val onBack = actions.onBack
     var address by rememberSaveable(dashboardUrl) { mutableStateOf(dashboardUrl) }
     var confirmForgetConnection by remember { mutableStateOf(false) }
@@ -366,12 +367,11 @@ internal fun GatewaySettingsScreen(
                 EditorialDivider()
             }
 
-            val visibleError = errorMessage
-            AnimatedVisibility(visibleError != null || loadingMessage != null) {
+            AnimatedVisibility(notice != null || loadingMessage != null) {
                 Column(modifier = Modifier.padding(vertical = 22.dp)) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    if (loadingMessage != null && visibleError != null) Spacer(Modifier.height(10.dp))
-                    visibleError?.let { StatusMessage(it, CelesteError) }
+                    if (loadingMessage != null && notice != null) Spacer(Modifier.height(10.dp))
+                    notice?.let { StatusMessage(it.message, CelesteError) }
                 }
             }
 
@@ -383,7 +383,7 @@ internal fun GatewaySettingsScreen(
             }
             val showPrimaryAction = !isConnected || addressChanged
             if (showPrimaryAction) {
-                Spacer(Modifier.height(if (visibleError == null && loadingMessage == null) 28.dp else 4.dp))
+                Spacer(Modifier.height(if (notice == null && loadingMessage == null) 28.dp else 4.dp))
                 CelestePrimaryButton(
                     text = when {
                         effectiveProbe == null -> "Find my Hermes"

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/gateway/GatewayScreens.kt
@@ -366,9 +366,7 @@ internal fun GatewaySettingsScreen(
                 EditorialDivider()
             }
 
-            val visibleError = errorMessage.takeUnless {
-                connectionPhase == ConnectionPhase.AuthenticationRequired
-            }
+            val visibleError = errorMessage
             AnimatedVisibility(visibleError != null || loadingMessage != null) {
                 Column(modifier = Modifier.padding(vertical = 22.dp)) {
                     loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -259,7 +259,12 @@ internal fun SessionListScreen(
                         modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
-                        StatusMessage("Loading conversations…", CelesteBlue, showSpinner = true)
+                        StatusMessage(
+                            "Loading conversations…",
+                            CelesteBlue,
+                            showSpinner = true,
+                            announce = true,
+                        )
                         repeat(4) { ConversationSkeleton() }
                     }
                 }
@@ -270,6 +275,7 @@ internal fun SessionListScreen(
                             "Refreshing conversations…",
                             CelesteBlue,
                             showSpinner = true,
+                            announce = true,
                         )
                     }
                 }
@@ -455,12 +461,13 @@ private fun CatalogMessage(
     message: String,
     actionLabel: String,
     onAction: () -> Unit,
+    announce: Boolean = true,
 ) {
     Column(
         modifier = Modifier.padding(horizontal = 28.dp, vertical = 9.dp),
         verticalArrangement = Arrangement.spacedBy(5.dp),
     ) {
-        StatusMessage(message, CelesteError)
+        StatusMessage(message, CelesteError, announce = announce)
         TextButton(
             onClick = onAction,
             modifier = Modifier.semantics { contentDescription = actionLabel },

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
@@ -44,8 +45,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.SessionCatalogState
 import dev.hazydreams.hermesceleste.SessionCatalogStatus
+import dev.hazydreams.hermesceleste.searchLoadedSessions
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.keyFor
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteError
@@ -75,19 +78,30 @@ internal fun SessionListScreen(
     onRefresh: () -> Unit = {},
     onRetry: () -> Unit = onRefresh,
     onBack: (() -> Unit)? = null,
+    activeSession: StoredSession? = null,
+    activeSessionRunning: Boolean = false,
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
-    val catalog = (catalogState ?: legacyCatalogState(
-        sessions = sessions,
-        selectedProfile = selectedProfile,
-        loadingMessage = loadingMessage,
-        errorMessage = errorMessage,
-    )).withQuery(query)
+    val catalog = if (catalogState == null) {
+        legacyCatalogState(
+            sessions = sessions,
+            selectedProfile = selectedProfile,
+            loadingMessage = loadingMessage,
+            errorMessage = errorMessage,
+        ).withQuery(query).let { state ->
+            if (query.isBlank()) state else {
+                state.withSearchResults(query, searchLoadedSessions(state.rows, query))
+            }
+        }
+    } else {
+        catalogState.withQuery(query)
+    }
     val visibleRows = catalog.filteredRows
     val visibleStatus = catalog.status
     val controlsBusy = catalog.phase == SessionCatalogStatus.Loading ||
         catalog.phase == SessionCatalogStatus.Refreshing ||
         catalog.phase == SessionCatalogStatus.Reconnecting
+    val selectedKey = activeSession?.keyFor(catalog.scope?.originKey.orEmpty())
 
     CelesteBackdrop(showOrnament = false) {
         Column(
@@ -113,7 +127,7 @@ internal fun SessionListScreen(
                     Text("Conversations", style = MaterialTheme.typography.headlineLarge)
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        "New conversations use ${selectedProfile.trim().ifBlank { "default" }} profile",
+                        "Profile scope: ${selectedProfile.trim().ifBlank { "default" }} · server order",
                         color = CelesteMuted,
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -142,7 +156,7 @@ internal fun SessionListScreen(
                             .height(50.dp)
                             .semantics {
                                 contentDescription =
-                                    "New conversation profile: ${selectedProfile.replaceFirstChar(Char::uppercase)}. This does not filter the loaded conversation list."
+                                    "New conversation profile: ${selectedProfile.replaceFirstChar(Char::uppercase)}. This also scopes the loaded conversation window; All Profiles is not available in Phase 1."
                                 stateDescription = if (profileMenuExpanded) "Expanded" else "Collapsed"
                             },
                         shape = RoundedCornerShape(25.dp),
@@ -312,6 +326,8 @@ internal fun SessionListScreen(
                             session = session,
                             showProfile = profiles.size > 1,
                             enabled = !controlsBusy,
+                            selected = selectedKey != null && session.keyFor(catalog.scope?.originKey.orEmpty()) == selectedKey,
+                            running = activeSessionRunning && selectedKey != null && session.keyFor(catalog.scope?.originKey.orEmpty()) == selectedKey,
                             onClick = { onSessionSelected(session) },
                         )
                     }
@@ -326,6 +342,8 @@ private fun SessionRow(
     session: StoredSession,
     showProfile: Boolean,
     enabled: Boolean,
+    selected: Boolean,
+    running: Boolean,
     onClick: () -> Unit,
 ) {
     val title = session.title.ifBlank { "Untitled conversation" }
@@ -333,15 +351,24 @@ private fun SessionRow(
         if (showProfile && session.profile.isNotBlank()) add(session.profile)
         if (session.messageCount > 0) add("${session.messageCount} messages")
         if (session.source.isNotBlank()) add(session.source)
+        if (selected) add("open")
+        if (running) add("running")
     }.joinToString("  ·  ").ifBlank { "No messages yet" }
+    val accessibilityState = when {
+        !enabled -> "Unavailable"
+        running -> "Open and running"
+        selected -> "Open and selected"
+        else -> "Ready"
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .semantics(mergeDescendants = true) {
                 role = Role.Button
+                selected = selected
                 contentDescription = "$title. $metadata. Open conversation."
-                stateDescription = if (enabled) "Ready" else "Unavailable"
+                stateDescription = accessibilityState
             }
             .padding(vertical = 19.dp),
     ) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.SessionCatalogState
 import dev.hazydreams.hermesceleste.SessionCatalogStatus
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.catalogRowKey
 import dev.hazydreams.hermesceleste.keyFor
 import dev.hazydreams.hermesceleste.searchLoadedSessions
@@ -67,7 +68,7 @@ internal fun SessionListScreen(
     profiles: List<DashboardProfile>,
     selectedProfile: String,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
     onProfileSelected: (String) -> Unit,
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
@@ -88,7 +89,7 @@ internal fun SessionListScreen(
             sessions = sessions,
             selectedProfile = selectedProfile,
             loadingMessage = loadingMessage,
-            errorMessage = errorMessage,
+            notice = notice,
         ).withQuery(query).let { state ->
             if (query.isBlank()) state else {
                 state.withSearchResults(query, searchLoadedSessions(state.rows, query))
@@ -338,13 +339,13 @@ internal fun SessionListScreen(
                 }
 
                 SessionCatalogStatus.Error -> CatalogMessage(
-                    message = catalog.errorMessage ?: "Could not load conversations.",
+                    message = catalog.notice?.message ?: "Could not load conversations.",
                     actionLabel = "Retry",
                     onAction = onRetry,
                 )
 
                 SessionCatalogStatus.Stale -> CatalogMessage(
-                    message = catalog.errorMessage ?: "Showing the last loaded conversations.",
+                    message = catalog.notice?.message ?: "Showing the last loaded conversations.",
                     actionLabel = "Retry",
                     onAction = onRetry,
                 )
@@ -396,7 +397,7 @@ private fun SessionRow(
     running: Boolean,
     onClick: () -> Unit,
 ) {
-    val semantics = sessionRowSemantics(
+    val rowSemantics = sessionRowSemantics(
         session = session,
         showProfile = showProfile,
         enabled = enabled,
@@ -409,9 +410,9 @@ private fun SessionRow(
             .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .semantics(mergeDescendants = true) {
                 role = Role.Button
-                selected = semantics.selected
-                contentDescription = semantics.contentDescription
-                stateDescription = semantics.stateDescription
+                this.selected = rowSemantics.selected
+                contentDescription = rowSemantics.contentDescription
+                stateDescription = rowSemantics.stateDescription
             }
             .padding(vertical = 19.dp),
     ) {
@@ -434,7 +435,7 @@ private fun SessionRow(
         }
         Spacer(Modifier.height(13.dp))
         Text(
-            semantics.metadata.uppercase(),
+            rowSemantics.metadata.uppercase(),
             color = CelesteMuted,
             fontSize = 10.sp,
             fontWeight = FontWeight.SemiBold,
@@ -538,12 +539,12 @@ private fun legacyCatalogState(
     sessions: List<StoredSession>,
     selectedProfile: String,
     loadingMessage: String?,
-    errorMessage: String?,
+    notice: UiNotice?,
 ): SessionCatalogState {
     val phase = when {
         loadingMessage != null -> SessionCatalogStatus.Loading
-        errorMessage != null && sessions.isNotEmpty() -> SessionCatalogStatus.Stale
-        errorMessage != null -> SessionCatalogStatus.Error
+        notice != null && sessions.isNotEmpty() -> SessionCatalogStatus.Stale
+        notice != null -> SessionCatalogStatus.Error
         sessions.isEmpty() -> SessionCatalogStatus.Empty
         else -> SessionCatalogStatus.Ready
     }
@@ -551,6 +552,6 @@ private fun legacyCatalogState(
         phase = phase,
         scope = dev.hazydreams.hermesceleste.SessionScope.from("legacy", selectedProfile),
         rows = sessions,
-        errorMessage = errorMessage,
+        notice = notice,
     )
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -1,5 +1,7 @@
 package dev.hazydreams.hermesceleste.ui.sessions
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,7 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -20,6 +22,8 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -29,26 +33,30 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.hazydreams.hermesceleste.SessionCatalogState
+import dev.hazydreams.hermesceleste.SessionCatalogStatus
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
-
 import dev.hazydreams.hermesceleste.ui.CelesteError
 import dev.hazydreams.hermesceleste.ui.CelesteHairline
 import dev.hazydreams.hermesceleste.ui.CelesteInk
 import dev.hazydreams.hermesceleste.ui.CelesteMuted
 import dev.hazydreams.hermesceleste.ui.CelestePanel
-
+import dev.hazydreams.hermesceleste.ui.CelestePaper
 import dev.hazydreams.hermesceleste.ui.EditorialDivider
 import dev.hazydreams.hermesceleste.ui.StatusMessage
+import java.util.Locale
 
 @Composable
 internal fun SessionListScreen(
@@ -61,25 +69,57 @@ internal fun SessionListScreen(
     onNewConversation: () -> Unit,
     onSessionSelected: (StoredSession) -> Unit,
     onSettings: () -> Unit,
+    catalogState: SessionCatalogState? = null,
+    query: String = "",
+    onQueryChange: (String) -> Unit = {},
+    onRefresh: () -> Unit = {},
+    onRetry: () -> Unit = onRefresh,
+    onBack: (() -> Unit)? = null,
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
+    val catalog = (catalogState ?: legacyCatalogState(
+        sessions = sessions,
+        selectedProfile = selectedProfile,
+        loadingMessage = loadingMessage,
+        errorMessage = errorMessage,
+    )).withQuery(query)
+    val visibleRows = catalog.filteredRows
+    val visibleStatus = catalog.status
+    val controlsBusy = catalog.phase == SessionCatalogStatus.Loading ||
+        catalog.phase == SessionCatalogStatus.Refreshing ||
+        catalog.phase == SessionCatalogStatus.Reconnecting
 
     CelesteBackdrop(showOrnament = false) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 44.dp),
+                .padding(top = 30.dp),
         ) {
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 28.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 28.dp),
                 verticalAlignment = Alignment.Top,
             ) {
                 Column(Modifier.weight(1f)) {
+                    if (onBack != null) {
+                        TextButton(
+                            onClick = onBack,
+                            contentPadding = PaddingValues(horizontal = 0.dp, vertical = 4.dp),
+                        ) {
+                            Text("←  Back", color = CelesteBlue, fontWeight = FontWeight.SemiBold)
+                        }
+                    }
                     Text("Conversations", style = MaterialTheme.typography.headlineLarge)
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "New conversations use ${selectedProfile.trim().ifBlank { "default" }} profile",
+                        color = CelesteMuted,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
                 }
                 TextButton(
                     onClick = onSettings,
-                    enabled = loadingMessage == null,
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
                 ) {
                     Text("Settings", fontWeight = FontWeight.SemiBold)
@@ -87,27 +127,30 @@ internal fun SessionListScreen(
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 28.dp, vertical = 24.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 28.dp, vertical = 18.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Box(Modifier.weight(1f)) {
                     OutlinedButton(
                         onClick = { profileMenuExpanded = true },
-                        enabled = loadingMessage == null,
+                        enabled = profiles.isNotEmpty() && !controlsBusy,
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(50.dp)
                             .semantics {
-                                contentDescription = "Profile: ${selectedProfile.replaceFirstChar(Char::uppercase)}"
+                                contentDescription =
+                                    "New conversation profile: ${selectedProfile.replaceFirstChar(Char::uppercase)}. This does not filter the loaded conversation list."
                                 stateDescription = if (profileMenuExpanded) "Expanded" else "Collapsed"
                             },
                         shape = RoundedCornerShape(25.dp),
-                        border = androidx.compose.foundation.BorderStroke(1.dp, CelesteHairline),
+                        border = BorderStroke(1.dp, CelesteHairline),
                         colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteInk),
                     ) {
                         Text(
-                            "${selectedProfile.replaceFirstChar(Char::uppercase)}  ↓",
+                            "New: ${selectedProfile.replaceFirstChar(Char::uppercase)}  ↓",
                             style = MaterialTheme.typography.labelLarge,
                         )
                     }
@@ -133,74 +176,269 @@ internal fun SessionListScreen(
                 }
                 OutlinedButton(
                     onClick = onNewConversation,
-                    enabled = loadingMessage == null,
+                    enabled = !controlsBusy,
                     modifier = Modifier.height(50.dp),
                     shape = RoundedCornerShape(25.dp),
                     contentPadding = PaddingValues(horizontal = 20.dp),
-                    border = androidx.compose.foundation.BorderStroke(1.dp, CelesteInk),
+                    border = BorderStroke(1.dp, CelesteInk),
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = CelesteInk),
                 ) {
                     Text("New chat  +", fontWeight = FontWeight.SemiBold)
                 }
             }
 
-            if (loadingMessage != null || errorMessage != null) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 28.dp, vertical = 4.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 28.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    enabled = catalog.phase != SessionCatalogStatus.NotReady,
+                    modifier = Modifier
+                        .weight(1f)
+                        .semantics { contentDescription = "Search loaded conversations" },
+                    singleLine = true,
+                    label = { Text("Search loaded") },
+                    placeholder = { Text("Title, preview, profile, source, or ID") },
+                    shape = RoundedCornerShape(22.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = CelesteBlue,
+                        unfocusedBorderColor = CelesteHairline,
+                        focusedContainerColor = CelestePaper,
+                        unfocusedContainerColor = CelestePaper,
+                        cursorColor = CelesteBlue,
+                    ),
+                )
+                TextButton(
+                    onClick = onRefresh,
+                    enabled = !controlsBusy,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Refresh conversations"
+                        stateDescription = if (catalog.phase == SessionCatalogStatus.Refreshing) {
+                            "Refreshing"
+                        } else {
+                            "Ready"
+                        }
+                    },
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 10.dp),
                 ) {
-                    loadingMessage?.let { StatusMessage(it, CelesteBlue, showSpinner = true) }
-                    errorMessage?.let { StatusMessage(it, CelesteError) }
+                    Text("Refresh", color = CelesteBlue, fontWeight = FontWeight.SemiBold)
                 }
             }
 
-            LazyColumn(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(start = 28.dp, end = 28.dp, top = 4.dp, bottom = 40.dp),
-            ) {
-                itemsIndexed(
-                    items = sessions,
-                    key = { _, session -> session.id },
-                ) { _, session ->
+            Text(
+                "Search is limited to loaded conversations.",
+                color = CelesteMuted,
+                fontSize = 11.sp,
+                modifier = Modifier.padding(horizontal = 32.dp, vertical = 6.dp),
+            )
+
+            when (visibleStatus) {
+                SessionCatalogStatus.Loading -> {
                     Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable(enabled = loadingMessage == null) { onSessionSelected(session) }
-                            .padding(vertical = 21.dp),
+                        modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
-                        Text(
-                            session.title.ifBlank { "Untitled conversation" },
-                            style = MaterialTheme.typography.headlineMedium,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        if (session.preview.isNotBlank()) {
-                            Spacer(Modifier.height(9.dp))
-                            Text(
-                                session.preview,
-                                color = CelesteMuted,
-                                style = MaterialTheme.typography.bodyMedium,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                        Spacer(Modifier.height(13.dp))
-                        val metadata = if (profiles.size > 1) {
-                            "${session.profile.uppercase()}  ·  ${session.messageCount} MESSAGES"
-                        } else {
-                            "${session.messageCount} MESSAGES"
-                        }
-                        Text(
-                            metadata,
-                            color = CelesteMuted,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            letterSpacing = 0.7.sp,
+                        StatusMessage("Loading conversations…", CelesteBlue, showSpinner = true)
+                        repeat(4) { ConversationSkeleton() }
+                    }
+                }
+
+                SessionCatalogStatus.Refreshing -> {
+                    Column(Modifier.padding(horizontal = 28.dp, vertical = 8.dp)) {
+                        StatusMessage(
+                            "Refreshing conversations…",
+                            CelesteBlue,
+                            showSpinner = true,
                         )
                     }
-                    EditorialDivider()
+                }
+
+                SessionCatalogStatus.Reconnecting -> {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        StatusMessage("Reconnecting conversation scope…", CelesteBlue, showSpinner = true)
+                        TextButton(
+                            onClick = onRetry,
+                            modifier = Modifier.semantics { contentDescription = "Retry conversation connection" },
+                        ) { Text("Retry", color = CelesteBlue) }
+                    }
+                }
+
+                SessionCatalogStatus.Error -> CatalogMessage(
+                    message = catalog.errorMessage ?: "Could not load conversations.",
+                    actionLabel = "Retry",
+                    onAction = onRetry,
+                )
+
+                SessionCatalogStatus.Stale -> CatalogMessage(
+                    message = catalog.errorMessage ?: "Showing the last loaded conversations.",
+                    actionLabel = "Retry",
+                    onAction = onRetry,
+                )
+
+                SessionCatalogStatus.Empty -> EmptyCatalog(onNewConversation)
+                SessionCatalogStatus.NoResults -> CatalogMessage(
+                    message = "No loaded conversation matches that search.",
+                    actionLabel = "Clear search",
+                    onAction = { onQueryChange("") },
+                )
+
+                SessionCatalogStatus.Ready,
+                SessionCatalogStatus.Opening,
+                SessionCatalogStatus.ActionInFlight,
+                SessionCatalogStatus.NotReady,
+                -> Unit
+            }
+
+            if (visibleRows.isNotEmpty()) {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(start = 28.dp, end = 28.dp, top = 4.dp, bottom = 40.dp),
+                ) {
+                    items(
+                        items = visibleRows,
+                        key = { session ->
+                            sessionRowKey(session, catalog.scope?.originKey.orEmpty())
+                        },
+                    ) { session ->
+                        SessionRow(
+                            session = session,
+                            showProfile = profiles.size > 1,
+                            enabled = !controlsBusy,
+                            onClick = { onSessionSelected(session) },
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun SessionRow(
+    session: StoredSession,
+    showProfile: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val title = session.title.ifBlank { "Untitled conversation" }
+    val metadata = buildList {
+        if (showProfile && session.profile.isNotBlank()) add(session.profile)
+        if (session.messageCount > 0) add("${session.messageCount} messages")
+        if (session.source.isNotBlank()) add(session.source)
+    }.joinToString("  ·  ").ifBlank { "No messages yet" }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                contentDescription = "$title. $metadata. Open conversation."
+                stateDescription = if (enabled) "Ready" else "Unavailable"
+            }
+            .padding(vertical = 19.dp),
+    ) {
+        Text(
+            title,
+            style = MaterialTheme.typography.headlineMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (session.preview.isNotBlank()) {
+            Spacer(Modifier.height(9.dp))
+            Text(
+                session.preview,
+                color = CelesteMuted,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(Modifier.height(13.dp))
+        Text(
+            metadata.uppercase(),
+            color = CelesteMuted,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 0.7.sp,
+        )
+    }
+    EditorialDivider()
+}
+
+@Composable
+private fun ConversationSkeleton() {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box(Modifier.fillMaxWidth(0.72f).height(22.dp).background(CelestePanel, RoundedCornerShape(5.dp)))
+        Box(Modifier.fillMaxWidth(0.94f).height(14.dp).background(CelestePanel, RoundedCornerShape(5.dp)))
+        Box(Modifier.fillMaxWidth(0.32f).height(11.dp).background(CelestePanel, RoundedCornerShape(5.dp)))
+    }
+}
+
+@Composable
+private fun CatalogMessage(
+    message: String,
+    actionLabel: String,
+    onAction: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = 28.dp, vertical = 9.dp),
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        StatusMessage(message, CelesteError)
+        TextButton(
+            onClick = onAction,
+            modifier = Modifier.semantics { contentDescription = actionLabel },
+        ) { Text(actionLabel, color = CelesteBlue, fontWeight = FontWeight.SemiBold) }
+    }
+}
+
+@Composable
+private fun EmptyCatalog(onNewConversation: () -> Unit) {
+    Column(
+        modifier = Modifier.padding(horizontal = 28.dp, vertical = 26.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("No conversations loaded", style = MaterialTheme.typography.titleLarge)
+        Text(
+            "Conversations created on Hermes will appear here after they have durable server identity.",
+            color = CelesteMuted,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Button(
+            onClick = onNewConversation,
+            colors = ButtonDefaults.buttonColors(containerColor = CelesteInk, contentColor = CelestePaper),
+        ) { Text("Start a new conversation") }
+    }
+}
+
+private fun sessionRowKey(session: StoredSession, originKey: String): String =
+    "$originKey\u0000${session.profile.trim().lowercase(Locale.ROOT)}\u0000${session.id.trim()}"
+
+private fun legacyCatalogState(
+    sessions: List<StoredSession>,
+    selectedProfile: String,
+    loadingMessage: String?,
+    errorMessage: String?,
+): SessionCatalogState {
+    val phase = when {
+        loadingMessage != null -> SessionCatalogStatus.Loading
+        errorMessage != null && sessions.isNotEmpty() -> SessionCatalogStatus.Stale
+        errorMessage != null -> SessionCatalogStatus.Error
+        sessions.isEmpty() -> SessionCatalogStatus.Empty
+        else -> SessionCatalogStatus.Ready
+    }
+    return SessionCatalogState(
+        phase = phase,
+        scope = dev.hazydreams.hermesceleste.SessionScope.from("legacy", selectedProfile),
+        rows = sessions,
+        errorMessage = errorMessage,
+    )
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -100,7 +100,9 @@ internal fun SessionListScreen(
     val visibleStatus = catalog.status
     val controlsBusy = catalog.phase == SessionCatalogStatus.Loading ||
         catalog.phase == SessionCatalogStatus.Refreshing ||
-        catalog.phase == SessionCatalogStatus.Reconnecting
+        catalog.phase == SessionCatalogStatus.Reconnecting ||
+        catalog.phase == SessionCatalogStatus.ActionInFlight ||
+        loadingMessage != null
     val selectedKey = activeSession?.keyFor(catalog.scope?.originKey.orEmpty())
 
     CelesteBackdrop(showOrnament = false) {
@@ -127,7 +129,7 @@ internal fun SessionListScreen(
                     Text("Conversations", style = MaterialTheme.typography.headlineLarge)
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        "Profile scope: ${selectedProfile.trim().ifBlank { "default" }} · server order",
+                        "New chats use ${selectedProfile.trim().ifBlank { "default" }} · all loaded profiles · server order",
                         color = CelesteMuted,
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -156,7 +158,7 @@ internal fun SessionListScreen(
                             .height(50.dp)
                             .semantics {
                                 contentDescription =
-                                    "New conversation profile: ${selectedProfile.replaceFirstChar(Char::uppercase)}. This also scopes the loaded conversation window; All Profiles is not available in Phase 1."
+                                    "New conversation profile: ${selectedProfile.replaceFirstChar(Char::uppercase)}. This does not filter the loaded conversation list."
                                 stateDescription = if (profileMenuExpanded) "Expanded" else "Collapsed"
                             },
                         shape = RoundedCornerShape(25.dp),
@@ -285,6 +287,16 @@ internal fun SessionListScreen(
                     }
                 }
 
+                SessionCatalogStatus.ActionInFlight -> {
+                    Column(Modifier.padding(horizontal = 28.dp, vertical = 8.dp)) {
+                        StatusMessage(
+                            loadingMessage ?: "Starting a new conversation…",
+                            CelesteBlue,
+                            showSpinner = true,
+                        )
+                    }
+                }
+
                 SessionCatalogStatus.Error -> CatalogMessage(
                     message = catalog.errorMessage ?: "Could not load conversations.",
                     actionLabel = "Retry",
@@ -306,7 +318,6 @@ internal fun SessionListScreen(
 
                 SessionCatalogStatus.Ready,
                 SessionCatalogStatus.Opening,
-                SessionCatalogStatus.ActionInFlight,
                 SessionCatalogStatus.NotReady,
                 -> Unit
             }
@@ -346,32 +357,26 @@ private fun SessionRow(
     running: Boolean,
     onClick: () -> Unit,
 ) {
-    val title = session.title.ifBlank { "Untitled conversation" }
-    val metadata = buildList {
-        if (showProfile && session.profile.isNotBlank()) add(session.profile)
-        if (session.messageCount > 0) add("${session.messageCount} messages")
-        if (session.source.isNotBlank()) add(session.source)
-        if (selected) add("open")
-        if (running) add("running")
-    }.joinToString("  ·  ").ifBlank { "No messages yet" }
-    val accessibilityState = when {
-        !enabled -> "Unavailable"
-        running -> "Open and running"
-        selected -> "Open and selected"
-        else -> "Ready"
-    }
+    val semantics = sessionRowSemantics(
+        session = session,
+        showProfile = showProfile,
+        enabled = enabled,
+        selected = selected,
+        running = running,
+    )
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(enabled = enabled, role = Role.Button, onClick = onClick)
             .semantics(mergeDescendants = true) {
                 role = Role.Button
-                selected = selected
-                contentDescription = "$title. $metadata. Open conversation."
-                stateDescription = accessibilityState
+                selected = semantics.selected
+                contentDescription = semantics.contentDescription
+                stateDescription = semantics.stateDescription
             }
             .padding(vertical = 19.dp),
     ) {
+        val title = session.title.ifBlank { "Untitled conversation" }
         Text(
             title,
             style = MaterialTheme.typography.headlineMedium,
@@ -390,7 +395,7 @@ private fun SessionRow(
         }
         Spacer(Modifier.height(13.dp))
         Text(
-            metadata.uppercase(),
+            semantics.metadata.uppercase(),
             color = CelesteMuted,
             fontSize = 10.sp,
             fontWeight = FontWeight.SemiBold,
@@ -398,6 +403,42 @@ private fun SessionRow(
         )
     }
     EditorialDivider()
+}
+
+internal data class SessionRowSemantics(
+    val selected: Boolean,
+    val contentDescription: String,
+    val stateDescription: String,
+    val metadata: String,
+)
+
+internal fun sessionRowSemantics(
+    session: StoredSession,
+    showProfile: Boolean,
+    enabled: Boolean,
+    selected: Boolean,
+    running: Boolean,
+): SessionRowSemantics {
+    val title = session.title.ifBlank { "Untitled conversation" }
+    val metadata = buildList {
+        if (showProfile && session.profile.isNotBlank()) add(session.profile)
+        if (session.messageCount > 0) add("${session.messageCount} messages")
+        if (session.source.isNotBlank()) add(session.source)
+        if (selected) add("open")
+        if (running) add("running")
+    }.joinToString("  ·  ").ifBlank { "No messages yet" }
+    val stateDescription = when {
+        !enabled -> "Unavailable"
+        running -> "Open and running"
+        selected -> "Open and selected"
+        else -> "Ready"
+    }
+    return SessionRowSemantics(
+        selected = selected,
+        contentDescription = "$title. $metadata. Open conversation.",
+        stateDescription = stateDescription,
+        metadata = metadata,
+    )
 }
 
 @Composable

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionListScreen.kt
@@ -45,10 +45,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.SessionCatalogState
 import dev.hazydreams.hermesceleste.SessionCatalogStatus
+import dev.hazydreams.hermesceleste.catalogRowKey
+import dev.hazydreams.hermesceleste.keyFor
 import dev.hazydreams.hermesceleste.searchLoadedSessions
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
-import dev.hazydreams.hermesceleste.keyFor
 import dev.hazydreams.hermesceleste.ui.CelesteBackdrop
 import dev.hazydreams.hermesceleste.ui.CelesteBlue
 import dev.hazydreams.hermesceleste.ui.CelesteError
@@ -59,7 +60,6 @@ import dev.hazydreams.hermesceleste.ui.CelestePanel
 import dev.hazydreams.hermesceleste.ui.CelestePaper
 import dev.hazydreams.hermesceleste.ui.EditorialDivider
 import dev.hazydreams.hermesceleste.ui.StatusMessage
-import java.util.Locale
 
 @Composable
 internal fun SessionListScreen(
@@ -77,6 +77,7 @@ internal fun SessionListScreen(
     onQueryChange: (String) -> Unit = {},
     onRefresh: () -> Unit = {},
     onRetry: () -> Unit = onRefresh,
+    onCancelOpening: () -> Unit = {},
     onBack: (() -> Unit)? = null,
     activeSession: StoredSession? = null,
     activeSessionRunning: Boolean = false,
@@ -101,6 +102,7 @@ internal fun SessionListScreen(
     val controlsBusy = catalog.phase == SessionCatalogStatus.Loading ||
         catalog.phase == SessionCatalogStatus.Refreshing ||
         catalog.phase == SessionCatalogStatus.Reconnecting ||
+        catalog.phase == SessionCatalogStatus.Opening ||
         catalog.phase == SessionCatalogStatus.ActionInFlight ||
         loadingMessage != null
     val selectedKey = activeSession?.keyFor(catalog.scope?.originKey.orEmpty())
@@ -129,7 +131,7 @@ internal fun SessionListScreen(
                     Text("Conversations", style = MaterialTheme.typography.headlineLarge)
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        "New chats use ${selectedProfile.trim().ifBlank { "default" }} · all loaded profiles · server order",
+                        "New chats use ${selectedProfile.trim().ifBlank { "default" }} · all loaded profiles · ownership may be unavailable · server order",
                         color = CelesteMuted,
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -252,6 +254,12 @@ internal fun SessionListScreen(
                 fontSize = 11.sp,
                 modifier = Modifier.padding(horizontal = 32.dp, vertical = 6.dp),
             )
+            Text(
+                "Rows without a verified profile stay visible but cannot be opened safely.",
+                color = CelesteMuted,
+                fontSize = 11.sp,
+                modifier = Modifier.padding(horizontal = 32.dp, vertical = 0.dp),
+            )
 
             when (visibleStatus) {
                 SessionCatalogStatus.Loading -> {
@@ -285,7 +293,12 @@ internal fun SessionListScreen(
                         modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        StatusMessage("Reconnecting conversation scope…", CelesteBlue, showSpinner = true)
+                        StatusMessage(
+                            "Reconnecting conversation scope…",
+                            CelesteBlue,
+                            showSpinner = true,
+                            announce = true,
+                        )
                         TextButton(
                             onClick = onRetry,
                             modifier = Modifier.semantics { contentDescription = "Retry conversation connection" },
@@ -299,7 +312,28 @@ internal fun SessionListScreen(
                             loadingMessage ?: "Starting a new conversation…",
                             CelesteBlue,
                             showSpinner = true,
+                            announce = true,
                         )
+                    }
+                }
+
+                SessionCatalogStatus.Opening -> {
+                    Column(
+                        Modifier.padding(horizontal = 28.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(5.dp),
+                    ) {
+                        StatusMessage(
+                            loadingMessage ?: "Opening conversation…",
+                            CelesteBlue,
+                            showSpinner = true,
+                            announce = true,
+                        )
+                        TextButton(
+                            onClick = onCancelOpening,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Cancel opening conversation"
+                            },
+                        ) { Text("Cancel", color = CelesteBlue, fontWeight = FontWeight.SemiBold) }
                     }
                 }
 
@@ -323,7 +357,6 @@ internal fun SessionListScreen(
                 )
 
                 SessionCatalogStatus.Ready,
-                SessionCatalogStatus.Opening,
                 SessionCatalogStatus.NotReady,
                 -> Unit
             }
@@ -342,7 +375,7 @@ internal fun SessionListScreen(
                         SessionRow(
                             session = session,
                             showProfile = profiles.size > 1,
-                            enabled = !controlsBusy,
+                            enabled = !controlsBusy && session.profile.isNotBlank(),
                             selected = selectedKey != null && session.keyFor(catalog.scope?.originKey.orEmpty()) == selectedKey,
                             running = activeSessionRunning && selectedKey != null && session.keyFor(catalog.scope?.originKey.orEmpty()) == selectedKey,
                             onClick = { onSessionSelected(session) },
@@ -427,13 +460,16 @@ internal fun sessionRowSemantics(
 ): SessionRowSemantics {
     val title = session.title.ifBlank { "Untitled conversation" }
     val metadata = buildList {
-        if (showProfile && session.profile.isNotBlank()) add(session.profile)
+        if (session.profile.isNotBlank() && showProfile) add(session.profile)
+        if (session.profile.isBlank()) add("profile unavailable")
         if (session.messageCount > 0) add("${session.messageCount} messages")
         if (session.source.isNotBlank()) add(session.source)
         if (selected) add("open")
         if (running) add("running")
     }.joinToString("  ·  ").ifBlank { "No messages yet" }
+    val canOpen = session.profile.isNotBlank()
     val stateDescription = when {
+        !canOpen -> "Unavailable: profile ownership unavailable"
         !enabled -> "Unavailable"
         running -> "Open and running"
         selected -> "Open and selected"
@@ -441,7 +477,7 @@ internal fun sessionRowSemantics(
     }
     return SessionRowSemantics(
         selected = selected,
-        contentDescription = "$title. $metadata. Open conversation.",
+        contentDescription = "$title. $metadata. ${if (canOpen) "Open conversation." else "Cannot open conversation: profile ownership is unavailable."}",
         stateDescription = stateDescription,
         metadata = metadata,
     )
@@ -495,7 +531,8 @@ private fun EmptyCatalog(onNewConversation: () -> Unit) {
 }
 
 private fun sessionRowKey(session: StoredSession, originKey: String): String =
-    "$originKey\u0000${session.profile.trim().lowercase(Locale.ROOT)}\u0000${session.id.trim()}"
+    session.catalogRowKey(originKey)
+        ?: "$originKey\u0000<invalid-row>\u0000${session.id.trim()}"
 
 private fun legacyCatalogState(
     sessions: List<StoredSession>,

--- a/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/dev/hazydreams/hermesceleste/CelesteScreensScreenshotTest.kt
@@ -83,7 +83,7 @@ private val gatewaySetupState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.ManualSetup,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private val passwordSignInState = GatewaySettingsUiState(
@@ -100,7 +100,7 @@ private val passwordSignInState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.AuthenticationRequired,
     loadingMessage = null,
-    errorMessage = "Sign in required.",
+    notice = UiNotice.AuthenticationRequired,
 )
 
 private val sessionTokenState = GatewaySettingsUiState(
@@ -117,7 +117,7 @@ private val sessionTokenState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.ManualSetup,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private val connectedGatewayState = GatewaySettingsUiState(
@@ -134,7 +134,7 @@ private val connectedGatewayState = GatewaySettingsUiState(
     sessionToken = "",
     connectionPhase = ConnectionPhase.Connected,
     loadingMessage = null,
-    errorMessage = null,
+    notice = null,
 )
 
 private fun gatewayPreviewActions(onBack: (() -> Unit)?): GatewaySettingsActions =
@@ -227,7 +227,7 @@ fun RestoringConnectionPreviewScreenshot() {
 fun RestoreFailedPreviewScreenshot() {
     HermesCelesteTheme {
         ConnectionUnavailableScreen(
-            errorMessage = "Could not reach Hermes.",
+            notice = UiNotice.DashboardUnavailable,
             onRetry = {},
             onSettings = {},
         )
@@ -247,7 +247,7 @@ fun SessionListPreviewScreenshot() {
             ),
             selectedProfile = "work",
             loadingMessage = null,
-            errorMessage = null,
+            notice = null,
             onProfileSelected = {},
             onNewConversation = {},
             onSessionSelected = {},
@@ -339,7 +339,7 @@ fun ReconnectingPreviewScreenshot() {
         PreviewConversation(
             draft = "This draft stays here while the connection recovers.",
             turnState = TurnState.Reconnecting,
-            errorMessage = "The dashboard connection closed before Hermes finished responding.",
+            notice = UiNotice.Reconnecting,
         )
     }
 }
@@ -351,7 +351,7 @@ private fun PreviewConversation(
     streamingText: String = "",
     draft: String = "",
     turnState: TurnState,
-    errorMessage: String? = null,
+    notice: UiNotice? = null,
 ) {
     ConversationScreen(
         summary = summary,
@@ -360,7 +360,7 @@ private fun PreviewConversation(
         draft = draft,
         turnState = turnState,
         loadingMessage = null,
-        errorMessage = errorMessage,
+        notice = notice,
         onDraftChange = {},
         onSend = {},
         onInterrupt = {},

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -15,6 +15,7 @@ import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.StoredSession
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -209,6 +210,44 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun successfulReconnectReconcilesTheConversationCatalog() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = openConversation(gateway, dashboard)
+        val callsBeforeDisconnect = dashboard.sessionListCalls
+
+        gateway.disconnect("dashboard restarted")
+        advanceUntilIdle()
+
+        assertTrue(dashboard.sessionListCalls > callsBeforeDisconnect)
+        assertEquals(SessionCatalogStatus.Ready, viewModel.state.value.sessionCatalog.phase)
+        assertEquals(listOf("stored-42"), viewModel.state.value.sessions?.map(StoredSession::id))
+        viewModel.leaveConversation()
+    }
+
+    @Test
+    fun initialCatalogLoadExposesLoadingStateBeforeTheServerResponds() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway).apply {
+            sessionListGate = CompletableDeferred()
+        }
+        val viewModel = CelesteViewModel(dashboard = dashboard)
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+
+        viewModel.loadSessions()
+
+        assertEquals(ConnectionPhase.LoadingSessions, viewModel.state.value.connectionPhase)
+        assertTrue(viewModel.state.value.sessions != null)
+        assertEquals(SessionCatalogStatus.Loading, viewModel.state.value.sessionCatalog.phase)
+
+        dashboard.sessionListGate?.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(ConnectionPhase.Connected, viewModel.state.value.connectionPhase)
+    }
+
+    @Test
     fun createsInTheSelectedProfileAndRecreatesOnlyAnUntouchedDraftSession() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
@@ -259,19 +298,37 @@ class CelesteViewModelTest {
     }
 
     @Test
-    fun profileSelectionChangesOnlyTheNextNewConversationProfile() = runTest {
+    fun profileSelectionClearsTheOldScopeAndLoadsOnlyTheSelectedProfile() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
-        val rowsBefore = viewModel.state.value.sessions
 
         viewModel.selectProfile("work")
+        advanceUntilIdle()
 
         assertEquals("work", viewModel.state.value.selectedProfile)
-        assertEquals(rowsBefore, viewModel.state.value.sessions)
         assertEquals(
-            rowsBefore?.map(StoredSession::id),
+            listOf("stored-work"),
+            viewModel.state.value.sessions?.map(StoredSession::id),
+        )
+        assertEquals(
+            listOf("stored-work"),
             viewModel.state.value.sessionCatalog.rows.map(StoredSession::id),
         )
+        assertTrue(viewModel.state.value.sessions.orEmpty().all { it.profile == "work" })
+    }
+
+    @Test
+    fun catalogAuthenticationFailureClearsReusableAuthenticationInsteadOfShowingStaleRows() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+        dashboard.sessionFailure = AuthenticationRejected("Hermes needs sign-in.")
+
+        viewModel.refreshSessionCatalog()
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
+        assertNull(viewModel.state.value.sessions)
+        assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
     }
 
     @Test
@@ -289,6 +346,65 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun noResultsDoesNotMaskRefreshingOrStaleCatalogState() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+
+        viewModel.updateSessionQuery("does-not-exist")
+        advanceUntilIdle()
+        assertEquals(SessionCatalogStatus.NoResults, viewModel.state.value.sessionCatalog.status)
+
+        dashboard.sessionFailure = IOException("offline")
+        viewModel.refreshSessionCatalog()
+        advanceUntilIdle()
+
+        assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.status)
+        assertEquals(listOf("stored-42"), viewModel.state.value.sessions?.map(StoredSession::id))
+    }
+
+    @Test
+    fun obsoleteLoadedWindowSearchCannotReplaceTheLatestQuery() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+
+        viewModel.updateSessionQuery("work")
+        viewModel.updateSessionQuery("shared")
+        advanceUntilIdle()
+
+        assertEquals("shared", viewModel.state.value.sessionQuery)
+        assertEquals(listOf("stored-42"), viewModel.state.value.sessionCatalog.filteredRows.map(StoredSession::id))
+    }
+
+    @Test
+    fun failedNewConversationRestoresThePreviousTranscriptAndDraft() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(
+                    ConversationMessage(role = "user", text = "Previous prompt", id = "user-1"),
+                    ConversationMessage(role = "assistant", text = "Previous answer", id = "assistant-1"),
+                ),
+                running = false,
+            )
+            createFailure = IOException("new conversation unavailable")
+        }
+        val viewModel = openConversation(gateway)
+        viewModel.updateDraft("Keep this unsent draft")
+
+        viewModel.createNewConversation()
+        advanceUntilIdle()
+
+        assertEquals("stored-42", viewModel.state.value.activeSummary?.id)
+        assertEquals(
+            listOf("Previous prompt", "Previous answer"),
+            viewModel.state.value.messages.map(ConversationMessage::text),
+        )
+        assertEquals("Keep this unsent draft", viewModel.state.value.draft)
+        assertEquals("new conversation unavailable", viewModel.state.value.errorMessage)
+        assertEquals(1, gateway.methods.count { it == "session.create" })
+        viewModel.leaveConversation()
+    }
+
+    @Test
     fun removesPersistedPrefixFromInflightProjection() {
         val suffix = CelesteViewModel.unpersistedInflightText(
             inflight = "Already stored and still arriving",
@@ -298,8 +414,10 @@ class CelesteViewModelTest {
         assertEquals("and still arriving", suffix)
     }
 
-    private suspend fun openConversation(gateway: FakeGateway): CelesteViewModel {
-        val dashboard = FakeDashboard(gateway)
+    private suspend fun openConversation(
+        gateway: FakeGateway,
+        dashboard: FakeDashboard = FakeDashboard(gateway),
+    ): CelesteViewModel {
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
@@ -329,6 +447,8 @@ class CelesteViewModelTest {
     ) : DashboardService {
         var profileFailure: Throwable? = null
         var sessionFailure: Throwable? = null
+        var sessionListGate: CompletableDeferred<Unit>? = null
+        var sessionListCalls = 0
 
         val session = StoredSession(
             id = "stored-42",
@@ -337,6 +457,16 @@ class CelesteViewModelTest {
             startedAt = 1.0,
             messageCount = 0,
             source = "desktop",
+        )
+
+        private val workSession = StoredSession(
+            id = "stored-work",
+            title = "Work conversation",
+            preview = "",
+            startedAt = 2.0,
+            messageCount = 0,
+            source = "desktop",
+            profile = "work",
         )
 
         override suspend fun probe(rawBaseUrl: String): DashboardProbeResult =
@@ -363,8 +493,10 @@ class CelesteViewModelTest {
             credential: GatewayCredential,
             limit: Int,
         ): List<StoredSession> {
+            sessionListCalls += 1
+            sessionListGate?.await()
             sessionFailure?.let { throw it }
-            return listOf(session)
+            return listOf(session, workSession)
         }
 
         override suspend fun listProfiles(
@@ -397,6 +529,7 @@ class CelesteViewModelTest {
         val requests = mutableListOf<Pair<String, JsonObject>>()
         var connectCount = 0
         var createCount = 0
+        var createFailure: Throwable? = null
         var failHealthCheck = false
         var connectFailure: Throwable? = null
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
@@ -418,6 +551,7 @@ class CelesteViewModelTest {
                 "session.resume" -> resumePayload
                 "session.create" -> {
                     createCount += 1
+                    createFailure?.let { throw it }
                     buildJsonObject {
                         put("session_id", "runtime-new-$createCount")
                         put("stored_session_id", "stored-new-$createCount")

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -226,6 +226,7 @@ class CelesteViewModelTest {
 
         assertEquals("work", viewModel.state.value.activeSummary?.profile)
         assertEquals("stored-new-1", viewModel.state.value.activeSummary?.id)
+        assertTrue(viewModel.state.value.sessions.orEmpty().none { it.id == "stored-new-1" })
         assertEquals(1, gateway.methods.count { it == "session.create" })
         assertEquals(0, gateway.methods.count { it == "session.resume" })
         val createParams = gateway.requests.first { it.first == "session.create" }.second
@@ -258,6 +259,36 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun profileSelectionChangesOnlyTheNextNewConversationProfile() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+        val rowsBefore = viewModel.state.value.sessions
+
+        viewModel.selectProfile("work")
+
+        assertEquals("work", viewModel.state.value.selectedProfile)
+        assertEquals(rowsBefore, viewModel.state.value.sessions)
+        assertEquals(
+            rowsBefore?.map(StoredSession::id),
+            viewModel.state.value.sessionCatalog.rows.map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun refreshFailureRetainsTheAuthoritativeWindowAsStale() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+        dashboard.sessionFailure = IOException("offline")
+
+        viewModel.refreshSessionCatalog()
+        advanceUntilIdle()
+
+        assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
+        assertEquals(listOf("stored-42"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals("offline", viewModel.state.value.sessionCatalog.errorMessage)
+    }
+
+    @Test
     fun removesPersistedPrefixFromInflightProjection() {
         val suffix = CelesteViewModel.unpersistedInflightText(
             inflight = "Already stored and still arriving",
@@ -280,11 +311,24 @@ class CelesteViewModelTest {
         return viewModel
     }
 
+    private suspend fun connectedViewModel(dashboard: FakeDashboard): CelesteViewModel {
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        return viewModel
+    }
+
     private class FakeDashboard(
         private val gateway: FakeGateway,
         private val authRequired: Boolean = false,
     ) : DashboardService {
         var profileFailure: Throwable? = null
+        var sessionFailure: Throwable? = null
 
         val session = StoredSession(
             id = "stored-42",
@@ -318,7 +362,10 @@ class CelesteViewModelTest {
             baseUrl: String,
             credential: GatewayCredential,
             limit: Int,
-        ): List<StoredSession> = listOf(session)
+        ): List<StoredSession> {
+            sessionFailure?.let { throw it }
+            return listOf(session)
+        }
 
         override suspend fun listProfiles(
             baseUrl: String,

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -358,6 +358,39 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun openingAuthenticationFailureClosesGatewayAndRequiresSignIn() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway, authRequired = true)
+        val store = InMemoryConnectionStore()
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            connectionStore = store,
+        )
+        viewModel.updateDashboardUrl("https://hermes.test")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.updateUsername("celeste")
+        viewModel.updatePassword("synthetic-password")
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        assertTrue(store.load()?.secret != null)
+
+        gateway.connectFailure = AuthenticationRejected("Hermes rejected the conversation gateway.")
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
+        assertNull(viewModel.state.value.sessions)
+        assertEquals(SessionCatalogStatus.NotReady, viewModel.state.value.sessionCatalog.phase)
+        assertNull(viewModel.state.value.activeSummary)
+        assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
+        assertNull(store.load()?.secret)
+        assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
+        assertEquals(GatewayConnectionState.Closed, gateway.state.value)
+        assertEquals(1, gateway.closeCount)
+    }
+
+    @Test
     fun newConversationAuthenticationFailureClosesGatewayAndRequiresSignIn() = runTest {
         val gateway = FakeGateway().apply {
             createFailure = AuthenticationRejected("Hermes rejected new conversation creation.")
@@ -434,6 +467,49 @@ class CelesteViewModelTest {
 
         assertEquals("shared", viewModel.state.value.sessionQuery)
         assertEquals(listOf("stored-42"), viewModel.state.value.sessionCatalog.filteredRows.map(StoredSession::id))
+    }
+
+    @Test
+    fun creationProfileChangeDoesNotLeaveDebouncedUnscopedSearchInFlight() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+
+        viewModel.updateSessionQuery("work")
+        assertTrue(viewModel.state.value.sessionCatalog.queryInFlight)
+
+        viewModel.selectProfile("work")
+        advanceUntilIdle()
+
+        assertEquals("work", viewModel.state.value.selectedProfile)
+        assertFalse(viewModel.state.value.sessionCatalog.queryInFlight)
+        assertEquals(
+            listOf("stored-work"),
+            viewModel.state.value.sessionCatalog.filteredRows.map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun creationProfileChangeDoesNotInvalidateAnInitialUnscopedCatalogLoad() = runTest {
+        val dashboard = FakeDashboard(FakeGateway())
+        val viewModel = connectedViewModel(dashboard)
+        viewModel.selectProfile("work")
+
+        dashboard.sessionListGate = CompletableDeferred()
+        viewModel.loadSessions()
+        assertEquals(ConnectionPhase.LoadingSessions, viewModel.state.value.connectionPhase)
+        assertEquals(SessionCatalogStatus.Loading, viewModel.state.value.sessionCatalog.phase)
+        assertFalse(viewModel.state.value.sessionCatalog.queryInFlight)
+
+        viewModel.selectProfile("default")
+        dashboard.sessionListGate?.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.Connected, viewModel.state.value.connectionPhase)
+        assertEquals("default", viewModel.state.value.selectedProfile)
+        assertEquals(
+            listOf("stored-42", "stored-work", "ambiguous-profile"),
+            viewModel.state.value.sessions?.map(StoredSession::id),
+        )
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -354,6 +354,41 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun newConversationAuthenticationFailureClosesGatewayAndRequiresSignIn() = runTest {
+        val gateway = FakeGateway().apply {
+            createFailure = AuthenticationRejected("Hermes rejected new conversation creation.")
+        }
+        val dashboard = FakeDashboard(gateway, authRequired = true)
+        val store = InMemoryConnectionStore()
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            connectionStore = store,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("https://hermes.test")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.updateUsername("celeste")
+        viewModel.updatePassword("synthetic-password")
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+        assertTrue(store.load()?.secret != null)
+
+        viewModel.createNewConversation()
+        advanceUntilIdle()
+
+        assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
+        assertNull(viewModel.state.value.sessions)
+        assertNull(viewModel.state.value.activeSummary)
+        assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
+        assertNull(store.load()?.secret)
+        assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
+        assertEquals(GatewayConnectionState.Closed, gateway.state.value)
+    }
+
+    @Test
     fun refreshFailureRetainsTheAuthoritativeWindowAsStale() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
@@ -418,6 +453,24 @@ class CelesteViewModelTest {
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
         assertEquals(loadedRows, viewModel.state.value.sessionCatalog.rows)
         assertEquals("new conversation unavailable", viewModel.state.value.sessionCatalog.errorMessage)
+    }
+
+    @Test
+    fun newConversationWithoutDurableIdentityNeverPromotesItsRuntimeId() = runTest {
+        val gateway = FakeGateway().apply { omitStoredIdentity = true }
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = connectedViewModel(dashboard)
+
+        viewModel.createNewConversation()
+        advanceUntilIdle()
+
+        assertNull(viewModel.state.value.activeSummary)
+        assertTrue(viewModel.state.value.sessions.orEmpty().none { it.id == "runtime-new-1" })
+        assertEquals(
+            "Hermes created a conversation without a durable stored identity.",
+            viewModel.state.value.errorMessage,
+        )
+        assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
     }
 
     @Test
@@ -585,6 +638,7 @@ class CelesteViewModelTest {
         var connectCount = 0
         var createCount = 0
         var createFailure: Throwable? = null
+        var omitStoredIdentity = false
         var createGate: CompletableDeferred<Unit>? = null
         var failHealthCheck = false
         var connectFailure: Throwable? = null
@@ -612,7 +666,7 @@ class CelesteViewModelTest {
                     createFailure?.let { throw it }
                     buildJsonObject {
                         put("session_id", "runtime-new-$createCount")
-                        put("stored_session_id", "stored-new-$createCount")
+                        if (!omitStoredIdentity) put("stored_session_id", "stored-new-$createCount")
                         put("profile", params["profile"]?.jsonPrimitive?.content ?: "default")
                     }
                 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -221,7 +221,7 @@ class CelesteViewModelTest {
 
         assertTrue(dashboard.sessionListCalls > callsBeforeDisconnect)
         assertEquals(SessionCatalogStatus.Ready, viewModel.state.value.sessionCatalog.phase)
-        assertEquals(listOf("stored-42", "stored-work"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals(listOf("stored-42", "stored-work", "ambiguous-profile"), viewModel.state.value.sessions?.map(StoredSession::id))
         viewModel.leaveConversation()
     }
 
@@ -272,12 +272,16 @@ class CelesteViewModelTest {
         assertEquals("work", createParams["profile"]?.jsonPrimitive?.content)
         assertEquals("android", createParams["source"]?.jsonPrimitive?.content)
 
+        viewModel.selectProfile("default")
+        assertEquals("default", viewModel.state.value.selectedProfile)
         gateway.disconnect("blank session socket died")
         advanceUntilIdle()
 
         assertEquals(2, gateway.methods.count { it == "session.create" })
         assertEquals(0, gateway.methods.count { it == "session.resume" })
         assertEquals("stored-new-2", viewModel.state.value.activeSummary?.id)
+        val recreatedParams = gateway.requests.filter { it.first == "session.create" }.last().second
+        assertEquals("work", recreatedParams["profile"]?.jsonPrimitive?.content)
 
         viewModel.updateDraft("Persist this conversation")
         viewModel.sendMessage()
@@ -306,16 +310,16 @@ class CelesteViewModelTest {
 
         assertEquals("work", viewModel.state.value.selectedProfile)
         assertEquals(
-            listOf("stored-42", "stored-work"),
+            listOf("stored-42", "stored-work", "ambiguous-profile"),
             viewModel.state.value.sessions?.map(StoredSession::id),
         )
         assertEquals(
-            listOf("stored-42", "stored-work"),
+            listOf("stored-42", "stored-work", "ambiguous-profile"),
             viewModel.state.value.sessionCatalog.rows.map(StoredSession::id),
         )
         assertTrue(viewModel.state.value.sessions.orEmpty().any { it.profile == "default" })
         assertTrue(viewModel.state.value.sessions.orEmpty().any { it.profile == "work" })
-        assertTrue(viewModel.state.value.sessions.orEmpty().none { it.id == "ambiguous-profile" })
+        assertTrue(viewModel.state.value.sessions.orEmpty().single { it.id == "ambiguous-profile" }.profile.isBlank())
     }
 
     @Test
@@ -398,7 +402,7 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
-        assertEquals(listOf("stored-42", "stored-work"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals(listOf("stored-42", "stored-work", "ambiguous-profile"), viewModel.state.value.sessions?.map(StoredSession::id))
         assertEquals("offline", viewModel.state.value.sessionCatalog.errorMessage)
     }
 
@@ -416,7 +420,7 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.status)
-        assertEquals(listOf("stored-42", "stored-work"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals(listOf("stored-42", "stored-work", "ambiguous-profile"), viewModel.state.value.sessions?.map(StoredSession::id))
     }
 
     @Test
@@ -555,6 +559,7 @@ class CelesteViewModelTest {
             startedAt = 1.0,
             messageCount = 0,
             source = "desktop",
+            profile = "default",
         )
 
         private val workSession = StoredSession(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -221,7 +221,7 @@ class CelesteViewModelTest {
 
         assertTrue(dashboard.sessionListCalls > callsBeforeDisconnect)
         assertEquals(SessionCatalogStatus.Ready, viewModel.state.value.sessionCatalog.phase)
-        assertEquals(listOf("stored-42"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals(listOf("stored-42", "stored-work"), viewModel.state.value.sessions?.map(StoredSession::id))
         viewModel.leaveConversation()
     }
 
@@ -298,29 +298,46 @@ class CelesteViewModelTest {
     }
 
     @Test
-    fun profileSelectionClearsTheOldScopeAndLoadsOnlyTheSelectedProfile() = runTest {
+    fun profileSelectionChangesOnlyTheNextNewConversationProfile() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
 
         viewModel.selectProfile("work")
-        advanceUntilIdle()
 
         assertEquals("work", viewModel.state.value.selectedProfile)
         assertEquals(
-            listOf("stored-work"),
+            listOf("stored-42", "stored-work"),
             viewModel.state.value.sessions?.map(StoredSession::id),
         )
         assertEquals(
-            listOf("stored-work"),
+            listOf("stored-42", "stored-work"),
             viewModel.state.value.sessionCatalog.rows.map(StoredSession::id),
         )
-        assertTrue(viewModel.state.value.sessions.orEmpty().all { it.profile == "work" })
+        assertTrue(viewModel.state.value.sessions.orEmpty().any { it.profile == "default" })
+        assertTrue(viewModel.state.value.sessions.orEmpty().any { it.profile == "work" })
+        assertTrue(viewModel.state.value.sessions.orEmpty().none { it.id == "ambiguous-profile" })
     }
 
     @Test
-    fun catalogAuthenticationFailureClearsReusableAuthenticationInsteadOfShowingStaleRows() = runTest {
-        val dashboard = FakeDashboard(FakeGateway())
-        val viewModel = connectedViewModel(dashboard)
+    fun catalogAuthenticationFailureClosesGatewayAndClearsTheCatalog() = runTest {
+        val gateway = FakeGateway()
+        val dashboard = FakeDashboard(gateway, authRequired = true)
+        val store = InMemoryConnectionStore()
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            connectionStore = store,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        advanceUntilIdle()
+        viewModel.updateUsername("celeste")
+        viewModel.updatePassword("synthetic-password")
+        viewModel.loadSessions()
+        advanceUntilIdle()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+        assertTrue(store.load()?.secret != null)
         dashboard.sessionFailure = AuthenticationRejected("Hermes needs sign-in.")
 
         viewModel.refreshSessionCatalog()
@@ -328,7 +345,12 @@ class CelesteViewModelTest {
 
         assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
         assertNull(viewModel.state.value.sessions)
+        assertNull(viewModel.state.value.activeSummary)
         assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
+        assertNull(store.load()?.secret)
+        assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
+        assertEquals(1, gateway.closeCount)
+        assertEquals(GatewayConnectionState.Closed, gateway.state.value)
     }
 
     @Test
@@ -341,7 +363,7 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
-        assertEquals(listOf("stored-42"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals(listOf("stored-42", "stored-work"), viewModel.state.value.sessions?.map(StoredSession::id))
         assertEquals("offline", viewModel.state.value.sessionCatalog.errorMessage)
     }
 
@@ -359,7 +381,7 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.status)
-        assertEquals(listOf("stored-42"), viewModel.state.value.sessions?.map(StoredSession::id))
+        assertEquals(listOf("stored-42", "stored-work"), viewModel.state.value.sessions?.map(StoredSession::id))
     }
 
     @Test
@@ -373,6 +395,29 @@ class CelesteViewModelTest {
 
         assertEquals("shared", viewModel.state.value.sessionQuery)
         assertEquals(listOf("stored-42"), viewModel.state.value.sessionCatalog.filteredRows.map(StoredSession::id))
+    }
+
+    @Test
+    fun newConversationFromTheListPublishesActionProgressAndThenAStaleError() = runTest {
+        val gateway = FakeGateway().apply {
+            createGate = CompletableDeferred()
+            createFailure = IOException("new conversation unavailable")
+        }
+        val dashboard = FakeDashboard(gateway)
+        val viewModel = connectedViewModel(dashboard)
+        val loadedRows = viewModel.state.value.sessionCatalog.rows
+
+        viewModel.createNewConversation()
+
+        assertEquals(SessionCatalogStatus.ActionInFlight, viewModel.state.value.sessionCatalog.phase)
+        assertEquals(loadedRows, viewModel.state.value.sessionCatalog.rows)
+
+        gateway.createGate?.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
+        assertEquals(loadedRows, viewModel.state.value.sessionCatalog.rows)
+        assertEquals("new conversation unavailable", viewModel.state.value.sessionCatalog.errorMessage)
     }
 
     @Test
@@ -469,6 +514,16 @@ class CelesteViewModelTest {
             profile = "work",
         )
 
+        private val ambiguousProfileSession = StoredSession(
+            id = "ambiguous-profile",
+            title = "Ambiguous profile",
+            preview = "",
+            startedAt = 3.0,
+            messageCount = 0,
+            source = "desktop",
+            profile = "",
+        )
+
         override suspend fun probe(rawBaseUrl: String): DashboardProbeResult =
             DashboardProbeResult(
                 baseUrl = rawBaseUrl,
@@ -496,7 +551,7 @@ class CelesteViewModelTest {
             sessionListCalls += 1
             sessionListGate?.await()
             sessionFailure?.let { throw it }
-            return listOf(session, workSession)
+            return listOf(session, workSession, ambiguousProfileSession)
         }
 
         override suspend fun listProfiles(
@@ -530,8 +585,10 @@ class CelesteViewModelTest {
         var connectCount = 0
         var createCount = 0
         var createFailure: Throwable? = null
+        var createGate: CompletableDeferred<Unit>? = null
         var failHealthCheck = false
         var connectFailure: Throwable? = null
+        var closeCount = 0
         var resumePayload: JsonObject = resumePayload(messages = emptyList(), running = false)
 
         override suspend fun connect() {
@@ -551,6 +608,7 @@ class CelesteViewModelTest {
                 "session.resume" -> resumePayload
                 "session.create" -> {
                     createCount += 1
+                    createGate?.await()
                     createFailure?.let { throw it }
                     buildJsonObject {
                         put("session_id", "runtime-new-$createCount")
@@ -572,6 +630,7 @@ class CelesteViewModelTest {
         }
 
         override fun close() {
+            closeCount += 1
             mutableState.value = GatewayConnectionState.Closed
         }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -14,6 +14,7 @@ import dev.hazydreams.hermesceleste.network.GatewayConnection
 import dev.hazydreams.hermesceleste.network.GatewayConnectionState
 import dev.hazydreams.hermesceleste.network.GatewayCredential
 import dev.hazydreams.hermesceleste.network.GatewayEvent
+import dev.hazydreams.hermesceleste.network.ProfileSessionList
 import dev.hazydreams.hermesceleste.network.StoredSession
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,7 +23,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -59,6 +62,7 @@ class CelesteViewModelTest {
     fun sendsAndReducesStreamingEventsWithoutDuplicatingCompletion() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
+        advanceUntilIdle()
 
         viewModel.updateDraft("Hello from Android")
         viewModel.sendMessage()
@@ -85,6 +89,7 @@ class CelesteViewModelTest {
     fun interruptUsesOfficialRpcThenReconcilesAuthoritativeHistory() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
+        advanceUntilIdle()
         viewModel.updateDraft("Please do a long task")
         viewModel.sendMessage()
         gateway.emit("message.start")
@@ -111,6 +116,7 @@ class CelesteViewModelTest {
     fun reconnectResumesTheServerSnapshotAndNeverResendsAnUncertainPrompt() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
+        advanceUntilIdle()
         viewModel.updateDraft("Do this once")
         viewModel.sendMessage()
         gateway.emit("message.start")
@@ -185,18 +191,20 @@ class CelesteViewModelTest {
 
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
+        advanceUntilIdle()
         viewModel.loadSessions()
         advanceUntilIdle()
 
-        assertEquals(ConnectionPhase.ManualSetup, viewModel.state.value.connectionPhase)
+        assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
         assertNull(viewModel.state.value.sessions)
-        assertEquals("Hermes rejected profile access.", viewModel.state.value.errorMessage)
+        assertEquals(UiNotice.AuthenticationRequired, viewModel.state.value.notice)
     }
 
     @Test
     fun foregroundHealthCheckReplacesAStaleSocketAndResumes() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
+        advanceUntilIdle()
         gateway.failHealthCheck = true
 
         viewModel.onForeground()
@@ -214,6 +222,7 @@ class CelesteViewModelTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)
         val viewModel = openConversation(gateway, dashboard)
+        advanceUntilIdle()
         val callsBeforeDisconnect = dashboard.sessionListCalls
 
         gateway.disconnect("dashboard restarted")
@@ -257,7 +266,9 @@ class CelesteViewModelTest {
         )
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
+        advanceUntilIdle()
         viewModel.loadSessions()
+        advanceUntilIdle()
         viewModel.selectProfile("work")
 
         viewModel.createNewConversation()
@@ -305,6 +316,7 @@ class CelesteViewModelTest {
     fun profileSelectionChangesOnlyTheNextNewConversationProfile() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
 
         viewModel.selectProfile("work")
 
@@ -350,7 +362,7 @@ class CelesteViewModelTest {
         assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
         assertNull(viewModel.state.value.sessions)
         assertNull(viewModel.state.value.activeSummary)
-        assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
+        assertEquals(UiNotice.AuthenticationRequired, viewModel.state.value.notice)
         assertNull(store.load()?.secret)
         assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
         assertEquals(1, gateway.closeCount)
@@ -383,7 +395,7 @@ class CelesteViewModelTest {
         assertNull(viewModel.state.value.sessions)
         assertEquals(SessionCatalogStatus.NotReady, viewModel.state.value.sessionCatalog.phase)
         assertNull(viewModel.state.value.activeSummary)
-        assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
+        assertEquals(UiNotice.AuthenticationRequired, viewModel.state.value.notice)
         assertNull(store.load()?.secret)
         assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
         assertEquals(GatewayConnectionState.Closed, gateway.state.value)
@@ -419,7 +431,7 @@ class CelesteViewModelTest {
         assertEquals(ConnectionPhase.AuthenticationRequired, viewModel.state.value.connectionPhase)
         assertNull(viewModel.state.value.sessions)
         assertNull(viewModel.state.value.activeSummary)
-        assertEquals("Hermes needs sign-in.", viewModel.state.value.errorMessage)
+        assertEquals(UiNotice.AuthenticationRequired, viewModel.state.value.notice)
         assertNull(store.load()?.secret)
         assertFalse(store.load()?.descriptor?.autoLoginEnabled ?: true)
         assertEquals(GatewayConnectionState.Closed, gateway.state.value)
@@ -429,6 +441,7 @@ class CelesteViewModelTest {
     fun refreshFailureRetainsTheAuthoritativeWindowAsStale() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
         dashboard.sessionFailure = IOException("offline")
 
         viewModel.refreshSessionCatalog()
@@ -436,16 +449,21 @@ class CelesteViewModelTest {
 
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
         assertEquals(listOf("stored-42", "stored-work", "ambiguous-profile"), viewModel.state.value.sessions?.map(StoredSession::id))
-        assertEquals("offline", viewModel.state.value.sessionCatalog.errorMessage)
+        assertEquals(UiNotice.CatalogUnavailable, viewModel.state.value.sessionCatalog.notice)
     }
 
     @Test
     fun noResultsDoesNotMaskRefreshingOrStaleCatalogState() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
 
         viewModel.updateSessionQuery("does-not-exist")
         advanceUntilIdle()
+        mainDispatcher.scheduler.advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.sessionCatalog.status == SessionCatalogStatus.NoResults
+        }
         assertEquals(SessionCatalogStatus.NoResults, viewModel.state.value.sessionCatalog.status)
 
         dashboard.sessionFailure = IOException("offline")
@@ -460,10 +478,17 @@ class CelesteViewModelTest {
     fun obsoleteLoadedWindowSearchCannotReplaceTheLatestQuery() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
 
         viewModel.updateSessionQuery("work")
         viewModel.updateSessionQuery("shared")
         advanceUntilIdle()
+        mainDispatcher.scheduler.advanceUntilIdle()
+        viewModel.state.first { state ->
+            state.sessionQuery == "shared" &&
+                !state.sessionCatalog.queryInFlight &&
+                state.sessionCatalog.filteredRows.map(StoredSession::id) == listOf("stored-42")
+        }
 
         assertEquals("shared", viewModel.state.value.sessionQuery)
         assertEquals(listOf("stored-42"), viewModel.state.value.sessionCatalog.filteredRows.map(StoredSession::id))
@@ -473,12 +498,18 @@ class CelesteViewModelTest {
     fun creationProfileChangeDoesNotLeaveDebouncedUnscopedSearchInFlight() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
 
         viewModel.updateSessionQuery("work")
         assertTrue(viewModel.state.value.sessionCatalog.queryInFlight)
 
         viewModel.selectProfile("work")
         advanceUntilIdle()
+        mainDispatcher.scheduler.advanceUntilIdle()
+        viewModel.state.first { state ->
+            !state.sessionCatalog.queryInFlight &&
+                state.sessionCatalog.filteredRows.map(StoredSession::id) == listOf("stored-work")
+        }
 
         assertEquals("work", viewModel.state.value.selectedProfile)
         assertFalse(viewModel.state.value.sessionCatalog.queryInFlight)
@@ -492,6 +523,7 @@ class CelesteViewModelTest {
     fun creationProfileChangeDoesNotInvalidateAnInitialUnscopedCatalogLoad() = runTest {
         val dashboard = FakeDashboard(FakeGateway())
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
         viewModel.selectProfile("work")
 
         dashboard.sessionListGate = CompletableDeferred()
@@ -520,6 +552,7 @@ class CelesteViewModelTest {
         }
         val dashboard = FakeDashboard(gateway)
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
         val loadedRows = viewModel.state.value.sessionCatalog.rows
 
         viewModel.createNewConversation()
@@ -532,7 +565,10 @@ class CelesteViewModelTest {
 
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
         assertEquals(loadedRows, viewModel.state.value.sessionCatalog.rows)
-        assertEquals("new conversation unavailable", viewModel.state.value.sessionCatalog.errorMessage)
+        assertEquals(
+            UiNotice.NewConversationUnavailable,
+            viewModel.state.value.sessionCatalog.notice,
+        )
     }
 
     @Test
@@ -540,6 +576,7 @@ class CelesteViewModelTest {
         val gateway = FakeGateway().apply { omitStoredIdentity = true }
         val dashboard = FakeDashboard(gateway)
         val viewModel = connectedViewModel(dashboard)
+        advanceUntilIdle()
 
         viewModel.createNewConversation()
         advanceUntilIdle()
@@ -547,8 +584,8 @@ class CelesteViewModelTest {
         assertNull(viewModel.state.value.activeSummary)
         assertTrue(viewModel.state.value.sessions.orEmpty().none { it.id == "runtime-new-1" })
         assertEquals(
-            "Hermes created a conversation without a durable stored identity.",
-            viewModel.state.value.errorMessage,
+            UiNotice.NewConversationUnavailable,
+            viewModel.state.value.notice,
         )
         assertEquals(SessionCatalogStatus.Stale, viewModel.state.value.sessionCatalog.phase)
     }
@@ -566,6 +603,7 @@ class CelesteViewModelTest {
             createFailure = IOException("new conversation unavailable")
         }
         val viewModel = openConversation(gateway)
+        advanceUntilIdle()
         viewModel.updateDraft("Keep this unsent draft")
 
         viewModel.createNewConversation()
@@ -577,7 +615,7 @@ class CelesteViewModelTest {
             viewModel.state.value.messages.map(ConversationMessage::text),
         )
         assertEquals("Keep this unsent draft", viewModel.state.value.draft)
-        assertEquals("new conversation unavailable", viewModel.state.value.errorMessage)
+        assertEquals(UiNotice.NewConversationUnavailable, viewModel.state.value.notice)
         assertEquals(1, gateway.methods.count { it == "session.create" })
         viewModel.leaveConversation()
     }
@@ -592,7 +630,7 @@ class CelesteViewModelTest {
         assertEquals("and still arriving", suffix)
     }
 
-    private suspend fun openConversation(
+    private fun TestScope.openConversation(
         gateway: FakeGateway,
         dashboard: FakeDashboard = FakeDashboard(gateway),
     ): CelesteViewModel {
@@ -602,18 +640,22 @@ class CelesteViewModelTest {
         )
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
+        advanceUntilIdle()
         viewModel.loadSessions()
+        advanceUntilIdle()
         viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
         return viewModel
     }
 
-    private suspend fun connectedViewModel(dashboard: FakeDashboard): CelesteViewModel {
+    private fun TestScope.connectedViewModel(dashboard: FakeDashboard): CelesteViewModel {
         val viewModel = CelesteViewModel(
             dashboard = dashboard,
             reconnectDelayMillis = { _, _ -> 0L },
         )
         viewModel.updateDashboardUrl("http://hermes.test:9119")
         viewModel.findDashboard()
+        advanceUntilIdle()
         viewModel.loadSessions()
         advanceUntilIdle()
         return viewModel
@@ -687,6 +729,16 @@ class CelesteViewModelTest {
             sessionFailure?.let { throw it }
             return listOf(session, workSession, ambiguousProfileSession)
         }
+
+        override suspend fun listProfileSessions(
+            baseUrl: String,
+            credential: GatewayCredential,
+            profile: String,
+            limit: Int,
+        ): ProfileSessionList = ProfileSessionList(
+            sessions = listSessions(baseUrl, credential, limit),
+            profileOwnershipVerified = true,
+        )
 
         override suspend fun listProfiles(
             baseUrl: String,

--- a/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
@@ -20,8 +20,8 @@ class SessionCatalogTest {
     }
 
     @Test
-    fun allProfilesScopeKeepsServerOrderAndDeduplicatesRows() {
-        val scope = requireNotNull(SessionScope.allProfiles(origin))
+    fun profileScopeKeepsServerOrderAndDeduplicatesRows() {
+        val scope = requireNotNull(SessionScope.from(origin, "work"))
         val rows = listOf(
             row("work-first", profile = "work"),
             row("default-row"),
@@ -30,12 +30,12 @@ class SessionCatalogTest {
 
         val filtered = SessionCatalogReducer.filterAuthoritativeRows(scope, rows)
 
-        assertEquals(listOf("work-first", "default-row"), filtered.map(StoredSession::id))
+        assertEquals(listOf("work-first"), filtered.map(StoredSession::id))
     }
 
     @Test
     fun sessionScopeRejectsAKeyFromAnotherOrigin() {
-        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val scope = requireNotNull(SessionScope.from(origin, "work"))
         val foreignKey = requireNotNull(SessionKey.from("https://other.example", "work", "stored-1"))
 
         assertFalse(scope.accepts(foreignKey))
@@ -58,7 +58,7 @@ class SessionCatalogTest {
 
     @Test
     fun lateRequestCannotPublishAfterANewerRequestBegan() {
-        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val scope = requireNotNull(SessionScope.from(origin, "work"))
         val first = request(scope, requestGeneration = 1)
         val second = request(scope, requestGeneration = 2)
         val loading = SessionCatalogReducer.begin(SessionCatalogState(), first, refreshing = false)
@@ -73,7 +73,7 @@ class SessionCatalogTest {
 
     @Test
     fun refreshFailureRetainsRowsAsStaleButInitialFailureIsError() {
-        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val scope = requireNotNull(SessionScope.from(origin, "work"))
         val initialRequest = request(scope, requestGeneration = 1)
         val loading = SessionCatalogReducer.begin(SessionCatalogState(), initialRequest, refreshing = false)
         val initialFailure = SessionCatalogReducer.failed(loading, initialRequest, "offline")
@@ -91,6 +91,60 @@ class SessionCatalogTest {
 
         assertEquals(SessionCatalogStatus.Stale, stale.phase)
         assertEquals(listOf("known"), stale.rows.map(StoredSession::id))
+    }
+
+    @Test
+    fun lateResponseFromAnotherProfileCannotPublishIntoTheCurrentScope() {
+        val defaultScope = requireNotNull(SessionScope.from(origin, "default"))
+        val workScope = requireNotNull(SessionScope.from(origin, "work"))
+        val first = request(defaultScope, requestGeneration = 1)
+        val second = request(workScope, requestGeneration = 2)
+        val loading = SessionCatalogReducer.begin(SessionCatalogState(), first, refreshing = false)
+        val switching = SessionCatalogReducer.begin(loading, second, refreshing = false)
+
+        val published = SessionCatalogReducer.succeeded(
+            switching,
+            first,
+            listOf(row("late-default", profile = "default")),
+        )
+
+        assertEquals(switching, published)
+        assertEquals(workScope, published.scope)
+        assertTrue(published.rows.isEmpty())
+    }
+
+    @Test
+    fun reconnectingAndStaleStatesAreNotMaskedByNoResults() {
+        val scope = requireNotNull(SessionScope.from(origin, "default"))
+        val initial = request(scope, requestGeneration = 1)
+        val ready = SessionCatalogReducer.succeeded(
+            SessionCatalogReducer.begin(SessionCatalogState(), initial, refreshing = false),
+            initial,
+            listOf(row("known")),
+        ).withQuery("missing").withSearchResults("missing", emptyList())
+        val refreshingRequest = request(scope, requestGeneration = 2)
+        val refreshing = SessionCatalogReducer.begin(ready, refreshingRequest, refreshing = true)
+
+        assertEquals(SessionCatalogStatus.Refreshing, refreshing.status)
+        val stale = SessionCatalogReducer.failed(refreshing, refreshingRequest, "offline")
+        assertEquals(SessionCatalogStatus.Stale, stale.status)
+    }
+
+    @Test
+    fun reapplyingTheSameQueryDoesNotDiscardDebouncedResults() {
+        val scope = requireNotNull(SessionScope.from(origin, "default"))
+        val row = row("known", title = "Known conversation")
+        val state = SessionCatalogState(
+            phase = SessionCatalogStatus.Ready,
+            scope = scope,
+            rows = listOf(row),
+            query = "known",
+            queryResults = listOf(row),
+            queryInFlight = false,
+        )
+
+        assertEquals(state, state.withQuery("known"))
+        assertEquals(listOf("known"), state.withQuery("known").filteredRows.map(StoredSession::id))
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
@@ -20,17 +20,18 @@ class SessionCatalogTest {
     }
 
     @Test
-    fun profileScopeKeepsServerOrderAndDeduplicatesRows() {
+    fun unscopedCatalogKeepsServerOrderDeduplicatesRowsAndDropsAmbiguousProfiles() {
         val scope = requireNotNull(SessionScope.from(origin, "work"))
         val rows = listOf(
             row("work-first", profile = "work"),
             row("default-row"),
             row("work-first", profile = "work"),
+            row("ambiguous", profile = ""),
         )
 
         val filtered = SessionCatalogReducer.filterAuthoritativeRows(scope, rows)
 
-        assertEquals(listOf("work-first"), filtered.map(StoredSession::id))
+        assertEquals(listOf("work-first", "default-row"), filtered.map(StoredSession::id))
     }
 
     @Test
@@ -42,7 +43,7 @@ class SessionCatalogTest {
     }
 
     @Test
-    fun profileScopeExcludesForeignProfileWithoutReorderingMatches() {
+    fun unscopedCatalogKeepsKnownProfilesWithoutReorderingMatches() {
         val scope = requireNotNull(SessionScope.from(origin, "work"))
         val rows = listOf(
             row("work-first", profile = "work"),
@@ -51,7 +52,7 @@ class SessionCatalogTest {
         )
 
         assertEquals(
-            listOf("work-first", "work-second"),
+            listOf("work-first", "default-row", "work-second"),
             SessionCatalogReducer.filterAuthoritativeRows(scope, rows).map(StoredSession::id),
         )
     }
@@ -91,6 +92,26 @@ class SessionCatalogTest {
 
         assertEquals(SessionCatalogStatus.Stale, stale.phase)
         assertEquals(listOf("known"), stale.rows.map(StoredSession::id))
+    }
+
+    @Test
+    fun newConversationActionShowsProgressAndFailurePreservesTheLoadedWindow() {
+        val scope = requireNotNull(SessionScope.from(origin, "default"))
+        val request = request(scope, requestGeneration = 1)
+        val ready = SessionCatalogReducer.succeeded(
+            SessionCatalogReducer.begin(SessionCatalogState(), request, refreshing = false),
+            request,
+            listOf(row("known")),
+        )
+
+        val inFlight = SessionCatalogReducer.actionStarted(ready)
+        assertEquals(SessionCatalogStatus.ActionInFlight, inFlight.status)
+        assertEquals(listOf("known"), inFlight.rows.map(StoredSession::id))
+
+        val failed = SessionCatalogReducer.actionFailed(inFlight, "new conversation unavailable")
+        assertEquals(SessionCatalogStatus.Stale, failed.status)
+        assertEquals(listOf("known"), failed.rows.map(StoredSession::id))
+        assertEquals("new conversation unavailable", failed.errorMessage)
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
@@ -225,7 +225,6 @@ class SessionCatalogTest {
         SessionCatalogRequest(
             scope = scope,
             originGeneration = 1,
-            profileGeneration = 1,
             requestGeneration = requestGeneration,
             connectionAttempt = 1,
         )

--- a/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
@@ -93,18 +93,26 @@ class SessionCatalogTest {
         val scope = requireNotNull(SessionScope.from(origin, "work"))
         val initialRequest = request(scope, requestGeneration = 1)
         val loading = SessionCatalogReducer.begin(SessionCatalogState(), initialRequest, refreshing = false)
-        val initialFailure = SessionCatalogReducer.failed(loading, initialRequest, "offline")
+        val initialFailure = SessionCatalogReducer.failed(
+            loading,
+            initialRequest,
+            UiNotice.CatalogUnavailable,
+        )
         assertEquals(SessionCatalogStatus.Error, initialFailure.phase)
 
         val readyRequest = request(scope, requestGeneration = 2)
         val ready = SessionCatalogReducer.succeeded(
             SessionCatalogReducer.begin(initialFailure, readyRequest, refreshing = false),
             readyRequest,
-            listOf(row("known")),
+            listOf(row("known", profile = "work")),
         )
         val refreshRequest = request(scope, requestGeneration = 3)
         val refreshing = SessionCatalogReducer.begin(ready, refreshRequest, refreshing = true)
-        val stale = SessionCatalogReducer.failed(refreshing, refreshRequest, "offline")
+        val stale = SessionCatalogReducer.failed(
+            refreshing,
+            refreshRequest,
+            UiNotice.CatalogUnavailable,
+        )
 
         assertEquals(SessionCatalogStatus.Stale, stale.phase)
         assertEquals(listOf("known"), stale.rows.map(StoredSession::id))
@@ -124,10 +132,14 @@ class SessionCatalogTest {
         assertEquals(SessionCatalogStatus.ActionInFlight, inFlight.status)
         assertEquals(listOf("known"), inFlight.rows.map(StoredSession::id))
 
-        val failed = SessionCatalogReducer.actionFailed(inFlight, "new conversation unavailable")
+        val failed = SessionCatalogReducer.actionFailed(
+            inFlight,
+            UiNotice.NewConversationUnavailable,
+        )
         assertEquals(SessionCatalogStatus.Stale, failed.status)
         assertEquals(listOf("known"), failed.rows.map(StoredSession::id))
-        assertEquals("new conversation unavailable", failed.errorMessage)
+        assertEquals(UiNotice.NewConversationUnavailable, failed.notice)
+        assertEquals("Could not create a Hermes conversation.", failed.notice?.message)
     }
 
     @Test
@@ -163,7 +175,11 @@ class SessionCatalogTest {
         val refreshing = SessionCatalogReducer.begin(ready, refreshingRequest, refreshing = true)
 
         assertEquals(SessionCatalogStatus.Refreshing, refreshing.status)
-        val stale = SessionCatalogReducer.failed(refreshing, refreshingRequest, "offline")
+        val stale = SessionCatalogReducer.failed(
+            refreshing,
+            refreshingRequest,
+            UiNotice.CatalogUnavailable,
+        )
         assertEquals(SessionCatalogStatus.Stale, stale.status)
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
@@ -20,8 +20,8 @@ class SessionCatalogTest {
     }
 
     @Test
-    fun unscopedCatalogKeepsServerOrderDeduplicatesRowsAndDropsAmbiguousProfiles() {
-        val scope = requireNotNull(SessionScope.from(origin, "work"))
+    fun unscopedCatalogKeepsServerOrderDeduplicatesRowsAndRetainsUnknownOwnership() {
+        val scope = requireNotNull(SessionScope.unscoped(origin))
         val rows = listOf(
             row("work-first", profile = "work"),
             row("default-row"),
@@ -31,7 +31,8 @@ class SessionCatalogTest {
 
         val filtered = SessionCatalogReducer.filterAuthoritativeRows(scope, rows)
 
-        assertEquals(listOf("work-first", "default-row"), filtered.map(StoredSession::id))
+        assertEquals(listOf("work-first", "default-row", "ambiguous"), filtered.map(StoredSession::id))
+        assertEquals("", filtered.last().profile)
     }
 
     @Test
@@ -44,7 +45,7 @@ class SessionCatalogTest {
 
     @Test
     fun unscopedCatalogKeepsKnownProfilesWithoutReorderingMatches() {
-        val scope = requireNotNull(SessionScope.from(origin, "work"))
+        val scope = requireNotNull(SessionScope.unscoped(origin))
         val rows = listOf(
             row("work-first", profile = "work"),
             row("default-row"),
@@ -53,6 +54,21 @@ class SessionCatalogTest {
 
         assertEquals(
             listOf("work-first", "default-row", "work-second"),
+            SessionCatalogReducer.filterAuthoritativeRows(scope, rows).map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun profileScopedCatalogExcludesUnknownAndForeignOwnership() {
+        val scope = requireNotNull(SessionScope.from(origin, "work"))
+        val rows = listOf(
+            row("work-row", profile = "work"),
+            row("default-row", profile = "default"),
+            row("unknown-row", profile = ""),
+        )
+
+        assertEquals(
+            listOf("work-row"),
             SessionCatalogReducer.filterAuthoritativeRows(scope, rows).map(StoredSession::id),
         )
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/SessionCatalogTest.kt
@@ -1,0 +1,157 @@
+package dev.hazydreams.hermesceleste
+
+import dev.hazydreams.hermesceleste.network.StoredSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionCatalogTest {
+    private val origin = "https://hermes.example"
+
+    @Test
+    fun sessionKeyUsesNormalizedOriginProfileAndDurableIdOnly() {
+        val first = SessionKey.from("HTTPS://Hermes.Example/", " Work ", " stored-1 ")
+        val second = SessionKey.from("https://hermes.example", "work", "stored-1")
+
+        assertEquals(second, first)
+        assertEquals("stored-1", first?.durableId)
+        assertFalse(first?.durableId == "runtime-1")
+    }
+
+    @Test
+    fun allProfilesScopeKeepsServerOrderAndDeduplicatesRows() {
+        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val rows = listOf(
+            row("work-first", profile = "work"),
+            row("default-row"),
+            row("work-first", profile = "work"),
+        )
+
+        val filtered = SessionCatalogReducer.filterAuthoritativeRows(scope, rows)
+
+        assertEquals(listOf("work-first", "default-row"), filtered.map(StoredSession::id))
+    }
+
+    @Test
+    fun sessionScopeRejectsAKeyFromAnotherOrigin() {
+        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val foreignKey = requireNotNull(SessionKey.from("https://other.example", "work", "stored-1"))
+
+        assertFalse(scope.accepts(foreignKey))
+    }
+
+    @Test
+    fun profileScopeExcludesForeignProfileWithoutReorderingMatches() {
+        val scope = requireNotNull(SessionScope.from(origin, "work"))
+        val rows = listOf(
+            row("work-first", profile = "work"),
+            row("default-row"),
+            row("work-second", profile = "work"),
+        )
+
+        assertEquals(
+            listOf("work-first", "work-second"),
+            SessionCatalogReducer.filterAuthoritativeRows(scope, rows).map(StoredSession::id),
+        )
+    }
+
+    @Test
+    fun lateRequestCannotPublishAfterANewerRequestBegan() {
+        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val first = request(scope, requestGeneration = 1)
+        val second = request(scope, requestGeneration = 2)
+        val loading = SessionCatalogReducer.begin(SessionCatalogState(), first, refreshing = false)
+        val newer = SessionCatalogReducer.begin(loading, second, refreshing = false)
+
+        val published = SessionCatalogReducer.succeeded(newer, first, listOf(row("late")))
+
+        assertEquals(newer, published)
+        assertEquals(SessionCatalogStatus.Loading, published.phase)
+        assertTrue(published.rows.isEmpty())
+    }
+
+    @Test
+    fun refreshFailureRetainsRowsAsStaleButInitialFailureIsError() {
+        val scope = requireNotNull(SessionScope.allProfiles(origin))
+        val initialRequest = request(scope, requestGeneration = 1)
+        val loading = SessionCatalogReducer.begin(SessionCatalogState(), initialRequest, refreshing = false)
+        val initialFailure = SessionCatalogReducer.failed(loading, initialRequest, "offline")
+        assertEquals(SessionCatalogStatus.Error, initialFailure.phase)
+
+        val readyRequest = request(scope, requestGeneration = 2)
+        val ready = SessionCatalogReducer.succeeded(
+            SessionCatalogReducer.begin(initialFailure, readyRequest, refreshing = false),
+            readyRequest,
+            listOf(row("known")),
+        )
+        val refreshRequest = request(scope, requestGeneration = 3)
+        val refreshing = SessionCatalogReducer.begin(ready, refreshRequest, refreshing = true)
+        val stale = SessionCatalogReducer.failed(refreshing, refreshRequest, "offline")
+
+        assertEquals(SessionCatalogStatus.Stale, stale.phase)
+        assertEquals(listOf("known"), stale.rows.map(StoredSession::id))
+    }
+
+    @Test
+    fun loadedWindowSearchMatchesSafeFieldsWithoutChangingOrder() {
+        val rows = listOf(
+            row("first", title = "Build notes", preview = "Deploy the gateway", source = "desktop"),
+            row("second", title = "Unrelated", profile = "work", source = "cli"),
+            row("third", title = "Another"),
+        )
+
+        assertEquals(
+            listOf("first", "second"),
+            searchLoadedSessions(rows, "gateway").map(StoredSession::id) +
+                searchLoadedSessions(rows, "work").map(StoredSession::id),
+        )
+        assertEquals(rows, searchLoadedSessions(rows, ""))
+    }
+
+    @Test
+    fun aliasIndexResolvesOnlyWithinTheVerifiedScope() {
+        val work = requireNotNull(SessionScope.from(origin, "work"))
+        val default = requireNotNull(SessionScope.from(origin, "default"))
+        val workKey = requireNotNull(SessionKey.from(origin, "work", "stored-1"))
+        val defaultKey = requireNotNull(SessionKey.from(origin, "default", "stored-1"))
+        val aliases = SessionAliasIndex()
+        aliases.replace(
+            work,
+            listOf(VerifiedSessionIdentity(workKey, aliases = setOf("runtime-work"))),
+        )
+        aliases.replace(
+            default,
+            listOf(VerifiedSessionIdentity(defaultKey, aliases = setOf("runtime-default"))),
+        )
+
+        assertEquals(workKey, aliases.resolve(work, "runtime-work"))
+        assertEquals(defaultKey, aliases.resolve(default, "runtime-default"))
+        assertEquals(null, aliases.resolve(work, "runtime-default"))
+    }
+
+    private fun request(scope: SessionScope, requestGeneration: Long): SessionCatalogRequest =
+        SessionCatalogRequest(
+            scope = scope,
+            originGeneration = 1,
+            profileGeneration = 1,
+            requestGeneration = requestGeneration,
+            connectionAttempt = 1,
+        )
+
+    private fun row(
+        id: String,
+        title: String = id,
+        preview: String = "",
+        profile: String = "default",
+        source: String = "desktop",
+    ) = StoredSession(
+        id = id,
+        title = title,
+        preview = preview,
+        startedAt = 1.0,
+        messageCount = 1,
+        source = source,
+        profile = profile,
+    )
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -327,6 +327,7 @@ class DashboardClientTest {
             baseUrl = baseUrl,
             credential = GatewayCredential.StaticToken("private-token"),
             storedSessionId = "stored-42",
+            profile = "work",
         )
 
         assertEquals("runtime-7", resumed.runtimeSessionId)
@@ -351,6 +352,7 @@ class DashboardClientTest {
             baseUrl = baseUrl,
             credential = GatewayCredential.None,
             storedSessionId = "stored-42",
+            profile = "work",
         )
         val canonical = decodeGatewayMessages(Json.parseToJsonElement(transcript).jsonArray)
 
@@ -620,6 +622,10 @@ class DashboardClientTest {
                             "stored-42",
                             request["params"]?.jsonObject?.get("session_id")?.jsonPrimitive?.content,
                         )
+                        assertEquals(
+                            "work",
+                            request["params"]?.jsonObject?.get("profile")?.jsonPrimitive?.content,
+                        )
                         webSocket.send(
                             """{"jsonrpc":"2.0","id":"session-resume","result":{"session_id":"runtime-7","resumed":"stored-42","messages":$messages}}""",
                         )
@@ -681,7 +687,7 @@ class DashboardClientTest {
 
         suspend fun execute(client: DashboardClient, baseUrl: String): Any = when (this) {
             SessionList -> client.listSessions(baseUrl, GatewayCredential.None)
-            SessionResume -> client.resumeSession(baseUrl, GatewayCredential.None, "stored-42")
+            SessionResume -> client.resumeSession(baseUrl, GatewayCredential.None, "stored-42", "default")
         }
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -104,6 +104,7 @@ class DashboardClientTest {
         assertEquals("This conversation", sessions.first().title)
         assertEquals("desktop", sessions.first().source)
         assertEquals("work", sessions.first().profile)
+        assertEquals("", sessions[1].profile)
         val upgrade = server.takeRequest()
         assertEquals("/api/ws", upgrade.url.encodedPath)
         assertEquals("private-token", upgrade.url.queryParameter("token"))

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -92,7 +92,7 @@ class DashboardClientTest {
     }
 
     @Test
-    fun listsTheDashboardStoredSessionsOverJsonRpc() = runBlocking {
+    fun listsTheDashboardStoredSessionsOverJsonRpcAndDropsConflictingProfileIdentity() = runBlocking {
         server.enqueue(sessionListWebSocket())
 
         val sessions = DashboardClient().listSessions(
@@ -105,6 +105,7 @@ class DashboardClientTest {
         assertEquals("desktop", sessions.first().source)
         assertEquals("work", sessions.first().profile)
         assertEquals("", sessions[1].profile)
+        assertTrue(sessions.none { it.id == "conflicting-profile" })
         val upgrade = server.takeRequest()
         assertEquals("/api/ws", upgrade.url.encodedPath)
         assertEquals("private-token", upgrade.url.queryParameter("token"))
@@ -594,7 +595,7 @@ class DashboardClientTest {
                         val request = Json.parseToJsonElement(text).jsonObject
                         assertEquals("session.list", request["method"]?.jsonPrimitive?.content)
                         webSocket.send(
-                            """{"jsonrpc":"2.0","id":"session-list","result":{"sessions":[{"id":"s1","title":"This conversation","preview":"perfect. lets build that.","started_at":123.5,"message_count":42,"source":"desktop","profile_name":"work"},{"id":"s2","title":"Older chat","preview":"hello","started_at":100,"message_count":2,"source":"cli"}]}}""",
+                            """{"jsonrpc":"2.0","id":"session-list","result":{"sessions":[{"id":"s1","title":"This conversation","preview":"perfect. lets build that.","started_at":123.5,"message_count":42,"source":"desktop","profile_name":"work"},{"id":"s2","title":"Older chat","preview":"hello","started_at":100,"message_count":2,"source":"cli"},{"id":"conflicting-profile","title":"Conflicting profile","preview":"must not be shown","started_at":90,"message_count":1,"source":"desktop","profile":"default","profile_name":"work"}]}}""",
                         )
                     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -104,7 +104,7 @@ class HermesGatewayTest {
         val gateway = gateway()
         gateway.connect()
 
-        val resumed = gateway.resumeStoredSession("stored-42")
+        val resumed = gateway.resumeStoredSession("stored-42", "default")
         assertEquals("runtime-7", resumed.runtimeSessionId)
         assertTrue(resumed.running == false)
 
@@ -264,9 +264,15 @@ class HermesGatewayTest {
                         val request = Json.parseToJsonElement(text).jsonObject
                         val id = request["id"].toString()
                         when (request["method"]?.jsonPrimitive?.content) {
-                            "session.resume" -> webSocket.send(
-                                """{"jsonrpc":"2.0","id":$id,"result":{"session_id":"runtime-7","resumed":"stored-42","running":false,"status":"idle","inflight":null,"messages":[{"id":"u1","role":"user","text":"Earlier message"}]}}""",
-                            )
+                            "session.resume" -> {
+                                assertEquals(
+                                    "default",
+                                    request["params"]?.jsonObject?.get("profile")?.jsonPrimitive?.content,
+                                )
+                                webSocket.send(
+                                    """{"jsonrpc":"2.0","id":$id,"result":{"session_id":"runtime-7","resumed":"stored-42","running":false,"status":"idle","inflight":null,"messages":[{"id":"u1","role":"user","text":"Earlier message"}]}}""",
+                                )
+                            }
 
                             "prompt.submit" -> {
                                 webSocket.send(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/LiveHermesDashboardTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/LiveHermesDashboardTest.kt
@@ -29,9 +29,16 @@ class LiveHermesDashboardTest {
         val sessions = client.listSessions(probe.baseUrl, credential, limit = 10)
 
         assertTrue("The real Hermes state store returned no sessions", sessions.isNotEmpty())
-        val selected = sessions.first()
-        val resumed = client.resumeSession(probe.baseUrl, credential, selected.id)
-        assertEquals(selected.id, resumed.storedSessionId)
+        val selected = sessions.firstOrNull { it.profile.isNotBlank() }
+        assumeTrue("The real Hermes session list did not identify a profile", selected != null)
+        val verifiedSession = requireNotNull(selected)
+        val resumed = client.resumeSession(
+            probe.baseUrl,
+            credential,
+            verifiedSession.id,
+            verifiedSession.profile,
+        )
+        assertEquals(verifiedSession.id, resumed.storedSessionId)
         assertTrue(resumed.runtimeSessionId.isNotBlank())
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
@@ -1,0 +1,62 @@
+package dev.hazydreams.hermesceleste.ui
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Focused source checks for the browser's accessibility and navigation contract.
+ * The JVM test source set has no Compose semantics runtime, so these assertions
+ * keep the high-risk labels and roles from disappearing during UI refactors.
+ */
+class ConversationBrowserSourceTest {
+    @Test
+    fun sessionRowsKeepStableIdentityAndButtonSemantics() {
+        val source = mainSource("ui/sessions/SessionListScreen.kt")
+
+        assertContains(source, ".clickable(enabled = enabled, role = Role.Button")
+        assertContains(source, ".semantics(mergeDescendants = true)")
+        assertContains(source, "role = Role.Button")
+        assertContains(source, """contentDescription = "${'$'}title. ${'$'}metadata. Open conversation.""")
+        assertContains(source, "sessionRowKey(session, catalog.scope?.originKey.orEmpty())")
+        assertContains(source, "${'$'}originKey\\u0000${'$'}{session.profile.trim().lowercase(Locale.ROOT)}\\u0000${'$'}{session.id.trim()}")
+    }
+
+    @Test
+    fun browserControlsDescribeLoadedSearchRefreshAndCreationScope() {
+        val source = mainSource("ui/sessions/SessionListScreen.kt")
+
+        assertContains(source, "New conversation profile:")
+        assertContains(source, "This does not filter the loaded conversation list.")
+        assertContains(source, "Search loaded conversations")
+        assertContains(source, "Search is limited to loaded conversations.")
+        assertContains(source, "Refresh conversations")
+        assertContains(source, "Retry conversation connection")
+    }
+
+    @Test
+    fun chatAndRoutesExposeExplicitBrowserOpenAndBackSemantics() {
+        val conversationSource = mainSource("ui/conversation/ConversationScreen.kt")
+        val routesSource = mainSource("ui/CelesteRoutes.kt")
+
+        assertContains(conversationSource, "onOpenBrowser: () -> Unit")
+        assertContains(conversationSource, "Text(\"Conversations\"")
+        assertContains(routesSource, "CelesteDestination.Conversations")
+        assertContains(routesSource, "viewModel.openConversationBrowser()")
+        assertContains(routesSource, "viewModel.closeConversationBrowser()")
+        assertContains(routesSource, "BackHandler { closeBrowser() }")
+    }
+
+    private fun assertContains(source: String, expected: String) {
+        assertTrue("Expected UI source to contain: $expected", source.contains(expected))
+    }
+
+    private fun mainSource(relativePath: String): String {
+        val candidates = listOf(
+            File("app/src/main/java/dev/hazydreams/hermesceleste/$relativePath"),
+            File("src/main/java/dev/hazydreams/hermesceleste/$relativePath"),
+        )
+        return candidates.firstOrNull(File::isFile)?.readText()
+            ?: error("Could not locate main source $relativePath")
+    }
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
@@ -27,7 +27,8 @@ class ConversationBrowserSourceTest {
         val source = mainSource("ui/sessions/SessionListScreen.kt")
 
         assertContains(source, "New conversation profile:")
-        assertContains(source, "This does not filter the loaded conversation list.")
+        assertContains(source, "This also scopes the loaded conversation window")
+        assertContains(source, "Profile scope:")
         assertContains(source, "Search loaded conversations")
         assertContains(source, "Search is limited to loaded conversations.")
         assertContains(source, "Refresh conversations")
@@ -45,6 +46,20 @@ class ConversationBrowserSourceTest {
         assertContains(routesSource, "viewModel.openConversationBrowser()")
         assertContains(routesSource, "viewModel.closeConversationBrowser()")
         assertContains(routesSource, "BackHandler { closeBrowser() }")
+        assertContains(routesSource, "ConnectionPhase.LoadingSessions")
+    }
+
+    @Test
+    fun rowsExposeSelectedAndRunningStateToAccessibility() {
+        val source = mainSource("ui/sessions/SessionListScreen.kt")
+
+        assertContains(source, "activeSession: StoredSession? = null")
+        assertContains(source, "activeSessionRunning: Boolean = false")
+        assertContains(source, "selected = selectedKey != null")
+        assertContains(source, "running = activeSessionRunning")
+        assertContains(source, "selected = selected")
+        assertContains(source, "Open and selected")
+        assertContains(source, "Open and running")
     }
 
     private fun assertContains(source: String, expected: String) {

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
@@ -62,7 +62,7 @@ class ConversationBrowserSourceTest {
         assertContains(source, "selected = selectedKey != null")
         assertContains(source, "running = activeSessionRunning")
         assertContains(source, "sessionRowSemantics(")
-        assertContains(source, "selected = semantics.selected")
+        assertContains(source, "this.selected = rowSemantics.selected")
         assertContains(source, "Open and selected")
         assertContains(source, "Open and running")
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
@@ -17,9 +17,8 @@ class ConversationBrowserSourceTest {
         assertContains(source, ".clickable(enabled = enabled, role = Role.Button")
         assertContains(source, ".semantics(mergeDescendants = true)")
         assertContains(source, "role = Role.Button")
-        assertContains(source, """contentDescription = "${'$'}title. ${'$'}metadata. Open conversation.""")
-        assertContains(source, "sessionRowKey(session, catalog.scope?.originKey.orEmpty())")
-        assertContains(source, "${'$'}originKey\\u0000${'$'}{session.profile.trim().lowercase(Locale.ROOT)}\\u0000${'$'}{session.id.trim()}")
+        assertContains(source, "Cannot open conversation: profile ownership is unavailable.")
+        assertContains(source, "session.catalogRowKey(originKey)")
     }
 
     @Test
@@ -34,6 +33,9 @@ class ConversationBrowserSourceTest {
         assertContains(source, "Refresh conversations")
         assertContains(source, "Retry conversation connection")
         assertContains(source, "SessionCatalogStatus.ActionInFlight")
+        assertContains(source, "SessionCatalogStatus.Opening")
+        assertContains(source, "onCancelOpening")
+        assertContains(source, "announce = true")
         assertContains(source, "loadingMessage != null")
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/ConversationBrowserSourceTest.kt
@@ -5,9 +5,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Focused source checks for the browser's accessibility and navigation contract.
- * The JVM test source set has no Compose semantics runtime, so these assertions
- * keep the high-risk labels and roles from disappearing during UI refactors.
+ * Focused source guards for the browser's accessibility and navigation contract.
+ * SessionListSemanticsTest covers the executable row/state projection; these
+ * assertions keep the Compose wiring and high-risk labels from disappearing.
  */
 class ConversationBrowserSourceTest {
     @Test
@@ -27,12 +27,14 @@ class ConversationBrowserSourceTest {
         val source = mainSource("ui/sessions/SessionListScreen.kt")
 
         assertContains(source, "New conversation profile:")
-        assertContains(source, "This also scopes the loaded conversation window")
-        assertContains(source, "Profile scope:")
+        assertContains(source, "This does not filter the loaded conversation list.")
+        assertContains(source, "all loaded profiles")
         assertContains(source, "Search loaded conversations")
         assertContains(source, "Search is limited to loaded conversations.")
         assertContains(source, "Refresh conversations")
         assertContains(source, "Retry conversation connection")
+        assertContains(source, "SessionCatalogStatus.ActionInFlight")
+        assertContains(source, "loadingMessage != null")
     }
 
     @Test
@@ -57,7 +59,8 @@ class ConversationBrowserSourceTest {
         assertContains(source, "activeSessionRunning: Boolean = false")
         assertContains(source, "selected = selectedKey != null")
         assertContains(source, "running = activeSessionRunning")
-        assertContains(source, "selected = selected")
+        assertContains(source, "sessionRowSemantics(")
+        assertContains(source, "selected = semantics.selected")
         assertContains(source, "Open and selected")
         assertContains(source, "Open and running")
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
@@ -46,6 +46,21 @@ class SessionListSemanticsTest {
     }
 
     @Test
+    fun unknownProfileRowIsVisibleButNotOpenable() {
+        val semantics = sessionRowSemantics(
+            session = session(profile = ""),
+            showProfile = true,
+            enabled = false,
+            selected = false,
+            running = false,
+        )
+
+        assertEquals("Unavailable: profile ownership unavailable", semantics.stateDescription)
+        assertTrue(semantics.contentDescription.contains("profile unavailable"))
+        assertTrue(semantics.contentDescription.contains("Cannot open conversation"))
+    }
+
+    @Test
     fun catalogPresentationKeepsLoadingRefreshNoResultsAndStaleDistinct() {
         val scope = requireNotNull(SessionScope.from("https://hermes.example", "default"))
         val firstRequest = request(scope, 1)
@@ -68,14 +83,14 @@ class SessionListSemanticsTest {
         assertEquals(SessionCatalogStatus.Stale, stale.status)
     }
 
-    private fun session() = StoredSession(
+    private fun session(profile: String = "work") = StoredSession(
         id = "stored-42",
         title = "Shared conversation",
         preview = "Synthetic preview",
         startedAt = 1.0,
         messageCount = 3,
         source = "desktop",
-        profile = "work",
+        profile = profile,
     )
 
     private fun request(scope: SessionScope, generation: Long) = SessionCatalogRequest(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
@@ -1,0 +1,88 @@
+package dev.hazydreams.hermesceleste.ui
+
+import dev.hazydreams.hermesceleste.SessionCatalogReducer
+import dev.hazydreams.hermesceleste.SessionCatalogRequest
+import dev.hazydreams.hermesceleste.SessionCatalogState
+import dev.hazydreams.hermesceleste.SessionCatalogStatus
+import dev.hazydreams.hermesceleste.SessionScope
+import dev.hazydreams.hermesceleste.network.StoredSession
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionListSemanticsTest {
+    @Test
+    fun selectedRunningRowExposesItsStateAndStableDescription() {
+        val semantics = sessionRowSemantics(
+            session = session(),
+            showProfile = true,
+            enabled = true,
+            selected = true,
+            running = true,
+        )
+
+        assertTrue(semantics.selected)
+        assertEquals("Open and running", semantics.stateDescription)
+        assertTrue(semantics.contentDescription.contains("Shared conversation"))
+        assertTrue(semantics.contentDescription.contains("work"))
+        assertTrue(semantics.contentDescription.contains("open"))
+        assertTrue(semantics.contentDescription.contains("running"))
+    }
+
+    @Test
+    fun unavailableRowAnnouncesDisabledState() {
+        val semantics = sessionRowSemantics(
+            session = session(),
+            showProfile = true,
+            enabled = false,
+            selected = false,
+            running = false,
+        )
+
+        assertFalse(semantics.selected)
+        assertEquals("Unavailable", semantics.stateDescription)
+        assertTrue(semantics.contentDescription.endsWith("Open conversation."))
+    }
+
+    @Test
+    fun catalogPresentationKeepsLoadingRefreshNoResultsAndStaleDistinct() {
+        val scope = requireNotNull(SessionScope.from("https://hermes.example", "default"))
+        val firstRequest = request(scope, 1)
+        val loading = SessionCatalogReducer.begin(SessionCatalogState(), firstRequest, refreshing = false)
+        assertEquals(SessionCatalogStatus.Loading, loading.status)
+
+        val ready = SessionCatalogReducer.succeeded(
+            loading,
+            firstRequest,
+            listOf(session()),
+        )
+        val noResults = ready.withQuery("missing").withSearchResults("missing", emptyList())
+        assertEquals(SessionCatalogStatus.NoResults, noResults.status)
+
+        val refreshRequest = request(scope, 2)
+        val refreshing = SessionCatalogReducer.begin(ready, refreshRequest, refreshing = true)
+        assertEquals(SessionCatalogStatus.Refreshing, refreshing.status)
+
+        val stale = SessionCatalogReducer.failed(refreshing, refreshRequest, "offline")
+        assertEquals(SessionCatalogStatus.Stale, stale.status)
+    }
+
+    private fun session() = StoredSession(
+        id = "stored-42",
+        title = "Shared conversation",
+        preview = "Synthetic preview",
+        startedAt = 1.0,
+        messageCount = 3,
+        source = "desktop",
+        profile = "work",
+    )
+
+    private fun request(scope: SessionScope, generation: Long) = SessionCatalogRequest(
+        scope = scope,
+        originGeneration = 1,
+        profileGeneration = 1,
+        requestGeneration = generation,
+        connectionAttempt = 1,
+    )
+}

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
@@ -5,7 +5,9 @@ import dev.hazydreams.hermesceleste.SessionCatalogRequest
 import dev.hazydreams.hermesceleste.SessionCatalogState
 import dev.hazydreams.hermesceleste.SessionCatalogStatus
 import dev.hazydreams.hermesceleste.SessionScope
+import dev.hazydreams.hermesceleste.UiNotice
 import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.ui.sessions.sessionRowSemantics
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -70,7 +72,7 @@ class SessionListSemanticsTest {
         val ready = SessionCatalogReducer.succeeded(
             loading,
             firstRequest,
-            listOf(session()),
+            listOf(session(profile = "default")),
         )
         val noResults = ready.withQuery("missing").withSearchResults("missing", emptyList())
         assertEquals(SessionCatalogStatus.NoResults, noResults.status)
@@ -79,7 +81,11 @@ class SessionListSemanticsTest {
         val refreshing = SessionCatalogReducer.begin(ready, refreshRequest, refreshing = true)
         assertEquals(SessionCatalogStatus.Refreshing, refreshing.status)
 
-        val stale = SessionCatalogReducer.failed(refreshing, refreshRequest, "offline")
+        val stale = SessionCatalogReducer.failed(
+            refreshing,
+            refreshRequest,
+            UiNotice.CatalogUnavailable,
+        )
         assertEquals(SessionCatalogStatus.Stale, stale.status)
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ui/SessionListSemanticsTest.kt
@@ -96,7 +96,6 @@ class SessionListSemanticsTest {
     private fun request(scope: SessionScope, generation: Long) = SessionCatalogRequest(
         scope = scope,
         originGeneration = 1,
-        profileGeneration = 1,
         requestGeneration = generation,
         connectionAttempt = 1,
     )


### PR DESCRIPTION
## Summary

- use authoritative Hermes REST profile-session catalog data for conversation ownership and resume identity
- keep legacy WebSocket `session.list` only as a 404 fallback; ownership-unknown rows remain visible but cannot be opened
- preserve composite profile/session identity across search, selection, reconnect, rollback, foreground health checks, send, and interrupt paths
- reconcile buffered events before restoring a previous conversation and route authentication failures through reusable-auth invalidation and gateway closure
- replace raw error strings with typed fixed-copy notices and maintain accessible conversation-row semantics

## Host validation

- `testDebugUnitTest`: 93 tests, 0 failures, 0 errors, 1 skipped
- `lintDebug`: `BUILD SUCCESSFUL`
- `git diff --check origin/main...HEAD`: passed
- branch diff contains no milestone specs, accepted screenshot PNGs, APKs, or `AGENTS.md` changes

## Pending validation

- Android instrumentation and accessibility verification
- owner review of screenshot references; no accepted PNG was changed
- physical-device runtime validation
- GitHub Actions / APK validation
