### PR TITLE
ci: add Dependabot maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      gradle-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions-minor-and-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ scripts/celeste-env ./gradlew --no-daemon validateDebugScreenshotTest
 
 Use [`testing.md`](testing.md) to select the checks required for a change. GitHub Actions owns APK assembly and test-build signing; do not create distributable APKs locally.
 
-GitHub Actions uses the checked-in Gradle wrapper directly on a standard Ubuntu runner. Workflow actions must be limited to necessary official actions and pinned to immutable commit SHAs. The CI and current-test-APK behavior is defined in [`testing.md`](testing.md).
+GitHub Actions uses the checked-in Gradle wrapper directly on a standard Ubuntu runner. Workflow actions must be limited to necessary official actions and pinned to immutable commit SHAs. Dependabot checks Gradle and GitHub Actions weekly, groups minor and patch updates per ecosystem, and leaves major updates isolated for review. The CI and current-test-APK behavior is defined in [`testing.md`](testing.md).
 
 ## Change workflow
 


### PR DESCRIPTION
## Summary
- check Gradle and GitHub Actions dependencies every Monday
- group minor and patch updates while keeping majors isolated
- cap routine version-update PRs at two per ecosystem
- use conventional dependency commit titles and the `dependencies` label

Dependabot vulnerability alerts were already enabled. Dependabot security-update PRs are now enabled at the repository level.

## Validation
- SchemaStore Dependabot v2 schema validation
- policy assertions for ecosystems, schedule, groups, labels, and PR limits
- `git diff --check`