### PR TITLE
ci: add informational Codecov coverage

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,8 +38,8 @@ jobs:
             "platforms;android-37.0" \
             "build-tools;37.0.0"
 
-      - name: Run unit tests and lint
-        run: ./gradlew --no-daemon testDebugUnitTest lintDebug
+      - name: Run unit tests, coverage, and lint
+        run: ./gradlew --no-daemon testDebugUnitTest :app:koverXmlReportDebug lintDebug
 
       - name: Validate Compose screenshots
         run: ./gradlew --no-daemon validateDebugScreenshotTest
@@ -46,6 +47,16 @@ jobs:
       - name: Verify debug packaging on pull requests
         if: github.event_name == 'pull_request'
         run: ./gradlew --no-daemon assembleDebug
+
+      - name: Upload unit coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          disable_search: true
+          fail_ci_if_error: false
+          files: app/build/reports/kover/reportDebug.xml
+          flags: unit
+          name: android-unit
+          use_oidc: true
 
   publish-test-apk:
     name: Publish latest test APK

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,6 +49,7 @@ jobs:
         run: ./gradlew --no-daemon assembleDebug
 
       - name: Upload unit coverage to Codecov
+        if: ${{ !cancelled() && hashFiles('app/build/reports/kover/reportDebug.xml') != '' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           disable_search: true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.compose.screenshot")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 val testKeystorePath = providers.environmentVariable("CELESTE_TEST_KEYSTORE_PATH").orNull

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     id("com.android.compose.screenshot") version "0.0.1-alpha16" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.4.10" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.9.9" apply false
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ coverage:
 
 comment:
   behavior: default
+  hide_project_coverage: false
   require_changes: false
   require_base: false
   require_head: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+github_checks:
+  annotations: false

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,6 +87,8 @@ Base-path-prefixed dashboard routing is supported in source but does not yet hav
 
 `.github/workflows/android.yml` runs the repository checks on pull requests. Pull requests must pass unit tests, lint, screenshot validation, and debug APK assembly without publishing an artifact.
 
+The `Verify` job generates `app/build/reports/kover/reportDebug.xml` from local JVM unit tests and uploads it to Codecov using GitHub OIDC. Codecov project and patch statuses are informational, and its pull-request comment is the primary coverage summary; coverage does not gate merges. The report includes the full application source, including Compose UI, but Kover does not measure screenshot or device execution.
+
 A successful `main` run, including a manually dispatched run, publishes `Hermes-Celeste-latest.apk` as the current test build. The workflow uploads the new APK before deleting older artifacts with the same name, then verifies that exactly one remains. A failed build cannot remove the last known-good package. GitHub requires artifacts to expire; the current APK uses the maximum 90-day retention and requires GitHub sign-in to download.
 
 The test APK is a debug build signed with a dedicated test-only identity, not a release or store artifact. Install it only for project testing. Each successful build uses the same application ID and test signing identity so Android can update-install it over an earlier GitHub Actions build while preserving application data. A locally built debug APK has a different signing identity and cannot update a GitHub-built installation.


### PR DESCRIPTION
## Summary
- generate debug host-unit coverage with Kover 0.9.9
- upload the explicit XML report to Codecov through GitHub OIDC
- keep project and patch coverage statuses informational
- post an updating coverage summary directly on pull requests
- retain the full source surface, including Compose UI, without a merge threshold

## Validation
- `testDebugUnitTest :app:koverXmlReportDebug lintDebug`
- `validateDebugScreenshotTest`
- Codecov configuration validator
- workflow and policy assertions
- `git diff --check`
- GitHub OIDC upload processed successfully by Codecov
- `codecov/patch` check and Codecov PR comment created

The raw Kover XML line counter is 45.26%. Codecov normalizes partially covered lines separately and currently displays 35.98%. No `CODECOV_TOKEN` secret is required.