### PR TITLE
ci: show project coverage in PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,10 @@ coverage:
   status:
     project:
       default:
+        base: auto
         informational: true
+        target: auto
+        threshold: "0%"
     patch:
       default:
         informational: true
@@ -10,6 +13,7 @@ coverage:
 comment:
   behavior: default
   hide_project_coverage: false
+  layout: "diff, flags, files"
   require_changes: false
   require_base: false
   require_head: true

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,7 +87,7 @@ Base-path-prefixed dashboard routing is supported in source but does not yet hav
 
 `.github/workflows/android.yml` runs the repository checks on pull requests. Pull requests must pass unit tests, lint, screenshot validation, and debug APK assembly without publishing an artifact.
 
-The `Verify` job generates `app/build/reports/kover/reportDebug.xml` from local JVM unit tests and uploads it to Codecov using GitHub OIDC. Codecov project and patch statuses are informational, and its pull-request comment is the primary coverage summary; coverage does not gate merges. The report includes the full application source, including Compose UI, but Kover does not measure screenshot or device execution.
+The `Verify` job generates `app/build/reports/kover/reportDebug.xml` from local JVM unit tests and uploads it to Codecov using GitHub OIDC. Codecov project and patch statuses are informational, and its pull-request comment includes both project and patch coverage as the primary summary; coverage does not gate merges. The report includes the full application source, including Compose UI, but Kover does not measure screenshot or device execution.
 
 A successful `main` run, including a manually dispatched run, publishes `Hermes-Celeste-latest.apk` as the current test build. The workflow uploads the new APK before deleting older artifacts with the same name, then verifies that exactly one remains. A failed build cannot remove the last known-good package. GitHub requires artifacts to expire; the current APK uses the maximum 90-day retention and requires GitHub sign-in to download.
 


### PR DESCRIPTION
## Summary
- configure the informational `codecov/project` comparison explicitly
- include overall project coverage alongside patch coverage in PR comments
- keep all coverage statuses non-blocking

## Validation
- Codecov configuration validator
- project status and comment-layout assertions
- `git diff --check`