### PR TITLE
build: run Celeste tooling on JDK 21

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,9 @@ scripts/celeste-env ./gradlew --no-daemon tasks
 
 Use the checked-in Gradle wrapper, not a system Gradle installation. Keep `distributionSha256Sum` pinned in `gradle/wrapper/gradle-wrapper.properties`.
 
-The project currently uses Java 17, a single Android `:app` module, Kotlin, Jetpack Compose, kotlinx.serialization, coroutines, and OkHttp. Build versions and dependency coordinates belong in Gradle files, not this document. No iOS target is configured yet.
+Gradle and the Compose screenshot host require JDK 21 or newer. The project toolchain and GitHub Actions use Temurin 21, while Android source and emitted bytecode remain targeted to Java 17. A newer build host does not authorize Java 21 application APIs or a higher Android runtime requirement.
+
+The project currently uses a single Android `:app` module, Kotlin, Jetpack Compose, kotlinx.serialization, coroutines, and OkHttp. Build versions and dependency coordinates belong in Gradle files, not this document. No iOS target is configured yet.
 
 ## Portability boundary
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,13 @@ pluginManagement {
     }
 }
 
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+    throw GradleException(
+        "Celeste requires JDK 21 or newer to run Gradle; " +
+            "use scripts/celeste-env (current JVM: ${JavaVersion.current()}).",
+    )
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## Summary
- run both GitHub Actions jobs on Temurin 21
- fail early with an actionable message when Gradle launches below JDK 21
- document the JDK 21 build host while retaining Java 17 Android source and bytecode targets

## Verification
- `scripts/celeste-env ./gradlew --no-daemon help` passes on pinned Temurin 21.0.12+8
- launching the wrapper on the preserved Temurin 17 toolchain fails with the intended JDK 21 message
- `testDebugUnitTest` passed under JDK 21
- `lintDebug` passed under JDK 21
- `validateDebugScreenshotTest` passed under JDK 21
- `git diff --check` passed

GitHub Actions remains authoritative for APK assembly and the complete PR matrix.

## Scope
- Android source and bytecode targets remain Java 17
- no Markdown dependency versions changed
- no screenshot references changed

Part of #37.
