### PR TITLE
build: upgrade Markdown renderer to 0.43.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.11.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.11.0")
     implementation("com.squareup.okhttp3:okhttp")
-    implementation("com.mikepenz:multiplatform-markdown-renderer-m3:0.39.0")
+    implementation("com.mikepenz:multiplatform-markdown-renderer-m3:0.43.0")
     implementation("org.jetbrains:markdown:0.7.5")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")


### PR DESCRIPTION
## Summary
- upgrade `multiplatform-markdown-renderer-m3` from `0.39.0` to `0.43.0`
- keep `org.jetbrains:markdown` pinned at `0.7.5` so renderer compatibility is validated independently

## Verification
- focused rich-Markdown contract tests pass
- full unit suite passes
- Android lint passes
- all Compose screenshot references validate without changes
- dependency resolution succeeds
- `git diff --check` passes

## Scope
- no screenshot references changed
- no parser dependency changed
- no application behavior or UI code changed

Part of #37.
