### PR TITLE
build: upgrade JetBrains Markdown parser to 0.7.8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.11.0")
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.mikepenz:multiplatform-markdown-renderer-m3:0.43.0")
-    implementation("org.jetbrains:markdown:0.7.5")
+    implementation("org.jetbrains:markdown:0.7.8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/RichMarkdownContractTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/RichMarkdownContractTest.kt
@@ -8,6 +8,7 @@ import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.CancellationToken
 import org.intellij.markdown.parser.EmptyStreamingMarkdownFile
 import org.intellij.markdown.parser.MarkdownParser
 import org.junit.Assert.assertEquals
@@ -19,7 +20,7 @@ import org.junit.Test
 class RichMarkdownContractTest {
     @Test
     fun parsesTheSupportedGitHubFlavoredMarkdownBlocks() {
-        val markdown = """
+        val markdown: CharSequence = """
             # Heading
 
             Paragraph with **strong**, *emphasis*, ~~strikethrough~~, [link](https://example.com), and `inline code`.
@@ -44,7 +45,7 @@ class RichMarkdownContractTest {
             | Ready | Tested |
         """.trimIndent()
 
-        val nodeTypes = MarkdownParser(GFMFlavourDescriptor())
+        val nodeTypes = MarkdownParser(GFMFlavourDescriptor(), cancellationToken = CancellationToken.NonCancellable)
             .buildMarkdownTreeFromString(markdown)
             .walk()
             .map(ASTNode::type)
@@ -95,8 +96,9 @@ class RichMarkdownContractTest {
 
     @Test
     fun malformedMarkdownStillProducesAReadableSourceRange() {
-        val source = "Before **unfinished emphasis\n\n[broken link](https://example.com\n\n```kotlin\nval answer = 42"
-        val root = MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(source)
+        val source: CharSequence = "Before **unfinished emphasis\n\n[broken link](https://example.com\n\n```kotlin\nval answer = 42"
+        val root = MarkdownParser(GFMFlavourDescriptor(), cancellationToken = CancellationToken.NonCancellable)
+            .buildMarkdownTreeFromString(source)
 
         assertTrue(root.children.isNotEmpty())
         assertEquals(0, root.startOffset)


### PR DESCRIPTION
## Summary
- upgrade `org.jetbrains:markdown` from `0.7.5` to `0.7.8`
- adopt the parser’s non-deprecated `CancellationToken` constructor and `CharSequence` parsing overload in contract tests
- retain the already-merged Markdown renderer `0.43.0`

## Verification
- focused rich-Markdown contract tests pass
- full unit suite passes
- Android lint passes
- all Compose screenshot references validate without changes
- dependency insight selects `org.jetbrains:markdown:0.7.8`
- `git diff --check` passes
- independent review found no correctness or scope issues

## Scope
- production UI and behavior are unchanged
- no screenshot references changed
- test cleanup is limited to APIs deprecated by parser `0.7.8`

Part of #37.
