### PR TITLE
Refactor session drawer composition

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionDrawerConversationList.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionDrawerConversationList.kt
@@ -1,0 +1,351 @@
+package dev.hazydreams.hermesceleste.ui.sessions
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.hazydreams.hermesceleste.network.StoredSession
+import dev.hazydreams.hermesceleste.ui.CelesteAccent
+import dev.hazydreams.hermesceleste.ui.CelesteError
+import dev.hazydreams.hermesceleste.ui.CelestePanel
+import dev.hazydreams.hermesceleste.ui.CelesteSurfaceSelected
+import dev.hazydreams.hermesceleste.ui.CelesteTextMuted
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+@Composable
+internal fun SessionDrawerConversationList(
+    sessions: List<StoredSession>,
+    selectedSessionId: String?,
+    enabled: Boolean,
+    showProfile: Boolean,
+    hasMoreSessions: Boolean,
+    isLoadingMoreSessions: Boolean,
+    sessionPageError: String?,
+    searchQuery: String,
+    searchResults: List<StoredSession>,
+    isSearchingSessions: Boolean,
+    sessionSearchError: String?,
+    onSessionSelected: (StoredSession) -> Unit,
+    onLoadMoreSessions: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var pinnedExpanded by rememberSaveable { mutableStateOf(true) }
+    var recentsExpanded by rememberSaveable { mutableStateOf(true) }
+    var scheduledExpanded by rememberSaveable { mutableStateOf(true) }
+    val sections = sessions.toSessionSections()
+    val searchActive = searchQuery.isNotBlank()
+    val listState = rememberLazyListState()
+    val focusManager = LocalFocusManager.current
+    val currentLoadMore by rememberUpdatedState(onLoadMoreSessions)
+
+    LaunchedEffect(
+        listState,
+        enabled,
+        hasMoreSessions,
+        isLoadingMoreSessions,
+        sessionPageError,
+        sessions.size,
+        searchActive,
+    ) {
+        snapshotFlow {
+            shouldRequestNextSessionPage(
+                isScrollInProgress = listState.isScrollInProgress,
+                lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1,
+                totalItemCount = listState.layoutInfo.totalItemsCount,
+                enabled = enabled && !searchActive,
+                hasMoreSessions = hasMoreSessions,
+                isLoadingMoreSessions = isLoadingMoreSessions,
+                hasPageError = sessionPageError != null,
+            )
+        }.distinctUntilChanged().collect { shouldLoad ->
+            if (shouldLoad) currentLoadMore()
+        }
+    }
+
+    if (sessions.isEmpty() && !searchActive) {
+        Column(
+            modifier = modifier.padding(horizontal = 12.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("No conversations yet", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = "Start a new conversation above.",
+                color = CelesteTextMuted,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier,
+        contentPadding = PaddingValues(top = 2.dp, bottom = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        if (searchActive) {
+            item(key = "search-results-header") {
+                Text(
+                    text = "Results",
+                    modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
+                    color = CelesteTextMuted,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            items(searchResults, key = { session -> "search-${session.id}" }) { session ->
+                DrawerSessionRow(
+                    session = session,
+                    selected = session.id == selectedSessionId,
+                    enabled = enabled,
+                    metadata = session.compactMetadata(showProfile),
+                    preview = session.preview.takeIf(String::isNotBlank),
+                    onClick = {
+                        focusManager.clearFocus()
+                        onSessionSelected(session)
+                    },
+                )
+            }
+            if (searchResults.isEmpty()) {
+                item(key = "search-empty") {
+                    Text(
+                        text = when {
+                            isSearchingSessions -> "Searching conversations…"
+                            sessionSearchError != null -> "Could not search conversations"
+                            else -> "No conversations found"
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 13.dp, vertical = 22.dp),
+                        color = if (sessionSearchError == null) CelesteTextMuted else CelesteError,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            } else if (sessionSearchError != null) {
+                item(key = "search-error") {
+                    Text(
+                        text = "Some results may be missing",
+                        modifier = Modifier.padding(horizontal = 13.dp, vertical = 10.dp),
+                        color = CelesteError,
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+            }
+        } else {
+            if (sections.pinned.isNotEmpty()) {
+                item(key = "pinned-header") {
+                    SessionSectionHeader(
+                        label = "Pinned",
+                        expanded = pinnedExpanded,
+                        onToggle = { pinnedExpanded = !pinnedExpanded },
+                    )
+                }
+                if (pinnedExpanded) {
+                    items(sections.pinned, key = { session -> "pinned-${session.id}" }) { session ->
+                        DrawerSessionRow(
+                            session = session,
+                            selected = session.id == selectedSessionId,
+                            enabled = enabled,
+                            metadata = session.compactMetadata(showProfile),
+                            onClick = { onSessionSelected(session) },
+                        )
+                    }
+                }
+            }
+            if (sections.recents.isNotEmpty()) {
+                item(key = "recents-header") {
+                    SessionSectionHeader(
+                        label = "Recents",
+                        expanded = recentsExpanded,
+                        onToggle = { recentsExpanded = !recentsExpanded },
+                    )
+                }
+                if (recentsExpanded) {
+                    items(sections.recents, key = { session -> "recent-${session.id}" }) { session ->
+                        DrawerSessionRow(
+                            session = session,
+                            selected = session.id == selectedSessionId,
+                            enabled = enabled,
+                            metadata = session.compactMetadata(showProfile),
+                            onClick = { onSessionSelected(session) },
+                        )
+                    }
+                }
+            }
+            if (sections.scheduled.isNotEmpty()) {
+                item(key = "scheduled-header") {
+                    SessionSectionHeader(
+                        label = "Scheduled",
+                        expanded = scheduledExpanded,
+                        onToggle = { scheduledExpanded = !scheduledExpanded },
+                    )
+                }
+                if (scheduledExpanded) {
+                    items(sections.scheduled, key = { session -> "scheduled-${session.id}" }) { session ->
+                        DrawerSessionRow(
+                            session = session,
+                            selected = session.id == selectedSessionId,
+                            enabled = enabled,
+                            metadata = session.compactMetadata(
+                                showProfile = showProfile,
+                                includeScheduledMarker = false,
+                            ),
+                            onClick = { onSessionSelected(session) },
+                        )
+                    }
+                }
+            }
+            if (isLoadingMoreSessions) {
+                item(key = "session-page-loading") {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                            .semantics { contentDescription = "Loading older conversations" },
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            color = CelesteAccent,
+                            strokeWidth = 2.dp,
+                        )
+                    }
+                }
+            } else if (sessionPageError != null) {
+                item(key = "session-page-error") {
+                    TextButton(
+                        onClick = onLoadMoreSessions,
+                        enabled = enabled && hasMoreSessions,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("Retry loading older conversations")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DrawerSessionRow(
+    session: StoredSession,
+    selected: Boolean,
+    enabled: Boolean,
+    metadata: String?,
+    preview: String? = null,
+    onClick: () -> Unit,
+) {
+    CelestePanel(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                this.selected = selected
+                val states = buildList {
+                    if (selected) add("Current conversation")
+                    if (session.unread) add("Unread")
+                }
+                if (states.isNotEmpty()) stateDescription = states.joinToString(", ")
+            }
+            .clickable(enabled = enabled, onClick = onClick),
+        shape = RoundedCornerShape(if (selected) 22.dp else 12.dp),
+        containerColor = if (selected) CelesteSurfaceSelected else Color.Transparent,
+        borderColor = Color.Transparent,
+        contentPadding = PaddingValues(horizontal = 13.dp, vertical = 9.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = session.title.ifBlank { "Untitled conversation" },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                preview?.let {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = it,
+                        color = CelesteTextMuted,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                metadata?.let {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = it,
+                        color = CelesteTextMuted,
+                        style = MaterialTheme.typography.labelSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            if (session.unread) {
+                Spacer(Modifier.size(10.dp))
+                Box(
+                    modifier = Modifier
+                        .size(7.dp)
+                        .background(CelesteAccent, CircleShape),
+                )
+            }
+        }
+    }
+}
+
+internal fun shouldRequestNextSessionPage(
+    isScrollInProgress: Boolean,
+    lastVisibleIndex: Int,
+    totalItemCount: Int,
+    enabled: Boolean,
+    hasMoreSessions: Boolean,
+    isLoadingMoreSessions: Boolean,
+    hasPageError: Boolean,
+): Boolean =
+    isScrollInProgress &&
+        enabled &&
+        hasMoreSessions &&
+        !isLoadingMoreSessions &&
+        !hasPageError &&
+        totalItemCount > 0 &&
+        lastVisibleIndex >= totalItemCount - 3

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionNavigationDrawer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/sessions/SessionNavigationDrawer.kt
@@ -1,7 +1,6 @@
 package dev.hazydreams.hermesceleste.ui.sessions
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,9 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -35,14 +31,10 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,9 +43,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
@@ -64,14 +54,12 @@ import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.ui.CelesteAccent
 import dev.hazydreams.hermesceleste.ui.CelesteError
-import dev.hazydreams.hermesceleste.ui.CelestePanel
 import dev.hazydreams.hermesceleste.ui.CelesteSurfacePrimary
 import dev.hazydreams.hermesceleste.ui.CelesteSurfaceRaised
 import dev.hazydreams.hermesceleste.ui.CelesteSurfaceSelected
 import dev.hazydreams.hermesceleste.ui.CelesteTextMuted
 import dev.hazydreams.hermesceleste.ui.CelesteTextPrimary
 import dev.hazydreams.hermesceleste.ui.StatusMessage
-import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 internal fun SessionNavigationDrawer(
@@ -96,40 +84,8 @@ internal fun SessionNavigationDrawer(
     onSettings: () -> Unit,
 ) {
     var profileMenuExpanded by remember { mutableStateOf(false) }
-    var pinnedExpanded by rememberSaveable { mutableStateOf(true) }
-    var recentsExpanded by rememberSaveable { mutableStateOf(true) }
-    var scheduledExpanded by rememberSaveable { mutableStateOf(true) }
     val enabled = loadingMessage == null
-    val sections = sessions.toSessionSections()
     val showProfile = profiles.size > 1
-    val searchActive = searchQuery.isNotBlank()
-    val listState = rememberLazyListState()
-    val focusManager = LocalFocusManager.current
-    val currentLoadMore by rememberUpdatedState(onLoadMoreSessions)
-
-    LaunchedEffect(
-        listState,
-        enabled,
-        hasMoreSessions,
-        isLoadingMoreSessions,
-        sessionPageError,
-        sessions.size,
-        searchActive,
-    ) {
-        snapshotFlow {
-            shouldRequestNextSessionPage(
-                isScrollInProgress = listState.isScrollInProgress,
-                lastVisibleIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1,
-                totalItemCount = listState.layoutInfo.totalItemsCount,
-                enabled = enabled && !searchActive,
-                hasMoreSessions = hasMoreSessions,
-                isLoadingMoreSessions = isLoadingMoreSessions,
-                hasPageError = sessionPageError != null,
-            )
-        }.distinctUntilChanged().collect { shouldLoad ->
-            if (shouldLoad) currentLoadMore()
-        }
-    }
 
     ModalDrawerSheet(
         modifier = Modifier
@@ -202,175 +158,24 @@ internal fun SessionNavigationDrawer(
                 Spacer(Modifier.height(18.dp))
             }
 
-            if (sessions.isEmpty() && !searchActive) {
-                Column(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth()
-                        .padding(horizontal = 12.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text("No conversations yet", style = MaterialTheme.typography.titleMedium)
-                    Spacer(Modifier.height(6.dp))
-                    Text(
-                        text = "Start a new conversation above.",
-                        color = CelesteTextMuted,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-            } else {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    contentPadding = PaddingValues(top = 2.dp, bottom = 10.dp),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    if (searchActive) {
-                        item(key = "search-results-header") {
-                            Text(
-                                text = "Results",
-                                modifier = Modifier.padding(horizontal = 13.dp, vertical = 9.dp),
-                                color = CelesteTextMuted,
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                        }
-                        items(searchResults, key = { session -> "search-${session.id}" }) { session ->
-                            DrawerSessionRow(
-                                session = session,
-                                selected = session.id == selectedSessionId,
-                                enabled = enabled,
-                                metadata = session.compactMetadata(showProfile),
-                                preview = session.preview.takeIf(String::isNotBlank),
-                                onClick = {
-                                    focusManager.clearFocus()
-                                    onSessionSelected(session)
-                                },
-                            )
-                        }
-                        if (searchResults.isEmpty()) {
-                            item(key = "search-empty") {
-                                Text(
-                                    text = when {
-                                        isSearchingSessions -> "Searching conversations…"
-                                        sessionSearchError != null -> "Could not search conversations"
-                                        else -> "No conversations found"
-                                    },
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 13.dp, vertical = 22.dp),
-                                    color = if (sessionSearchError == null) CelesteTextMuted else CelesteError,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                            }
-                        } else if (sessionSearchError != null) {
-                            item(key = "search-error") {
-                                Text(
-                                    text = "Some results may be missing",
-                                    modifier = Modifier.padding(horizontal = 13.dp, vertical = 10.dp),
-                                    color = CelesteError,
-                                    style = MaterialTheme.typography.labelMedium,
-                                )
-                            }
-                        }
-                    } else {
-                        if (sections.pinned.isNotEmpty()) {
-                            item(key = "pinned-header") {
-                                SessionSectionHeader(
-                                    label = "Pinned",
-                                    expanded = pinnedExpanded,
-                                    onToggle = { pinnedExpanded = !pinnedExpanded },
-                                )
-                            }
-                            if (pinnedExpanded) {
-                                items(sections.pinned, key = { session -> "pinned-${session.id}" }) { session ->
-                                    DrawerSessionRow(
-                                        session = session,
-                                        selected = session.id == selectedSessionId,
-                                        enabled = enabled,
-                                        metadata = session.compactMetadata(showProfile),
-                                        onClick = { onSessionSelected(session) },
-                                    )
-                                }
-                            }
-                        }
-                        if (sections.recents.isNotEmpty()) {
-                            item(key = "recents-header") {
-                                SessionSectionHeader(
-                                    label = "Recents",
-                                    expanded = recentsExpanded,
-                                    onToggle = { recentsExpanded = !recentsExpanded },
-                                )
-                            }
-                            if (recentsExpanded) {
-                                items(sections.recents, key = { session -> "recent-${session.id}" }) { session ->
-                                    DrawerSessionRow(
-                                        session = session,
-                                        selected = session.id == selectedSessionId,
-                                        enabled = enabled,
-                                        metadata = session.compactMetadata(showProfile),
-                                        onClick = { onSessionSelected(session) },
-                                    )
-                                }
-                            }
-                        }
-                        if (sections.scheduled.isNotEmpty()) {
-                            item(key = "scheduled-header") {
-                                SessionSectionHeader(
-                                    label = "Scheduled",
-                                    expanded = scheduledExpanded,
-                                    onToggle = { scheduledExpanded = !scheduledExpanded },
-                                )
-                            }
-                            if (scheduledExpanded) {
-                                items(sections.scheduled, key = { session -> "scheduled-${session.id}" }) { session ->
-                                    DrawerSessionRow(
-                                        session = session,
-                                        selected = session.id == selectedSessionId,
-                                        enabled = enabled,
-                                        metadata = session.compactMetadata(
-                                            showProfile = showProfile,
-                                            includeScheduledMarker = false,
-                                        ),
-                                        onClick = { onSessionSelected(session) },
-                                    )
-                                }
-                            }
-                        }
-                        if (isLoadingMoreSessions) {
-                            item(key = "session-page-loading") {
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(48.dp)
-                                        .semantics { contentDescription = "Loading older conversations" },
-                                    horizontalArrangement = Arrangement.Center,
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(18.dp),
-                                        color = CelesteAccent,
-                                        strokeWidth = 2.dp,
-                                    )
-                                }
-                            }
-                        } else if (sessionPageError != null) {
-                            item(key = "session-page-error") {
-                                TextButton(
-                                    onClick = onLoadMoreSessions,
-                                    enabled = enabled && hasMoreSessions,
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
-                                    Text("Retry loading older conversations")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            SessionDrawerConversationList(
+                sessions = sessions,
+                selectedSessionId = selectedSessionId,
+                enabled = enabled,
+                showProfile = showProfile,
+                hasMoreSessions = hasMoreSessions,
+                isLoadingMoreSessions = isLoadingMoreSessions,
+                sessionPageError = sessionPageError,
+                searchQuery = searchQuery,
+                searchResults = searchResults,
+                isSearchingSessions = isSearchingSessions,
+                sessionSearchError = sessionSearchError,
+                onSessionSelected = onSessionSelected,
+                onLoadMoreSessions = onLoadMoreSessions,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+            )
 
             Row(
                 modifier = Modifier
@@ -540,91 +345,6 @@ private fun SessionSearchField(
         ),
     )
 }
-
-@Composable
-private fun DrawerSessionRow(
-    session: StoredSession,
-    selected: Boolean,
-    enabled: Boolean,
-    metadata: String?,
-    preview: String? = null,
-    onClick: () -> Unit,
-) {
-    CelestePanel(
-        modifier = Modifier
-            .fillMaxWidth()
-            .semantics {
-                this.selected = selected
-                val states = buildList {
-                    if (selected) add("Current conversation")
-                    if (session.unread) add("Unread")
-                }
-                if (states.isNotEmpty()) stateDescription = states.joinToString(", ")
-            }
-            .clickable(enabled = enabled, onClick = onClick),
-        shape = RoundedCornerShape(if (selected) 22.dp else 12.dp),
-        containerColor = if (selected) CelesteSurfaceSelected else Color.Transparent,
-        borderColor = Color.Transparent,
-        contentPadding = PaddingValues(horizontal = 13.dp, vertical = 9.dp),
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = session.title.ifBlank { "Untitled conversation" },
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                preview?.let {
-                    Spacer(Modifier.height(2.dp))
-                    Text(
-                        text = it,
-                        color = CelesteTextMuted,
-                        style = MaterialTheme.typography.bodySmall,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                metadata?.let {
-                    Spacer(Modifier.height(2.dp))
-                    Text(
-                        text = it,
-                        color = CelesteTextMuted,
-                        style = MaterialTheme.typography.labelSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-            if (session.unread) {
-                Spacer(Modifier.size(10.dp))
-                Box(
-                    modifier = Modifier
-                        .size(7.dp)
-                        .background(CelesteAccent, CircleShape),
-                )
-            }
-        }
-    }
-}
-
-internal fun shouldRequestNextSessionPage(
-    isScrollInProgress: Boolean,
-    lastVisibleIndex: Int,
-    totalItemCount: Int,
-    enabled: Boolean,
-    hasMoreSessions: Boolean,
-    isLoadingMoreSessions: Boolean,
-    hasPageError: Boolean,
-): Boolean =
-    isScrollInProgress &&
-        enabled &&
-        hasMoreSessions &&
-        !isLoadingMoreSessions &&
-        !hasPageError &&
-        totalItemCount > 0 &&
-        lastVisibleIndex >= totalItemCount - 3
 
 private val NewConversationIcon: ImageVector by lazy {
     ImageVector.Builder(


### PR DESCRIPTION
## Summary
- extract session sections, search results, paging state, and row rendering into `SessionDrawerConversationList`
- keep `SessionNavigationDrawer` focused on the sheet shell, top actions, connection status, and profile/settings controls
- preserve callbacks, state ownership, copy, layout, semantics, and accepted screenshot references

## Verification
- `compileDebugKotlin`
- `compileDebugScreenshotTestKotlin`
- focused `SessionSectionsTest`
- focused `NavigationDrawerPreviewScreenshot` validation
- `lintDebug`
- `git diff --check`
- active-search render SHA-256 matches the pre-refactor render exactly: `d4506b550ff21a24e824f146e10ae65ea92df0f2aad88074721026a9c388a796`

## Scope
Behavior-preserving composition refactor only. No controller, protocol, state, copy, or visual changes. Prepares the drawer row boundary for #47.