### PR TITLE
Restore saved reasoning and preserve interim activity order

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -1541,7 +1541,7 @@ internal class CelesteController(
                 val text = event.payload.string("text").orEmpty()
                 val alreadyStreamed = event.payload.boolean("already_streamed") == true
                 mutableState.value = mutableState.value.copy(
-                    messages = settleCurrentReasoning(mutableState.value.messages),
+                    messages = settleCurrentTurnSteps(mutableState.value.messages),
                 )
                 if (alreadyStreamed && mutableState.value.streamingText.isNotBlank()) {
                     finalizeAssistant(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -36,6 +36,8 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -1387,9 +1389,38 @@ internal class CelesteController(
         reconciling = true
         bufferedEvents.clear()
         try {
-            val resumed = activeGateway.resumeStoredSession(storedSessionId, clientSource)
+            val snapshot = mutableState.value
+            val connection = snapshot.probe
+            val activeCredential = credential
+            val profile = snapshot.activeSummary?.profile ?: snapshot.selectedProfile
+            val (resumed, persistedMessages) = coroutineScope {
+                val persisted = if (connection != null && activeCredential != null && profile.isNotBlank()) {
+                    async {
+                        try {
+                            dashboard.loadSessionMessages(
+                                baseUrl = connection.baseUrl,
+                                credential = activeCredential,
+                                sessionId = storedSessionId,
+                                profile = profile,
+                            )
+                        } catch (error: CancellationException) {
+                            throw error
+                        } catch (_: Throwable) {
+                            emptyList()
+                        }
+                    }
+                } else {
+                    null
+                }
+                val runtime = activeGateway.resumeStoredSession(storedSessionId, clientSource)
+                runtime to persisted?.await().orEmpty()
+            }
             if (gateway !== activeGateway) return
-            applyResumedSession(resumed)
+            applyResumedSession(
+                resumed.copy(
+                    messages = persistedMessages.ifEmpty { resumed.messages },
+                ),
+            )
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
@@ -166,7 +166,7 @@ private fun updateCurrentTurnSteps(
     stepsMessageId: String,
     transform: (List<ConversationStep>) -> List<ConversationStep>,
 ): List<ConversationMessage> {
-    val index = currentTurnStepsIndex(messages)
+    val index = activeStepsIndex(messages)
     if (index >= 0) {
         val previous = messages[index]
         val steps = transform(previous.steps)
@@ -184,6 +184,12 @@ private fun updateCurrentTurnSteps(
         pending = true,
         steps = steps,
     )
+}
+
+private fun activeStepsIndex(messages: List<ConversationMessage>): Int {
+    val index = messages.lastIndex
+    val turnStart = messages.indexOfLast { it.role == "user" }
+    return index.takeIf { it > turnStart && messages[it].role == "steps" } ?: -1
 }
 
 private fun currentTurnStepsIndex(messages: List<ConversationMessage>): Int {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -141,6 +141,14 @@ interface DashboardService {
         limit: Int = 20,
     ): List<StoredSession>
 
+    suspend fun loadSessionMessages(
+        baseUrl: String,
+        credential: GatewayCredential,
+        sessionId: String,
+        profile: String,
+        limit: Int = 500,
+    ): List<ConversationMessage>
+
     suspend fun markSessionRead(
         baseUrl: String,
         credential: GatewayCredential,
@@ -412,6 +420,41 @@ class DashboardClient(
                 decodeSearchSession(row, profile)
                     ?: throw InvalidDashboardResponse("Hermes returned an invalid session search result.")
             }
+        }
+    }
+
+    override suspend fun loadSessionMessages(
+        baseUrl: String,
+        credential: GatewayCredential,
+        sessionId: String,
+        profile: String,
+        limit: Int,
+    ): List<ConversationMessage> {
+        require(sessionId.isNotBlank()) { "Choose a Hermes session to open." }
+        require(profile.isNotBlank()) { "A Hermes profile is required." }
+        val boundedLimit = limit.coerceIn(1, 500)
+        return withContext(Dispatchers.IO) {
+            val url = "$baseUrl/api/sessions/$sessionId/messages".toHttpUrl().newBuilder()
+                .addQueryParameter("profile", profile)
+                .addQueryParameter("limit", boundedLimit.toString())
+                .addQueryParameter("order", "latest")
+                .addQueryParameter("include_compacted", "true")
+                .build()
+            val request = Request.Builder()
+                .url(url)
+                .header("Accept", "application/json")
+                .apply {
+                    if (credential is GatewayCredential.StaticToken) {
+                        header("X-Hermes-Session-Token", credential.value.trim())
+                    }
+                }
+                .get()
+                .build()
+            val root = executeJson(request, "Hermes conversation history") as? JsonObject
+                ?: throw InvalidDashboardResponse("Hermes returned no conversation history.")
+            val rows = root["messages"] as? JsonArray
+                ?: throw InvalidDashboardResponse("Hermes returned no conversation history.")
+            decodeGatewayMessages(rows)
         }
     }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -111,6 +111,7 @@ suspend fun GatewayConnection.interruptSession(runtimeSessionId: String): JsonOb
 
 internal fun decodeGatewayMessages(elements: List<JsonElement>): List<ConversationMessage> {
     val usedIds = mutableSetOf<String>()
+    val persistedToolCalls = mutableMapOf<String, Pair<String, String>>()
     var messages = emptyList<ConversationMessage>()
 
     fun uniqueMessageId(preferred: String?, fallback: String): String {
@@ -132,6 +133,14 @@ internal fun decodeGatewayMessages(elements: List<JsonElement>): List<Conversati
             ?: ""
 
         if (role == "assistant") {
+            (row["tool_calls"] as? JsonArray).orEmpty().forEach { callElement ->
+                val call = callElement as? JsonObject ?: return@forEach
+                val function = call["function"] as? JsonObject ?: return@forEach
+                val toolId = call.string("id")?.takeIf(String::isNotBlank) ?: return@forEach
+                val name = function.string("name")?.takeIf(String::isNotBlank) ?: "tool"
+                val context = function.string("arguments")?.takeIf(String::isNotBlank) ?: name
+                persistedToolCalls[toolId] = name to context
+            }
             val reasoning = sequenceOf("reasoning", "reasoning_content", "reasoning_details")
                 .mapNotNull(row::string)
                 .firstOrNull(String::isNotBlank)
@@ -148,18 +157,24 @@ internal fun decodeGatewayMessages(elements: List<JsonElement>): List<Conversati
         }
 
         if (role == "tool") {
-            val name = row.string("name") ?: row.string("tool_name") ?: "tool"
-            val context = text.ifBlank { row["args"]?.toString().orEmpty() }.ifBlank { name }
             val toolId = row.string("tool_id")
                 ?: row.string("tool_call_id")
                 ?: "${sourceIdentity ?: "resume-$index"}:tool"
+            val persistedCall = persistedToolCalls[toolId]
+            val name = row.string("name") ?: row.string("tool_name") ?: persistedCall?.first ?: "tool"
+            val context = row.string("context")
+                ?: persistedCall?.second
+                ?: row["args"]?.toString().orEmpty()
+            val result = row.string("result")
+                ?: row.string("content")
+                ?: ""
             messages = completeToolInCurrentTurn(
                 messages = messages,
                 id = toolId,
                 name = name,
-                context = context,
+                context = context.ifBlank { name },
                 summary = row.string("summary").orEmpty(),
-                result = row.string("result").orEmpty(),
+                result = result,
                 fallbackStepId = toolId,
                 stepsMessageId = "steps:${sourceIdentity ?: "resume-$index"}",
             )

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelAutoLoginTest.kt
@@ -11,6 +11,7 @@ import dev.hazydreams.hermesceleste.connection.StoredConnection
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
 import dev.hazydreams.hermesceleste.network.AuthProvider
+import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.DashboardProfile
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardService
@@ -439,6 +440,14 @@ class CelesteViewModelAutoLoginTest {
             profile: String,
             limit: Int,
         ): List<StoredSession> = emptyList()
+
+        override suspend fun loadSessionMessages(
+            baseUrl: String,
+            credential: GatewayCredential,
+            sessionId: String,
+            profile: String,
+            limit: Int,
+        ): List<ConversationMessage> = emptyList()
 
         override suspend fun markSessionRead(
             baseUrl: String,

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -7,6 +7,7 @@ import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.AuthProvider
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.ConversationStep
 import dev.hazydreams.hermesceleste.network.ConversationStepKind
 import dev.hazydreams.hermesceleste.network.DashboardProbeResult
 import dev.hazydreams.hermesceleste.network.DashboardProfile
@@ -184,7 +185,7 @@ class CelesteViewModelTest {
     }
 
     @Test
-    fun assistantInterimSeparatesReasoningBlocksWithinTheTurn() = runTest {
+    fun assistantInterimEndsTheCurrentStepsCapsuleAndKeepsItsMessageVisible() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)
 
@@ -197,12 +198,16 @@ class CelesteViewModelTest {
         gateway.emit("message.complete", """{"content":"Finished.","status":"complete"}""")
         advanceUntilIdle()
 
-        val reasoning = viewModel.state.value.messages
-            .single { it.role == "steps" }
-            .steps
-            .filter { it.kind == ConversationStepKind.Reasoning }
-        assertEquals(listOf("First thought.", "Second thought."), reasoning.map { it.detail })
-        assertTrue(reasoning.none { it.pending })
+        val messages = viewModel.state.value.messages
+        assertEquals(
+            listOf("user", "steps", "assistant", "steps", "assistant"),
+            messages.map { it.role },
+        )
+        assertEquals("I checked the first part.", messages[2].text)
+        assertTrue(messages[2].interim)
+        assertEquals("First thought.", messages[1].steps.single().detail)
+        assertEquals("Second thought.", messages[3].steps.single().detail)
+        assertTrue(messages.filter { it.role == "steps" }.flatMap { it.steps }.none { it.pending })
         viewModel.controller.close()
     }
 
@@ -241,6 +246,53 @@ class CelesteViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf("user", "assistant"), viewModel.state.value.messages.map { it.role })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun openingConversationUsesPersistedTranscriptReasoning() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(
+                    ConversationMessage(role = "user", text = "Inspect this", id = "resume-user"),
+                    ConversationMessage(role = "assistant", text = "Done", id = "resume-final"),
+                ),
+                running = false,
+            )
+        }
+        val dashboard = FakeDashboard(gateway).apply {
+            sessionMessages = listOf(
+                ConversationMessage(role = "user", text = "Inspect this", id = "stored-user"),
+                ConversationMessage(
+                    role = "steps",
+                    text = "",
+                    id = "stored-steps",
+                    steps = listOf(
+                        ConversationStep(
+                            id = "stored-reasoning",
+                            kind = ConversationStepKind.Reasoning,
+                            detail = "I should read the file first.",
+                        ),
+                    ),
+                ),
+                ConversationMessage(role = "assistant", text = "Done", id = "stored-final"),
+            )
+        }
+        val viewModel = CelesteViewModel(
+            dashboard = dashboard,
+            reconnectDelayMillis = { _, _ -> 0L },
+        )
+        viewModel.updateDashboardUrl("http://hermes.test:9119")
+        viewModel.findDashboard()
+        viewModel.loadSessions()
+        viewModel.openSession(dashboard.session)
+        advanceUntilIdle()
+
+        val messages = viewModel.state.value.messages
+        assertEquals(listOf("user", "steps", "assistant"), messages.map { it.role })
+        assertEquals("I should read the file first.", messages[1].steps.single().detail)
+        assertEquals(listOf(Triple("stored-42", "default", 500)), dashboard.sessionMessageRequests)
+        assertEquals(1, gateway.methods.count { it == "session.resume" })
         viewModel.controller.close()
     }
 
@@ -1192,6 +1244,8 @@ class CelesteViewModelTest {
         val searchResults = mutableMapOf<String, List<StoredSession>>()
         val searchGates = mutableMapOf<String, CompletableDeferred<Unit>>()
         val searchRequests = mutableListOf<Triple<String, String, Int>>()
+        val sessionMessageRequests = mutableListOf<Triple<String, String, Int>>()
+        var sessionMessages = emptyList<ConversationMessage>()
         val markReadRequests = mutableListOf<Pair<String, String>>()
         val pinRequests = mutableListOf<Triple<String, String, Boolean>>()
         val pinGates = mutableMapOf<Boolean, CompletableDeferred<Unit>>()
@@ -1266,6 +1320,17 @@ class CelesteViewModelTest {
                 withContext(NonCancellable) { searchGates[query]?.await() }
             }
             return searchResults[query].orEmpty()
+        }
+
+        override suspend fun loadSessionMessages(
+            baseUrl: String,
+            credential: GatewayCredential,
+            sessionId: String,
+            profile: String,
+            limit: Int,
+        ): List<ConversationMessage> {
+            sessionMessageRequests += Triple(sessionId, profile, limit)
+            return sessionMessages
         }
 
         override suspend fun markSessionRead(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -207,7 +207,9 @@ class CelesteViewModelTest {
         assertTrue(messages[2].interim)
         assertEquals("First thought.", messages[1].steps.single().detail)
         assertEquals("Second thought.", messages[3].steps.single().detail)
-        assertTrue(messages.filter { it.role == "steps" }.flatMap { it.steps }.none { it.pending })
+        val thinkingCapsules = messages.filter { it.role == "steps" }
+        assertTrue(thinkingCapsules.none { it.pending })
+        assertTrue(thinkingCapsules.flatMap { it.steps }.none { it.pending })
         viewModel.controller.close()
     }
 

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/DashboardClientTest.kt
@@ -589,6 +589,43 @@ class DashboardClientTest {
     }
 
     @Test
+    fun loadsPersistedTranscriptWithReasoningAndCompactedHistory() = runBlocking {
+        server.enqueue(
+            MockResponse.Builder()
+                .code(200)
+                .body(
+                    """{"session_id":"stored-42","messages":[{"id":1,"role":"user","content":"Inspect this"},{"id":2,"role":"assistant","content":"","reasoning":"I should read the file first.","tool_calls":[{"id":"call-1","function":{"name":"read_file","arguments":"{\"path\":\"README.md\"}"}}]},{"id":3,"role":"tool","content":"contents","tool_call_id":"call-1","tool_name":"read_file"},{"id":4,"role":"assistant","content":"Done"}],"pagination":{"limit":500,"offset":0,"order":"latest","returned":4}}""",
+                )
+                .build(),
+        )
+
+        val messages = DashboardClient().loadSessionMessages(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            credential = GatewayCredential.StaticToken("private-token"),
+            sessionId = "stored-42",
+            profile = "work",
+        )
+
+        assertEquals(listOf("user", "steps", "assistant"), messages.map { it.role })
+        val steps = messages.single { it.role == "steps" }.steps
+        assertEquals(
+            listOf(ConversationStepKind.Reasoning, ConversationStepKind.Tool),
+            steps.map { it.kind },
+        )
+        assertEquals("I should read the file first.", steps.first().detail)
+        assertEquals("read_file", steps.last().toolName)
+        assertEquals("{\"path\":\"README.md\"}", steps.last().context)
+        assertEquals("contents", steps.last().result)
+        val request = server.takeRequest()
+        assertEquals("/api/sessions/stored-42/messages", request.url.encodedPath)
+        assertEquals("work", request.url.queryParameter("profile"))
+        assertEquals("500", request.url.queryParameter("limit"))
+        assertEquals("latest", request.url.queryParameter("order"))
+        assertEquals("true", request.url.queryParameter("include_compacted"))
+        assertEquals("private-token", request.headers["X-Hermes-Session-Token"])
+    }
+
+    @Test
     fun listsProfilesWithTheOfficialStaticTokenHeader() = runTest {
         server.enqueue(
             MockResponse.Builder()

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -183,6 +183,31 @@ class HermesGatewayTest {
     }
 
     @Test
+    fun resumedAssistantMessageStartsANewActivityCapsuleForLaterReasoning() {
+        val messages = decodeGatewayMessages(
+            Json.parseToJsonElement(
+                """[
+                    {"row_id":1,"role":"user","text":"Inspect this"},
+                    {"row_id":2,"role":"assistant","reasoning":"First thought.","text":""},
+                    {"row_id":3,"role":"tool","tool_call_id":"call-1","name":"read_file","context":"app/Main.kt"},
+                    {"row_id":4,"role":"assistant","text":"I checked the first part."},
+                    {"row_id":5,"role":"assistant","reasoning":"Second thought.","text":""},
+                    {"row_id":6,"role":"assistant","text":"Finished."}
+                ]""".trimIndent(),
+            ).jsonArray,
+        )
+
+        assertEquals(
+            listOf("user", "steps", "assistant", "steps", "assistant"),
+            messages.map { it.role },
+        )
+        assertEquals("First thought.", messages[1].steps.first().detail)
+        assertEquals("I checked the first part.", messages[2].text)
+        assertEquals("Second thought.", messages[3].steps.single().detail)
+        assertTrue(messages.filter { it.role == "steps" }.flatMap { it.steps }.none { it.pending })
+    }
+
+    @Test
     fun resumedHistorySafelySkipsStructuredReasoningDetails() {
         val messages = decodeGatewayMessages(
             Json.parseToJsonElement(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ The four turn states are intentionally user-facing projections:
 - `Running` — Hermes owns an active turn.
 - `Reconnecting` — the draft remains local while Celeste restores the server relationship.
 
-Reasoning and tool events are reduced into one chronological `steps` transcript row for the current user turn. Adjacent reasoning deltas coalesce until a tool or assistant-message boundary, while tool starts and completions reconcile by stable Hermes tool ID. Compose renders that row as the compact **Thinking** affordance and presents the same projection in a separate **Steps** bottom sheet.
+Reasoning and tool events are reduced into chronological `steps` transcript rows for the current user turn. Adjacent reasoning deltas coalesce within the active segment, while tool starts and completions reconcile by stable Hermes tool ID. Interim assistant prose closes the current activity segment and appears in the transcript; later reasoning or tools begin a fresh **Thinking** row. Compose presents each row through the same separate **Steps** bottom sheet.
 
 Do not derive protocol truth from animation or view-local state.
 
@@ -110,7 +110,7 @@ Do not substitute one for the other because they happen to match in a test fixtu
 
 ## Projection behavior
 
-- Current `session.resume` history supplies persisted tool names and available context. Celeste presents that resumed detail in the same Steps projection as live activity.
+- `GET /api/sessions/{session_id}/messages` supplies the persisted display transcript, including compacted history, reasoning, and tool detail. `session.resume` binds the live runtime and supplies current turn state. Celeste presents both through the same Steps projection.
 - Interim/final assistant merging and completion deduplication use text- and prefix-based projection rules.
 - A newly persisted conversation keeps its current projected summary while active and receives refreshed catalog metadata on the next catalog load.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -45,7 +45,7 @@ Do not duplicate hexadecimal values here. Change tokens in code and validate aff
 - Standard user messages use a quiet rounded surface without a speaker label. Standard assistant responses are plain transcript text without a speaker label, rail, or generic response container.
 - User and assistant message bodies derive native rich Markdown from their canonical raw text. Tool input and output remain literal. Code and tables use a neutral raised surface, size from the available message width, and scroll internally rather than widening the transcript.
 - Sending a message opts into following the latest transcript content. Scrolling upward pauses automatic following during streaming; tapping the centered jump-to-latest control or manually reaching the bottom resumes it. Show the control immediately above the composer whenever content continues below the viewport.
-- Routine reasoning and tool activity share one chronological per-turn projection. The transcript presents a compact **Thinking** entry that opens the mobile **Steps** sheet. High-salience interactions such as approvals and user questions retain their dedicated surfaces.
+- Routine reasoning and tool activity form chronological segments around assistant commentary. The transcript presents each activity segment as a compact **Thinking** entry that opens the mobile **Steps** sheet. High-salience interactions such as approvals and user questions retain their dedicated surfaces.
 - Active work uses concise copy, semantic status color, and restrained progress treatment. It must not frame or illuminate the page.
 - Only expose controls and destinations with working behavior. Future drawer locations do not justify inert placeholders.
 

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -87,9 +87,9 @@ The current reducer recognizes:
 - `tool.start` and `tool.complete`;
 - top-level `error`.
 
-`reasoning.delta` and `reasoning.available` provide display reasoning for the current turn's chronological Steps projection. `thinking.delta` carries provider/status activity for the running turn. Tool events correlate by `tool_id` (or the current equivalent tool-call ID alias), so simultaneous tools with the same name retain their own start order and completion detail.
+`reasoning.delta` and `reasoning.available` provide display reasoning for the current activity segment. Interim assistant messages appear in the transcript and close that segment; later reasoning or tools begin a fresh Steps segment. `thinking.delta` carries provider/status activity for the running turn. Tool events correlate by `tool_id` (or the current equivalent tool-call ID alias), so simultaneous tools with the same name retain their own start order and completion detail.
 
-The `session.resume` display projection may expose assistant reasoning through `reasoning`, `reasoning_content`, or `reasoning_details`, followed by projected `role: "tool"` rows. Celeste reconstructs those available rows into the same settled per-turn Steps projection used by live events and presents each resumed tool's supplied name and context.
+Celeste loads persisted display history from `GET /api/sessions/{session_id}/messages` with the owning profile, `order=latest`, and `include_compacted=true`. Assistant rows may expose reasoning through `reasoning`, `reasoning_content`, or `reasoning_details`; their tool-call metadata correlates with following `role: "tool"` rows. Celeste reconstructs those rows into settled chronological Steps segments around assistant prose while `session.resume` binds the live runtime and current turn state.
 
 Event names, payloads, and ordering are verified against current Hermes source and covered by focused decoding/state tests. This document records the cross-event semantics that connect those implementation points.
 


### PR DESCRIPTION
## Summary

- Load persisted conversation history from the canonical session messages endpoint used by Hermes Desktop while retaining session.resume for runtime binding and in-flight state.
- Restore saved model reasoning and correlate tool arguments with their results when conversations are reopened.
- End the current Thinking capsule at an intermediate assistant message and begin a new capsule for later activity, preserving the visible sequence.

## Verification

- Focused DashboardClient, controller, gateway, reconnect, and interruption tests pass.
- Thinking entry and Steps sheet screenshot validation passes.
- Lint and git diff checks pass.

Advances #28