### PR TITLE
Preserve Thinking chronology around file changes

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -3,6 +3,7 @@ package dev.hazydreams.hermesceleste
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.TaskProgress
+import dev.hazydreams.hermesceleste.network.appendCurrentTurnMessage
 import dev.hazydreams.hermesceleste.network.appendReasoningToCurrentTurn
 import dev.hazydreams.hermesceleste.network.bindClarificationRequest
 import dev.hazydreams.hermesceleste.network.boolean
@@ -11,6 +12,7 @@ import dev.hazydreams.hermesceleste.network.clearUnansweredClarifications
 import dev.hazydreams.hermesceleste.network.completeClarificationInCurrentTurn
 import dev.hazydreams.hermesceleste.network.completeFileEditInCurrentTurn
 import dev.hazydreams.hermesceleste.network.completeToolInCurrentTurn
+import dev.hazydreams.hermesceleste.network.currentTurnContentTailIndex
 import dev.hazydreams.hermesceleste.network.fileEditDiff
 import dev.hazydreams.hermesceleste.network.fileEditPaths
 import dev.hazydreams.hermesceleste.network.isFileEditTool
@@ -341,22 +343,28 @@ private fun ConversationProjection.finalizeAssistant(
         streamingText.startsWith(suppliedContent) -> streamingText
         else -> suppliedContent
     }.trimEnd()
-    val previous = messages.lastOrNull()
+    val previousIndex = currentTurnContentTailIndex(messages)
+    val previous = messages.getOrNull(previousIndex)
     val continuesInterim = !interim &&
         previous?.role == "assistant" &&
         previous.interim &&
         finalText.isNotBlank() &&
         (finalText.startsWith(previous.text) || previous.text.startsWith(finalText))
     val nextMessages = when {
-        continuesInterim -> messages.dropLast(1) + previous.copy(
-            text = if (finalText.length >= previous.text.length) finalText else previous.text,
-            interim = false,
-        )
+        continuesInterim -> messages.toMutableList().also { next ->
+            next[previousIndex] = previous.copy(
+                text = if (finalText.length >= previous.text.length) finalText else previous.text,
+                interim = false,
+            )
+        }
         finalText.isNotBlank() && previous?.let { it.role == "assistant" && it.text == finalText } != true ->
-            messages + ConversationMessage(
-                role = "assistant",
-                text = finalText,
-                interim = interim,
+            appendCurrentTurnMessage(
+                messages = messages,
+                message = ConversationMessage(
+                    role = "assistant",
+                    text = finalText,
+                    interim = interim,
+                ),
             )
         else -> messages
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/BackgroundProcessResult.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/BackgroundProcessResult.kt
@@ -72,7 +72,7 @@ internal fun upsertBackgroundProcessResult(
     val existingIndex = messages.indexOfFirst { message ->
         message.role == "process" && message.processResult?.processId == result.processId
     }
-    if (existingIndex < 0) return messages + next
+    if (existingIndex < 0) return appendCurrentTurnMessage(messages, next)
     return messages.toMutableList().also { it[existingIndex] = next }
 }
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/Clarification.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/Clarification.kt
@@ -62,7 +62,7 @@ internal fun startClarificationInCurrentTurn(
         clarification = clarification,
     )
     return if (existingIndex < 0) {
-        messages + message
+        appendCurrentTurnMessage(messages, message)
     } else {
         messages.toMutableList().also { it[existingIndex] = message }
     }
@@ -102,7 +102,7 @@ internal fun bindClarificationRequest(
         )
     }
     return if (existingIndex < 0) {
-        messages + nextMessage
+        appendCurrentTurnMessage(messages, nextMessage)
     } else {
         messages.toMutableList().also { it[existingIndex] = nextMessage }
     }
@@ -132,7 +132,7 @@ internal fun completeClarificationInCurrentTurn(
         clarification = result.copy(submitting = false),
     )
     return if (existingIndex < 0) {
-        messages + nextMessage
+        appendCurrentTurnMessage(messages, nextMessage)
     } else {
         messages.toMutableList().also { it[existingIndex] = nextMessage }
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
@@ -156,6 +156,20 @@ internal fun settleCurrentTurnSteps(messages: List<ConversationMessage>): List<C
     }
 }
 
+internal fun appendCurrentTurnMessage(
+    messages: List<ConversationMessage>,
+    message: ConversationMessage,
+): List<ConversationMessage> {
+    val changesIndex = currentTurnChangesIndex(messages)
+    if (changesIndex < 0) return messages + message
+    return messages.toMutableList().also { next -> next.add(changesIndex, message) }
+}
+
+internal fun currentTurnContentTailIndex(messages: List<ConversationMessage>): Int {
+    val changesIndex = currentTurnChangesIndex(messages)
+    return if (changesIndex < 0) messages.lastIndex else changesIndex - 1
+}
+
 internal fun ConversationMessage.settledSteps(): ConversationMessage {
     if (role != "steps" || (!pending && steps.none(ConversationStep::pending))) return this
     return copy(
@@ -187,9 +201,7 @@ private fun updateCurrentTurnSteps(
         pending = true,
         steps = steps,
     )
-    val changesIndex = currentTurnChangesIndexForSteps(messages)
-    if (changesIndex < 0) return messages + message
-    return messages.toMutableList().also { next -> next.add(changesIndex, message) }
+    return appendCurrentTurnMessage(messages, message)
 }
 
 private fun activeStepsIndex(messages: List<ConversationMessage>): Int {
@@ -212,7 +224,7 @@ private fun currentTurnStepsIndex(messages: List<ConversationMessage>): Int {
     return -1
 }
 
-private fun currentTurnChangesIndexForSteps(messages: List<ConversationMessage>): Int {
+private fun currentTurnChangesIndex(messages: List<ConversationMessage>): Int {
     val turnStart = messages.indexOfLast { it.role == "user" }
     for (index in (turnStart + 1)..messages.lastIndex) {
         if (messages[index].role == "changes") return index

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -210,14 +210,17 @@ internal fun decodeGatewayConversation(elements: List<JsonElement>): DecodedGate
             restoredAssistantSegments(reasoning, commentary).forEach { segment ->
                 if (segment.commentary) {
                     messages = settleCurrentTurnSteps(messages)
-                    messages = messages + ConversationMessage(
-                        role = "assistant",
-                        text = segment.text,
-                        id = uniqueMessageId(
-                            preferred = "$baseIdentity:commentary-$commentaryIndex",
-                            fallback = "resume-$index-commentary-$commentaryIndex",
+                    messages = appendCurrentTurnMessage(
+                        messages = messages,
+                        message = ConversationMessage(
+                            role = "assistant",
+                            text = segment.text,
+                            id = uniqueMessageId(
+                                preferred = "$baseIdentity:commentary-$commentaryIndex",
+                                fallback = "resume-$index-commentary-$commentaryIndex",
+                            ),
+                            interim = true,
                         ),
-                        interim = true,
                     )
                     commentaryIndex += 1
                 } else {
@@ -301,11 +304,16 @@ internal fun decodeGatewayConversation(elements: List<JsonElement>): DecodedGate
         }
 
         if (text.isBlank()) return@forEachIndexed
-        messages = messages + ConversationMessage(
+        val message = ConversationMessage(
             role = role,
             text = text,
             id = uniqueMessageId(sourceIdentity, "resume-$index"),
         )
+        messages = if (role == "user") {
+            messages + message
+        } else {
+            appendCurrentTurnMessage(messages, message)
+        }
     }
 
     return DecodedGatewayConversation(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/ConversationScreen.kt
@@ -137,6 +137,13 @@ internal fun ConversationScreen(
     }
     val focusManager = LocalFocusManager.current
     val transcriptKeys = remember(messages) { transcriptItemKeys(messages) }
+    val streamingInsertionIndex = remember(messages) { streamingTranscriptInsertionIndex(messages) }
+    val messagesBeforeStreaming = remember(messages, streamingInsertionIndex) {
+        messages.subList(0, streamingInsertionIndex)
+    }
+    val messagesAfterStreaming = remember(messages, streamingInsertionIndex) {
+        messages.subList(streamingInsertionIndex, messages.size)
+    }
     val pendingClarificationFollowKey = remember(messages) { pendingClarificationFollowKey(messages) }
     val visibleMessageCount = messages.size +
         (if (streamingText.isNotBlank()) 1 else 0) +
@@ -212,7 +219,7 @@ internal fun ConversationScreen(
                     verticalArrangement = Arrangement.spacedBy(20.dp),
                 ) {
                     itemsIndexed(
-                        items = messages,
+                        items = messagesBeforeStreaming,
                         key = { index, _ -> transcriptKeys[index] },
                     ) { _, message ->
                         MessageBubble(
@@ -228,6 +235,16 @@ internal fun ConversationScreen(
                                 streaming = true,
                             )
                         }
+                    }
+                    itemsIndexed(
+                        items = messagesAfterStreaming,
+                        key = { index, _ -> transcriptKeys[streamingInsertionIndex + index] },
+                    ) { _, message ->
+                        MessageBubble(
+                            message = message,
+                            onOpenInspection = { openedInspectionMessageId = message.id },
+                            onClarificationRespond = onClarificationRespond,
+                        )
                     }
                     if (isCompacting) {
                         item(key = "compaction-status:$conversationKey") {
@@ -359,6 +376,10 @@ private fun ResumeExhaustedCard(
 
 internal fun latestTranscriptIndex(visibleMessageCount: Int): Int? =
     (visibleMessageCount - 1).takeIf { it >= 0 }
+
+internal fun streamingTranscriptInsertionIndex(messages: List<ConversationMessage>): Int =
+    messages.lastIndex.takeIf { index -> index >= 0 && messages[index].role == "changes" }
+        ?: messages.size
 
 internal fun pendingClarificationFollowKey(messages: List<ConversationMessage>): String? =
     messages.lastOrNull { message ->

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -41,7 +41,7 @@ class ConversationEventReducerTest {
             event("message.complete", """{"content":"Both files are updated.","status":"complete"}"""),
         )
 
-        assertEquals(listOf("user", "steps", "changes", "assistant"), result.projection.messages.map { it.role })
+        assertEquals(listOf("user", "steps", "assistant", "changes"), result.projection.messages.map { it.role })
         val thinking = result.projection.messages.single { it.role == "steps" }
         assertEquals(
             listOf("Choose the first edit.", "Check the second boundary."),
@@ -238,6 +238,42 @@ class ConversationEventReducerTest {
         val thinkingCapsules = messages.filter { it.role == "steps" }
         assertTrue(thinkingCapsules.none { it.pending })
         assertTrue(thinkingCapsules.flatMap { it.steps }.none { it.pending })
+    }
+
+    @Test
+    fun changedFilesStayAtTheEndWithoutReorderingCommentaryAndLaterActivity() {
+        val result = reduceEvents(
+            event("message.start"),
+            event("reasoning.delta", """{"text":"Plan the edit."}"""),
+            event("tool.start", """{"tool_id":"edit-a","name":"patch","args":{"path":"App.kt"}}"""),
+            event(
+                "tool.complete",
+                """{"tool_id":"edit-a","name":"patch","args":{"path":"App.kt"},"inline_diff":"a/App.kt → b/App.kt\n@@\n-old\n+new"}""",
+            ),
+            event("reasoning.delta", """{"text":"Check the first result."}"""),
+            event("message.interim", """{"text":"The edit is in; I’m checking it."}"""),
+            event("reasoning.delta", """{"text":"Run the focused tests."}"""),
+            event("tool.start", """{"tool_id":"test-a","name":"terminal","context":"./gradlew focusedTest"}"""),
+            event("tool.complete", """{"tool_id":"test-a","name":"terminal","summary":"Tests passed"}"""),
+            event("reasoning.delta", """{"text":"Verify the diff."}"""),
+            event("tool.start", """{"tool_id":"read-a","name":"read_file","context":"App.kt"}"""),
+            event("tool.complete", """{"tool_id":"read-a","name":"read_file","summary":"Read App.kt"}"""),
+            event("message.complete", """{"content":"Everything checks out.","status":"complete"}"""),
+        )
+
+        assertEquals(
+            listOf("user", "steps", "assistant", "steps", "assistant", "changes"),
+            result.projection.messages.map { it.role },
+        )
+        assertEquals("The edit is in; I’m checking it.", result.projection.messages[2].text)
+        assertEquals("Everything checks out.", result.projection.messages[4].text)
+        val thinking = result.projection.messages.filter { it.role == "steps" }
+        assertEquals(2, thinking.size)
+        assertEquals(
+            listOf(ConversationStepKind.Reasoning, ConversationStepKind.Tool, ConversationStepKind.Reasoning, ConversationStepKind.Tool),
+            thinking[1].steps.map { it.kind },
+        )
+        assertEquals(listOf("App.kt"), result.projection.messages.last().changedFiles().map { it.path })
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/TranscriptItemKeysTest.kt
@@ -8,6 +8,7 @@ import dev.hazydreams.hermesceleste.ui.conversation.latestTranscriptIndex
 import dev.hazydreams.hermesceleste.ui.conversation.pendingClarificationFollowKey
 import dev.hazydreams.hermesceleste.ui.conversation.remainingScrollToLatest
 import dev.hazydreams.hermesceleste.ui.conversation.shouldShowJumpToLatest
+import dev.hazydreams.hermesceleste.ui.conversation.streamingTranscriptInsertionIndex
 import dev.hazydreams.hermesceleste.ui.conversation.streamingTranscriptKey
 import dev.hazydreams.hermesceleste.ui.conversation.transcriptItemKeys
 import dev.hazydreams.hermesceleste.ui.conversation.updatedFollowLatest
@@ -63,6 +64,17 @@ class TranscriptItemKeysTest {
         assertEquals(null, latestTranscriptIndex(0))
         assertEquals(0, latestTranscriptIndex(1))
         assertEquals(4, latestTranscriptIndex(5))
+    }
+
+    @Test
+    fun streamingAssistantRendersBeforeOnlyATrailingChangesSummary() {
+        val assistant = message("assistant")
+        val changes = ConversationMessage(role = "changes", text = "", id = "changes")
+
+        assertEquals(0, streamingTranscriptInsertionIndex(emptyList()))
+        assertEquals(1, streamingTranscriptInsertionIndex(listOf(assistant)))
+        assertEquals(1, streamingTranscriptInsertionIndex(listOf(assistant, changes)))
+        assertEquals(2, streamingTranscriptInsertionIndex(listOf(changes, assistant)))
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -350,6 +350,38 @@ One test failed
     }
 
     @Test
+    fun restoredChangesStayAtTheEndWithoutReorderingCommentaryAndLaterActivity() {
+        val messages = decodeGatewayMessages(
+            Json.parseToJsonElement(
+                """[
+                    {"row_id":1,"role":"user","text":"Fix the queue"},
+                    {"row_id":2,"role":"assistant","reasoning":"Plan the edit.","tool_calls":[{"id":"edit-a","function":{"name":"patch","arguments":"{\"path\":\"App.kt\"}"}}]},
+                    {"row_id":3,"role":"tool","tool_call_id":"edit-a","tool_name":"patch","content":"{\"diff\":\"a/App.kt → b/App.kt\\n@@\\n-old\\n+new\"}"},
+                    {"row_id":4,"role":"assistant","reasoning":"Check the first result.\n\nThe edit is in; I’m checking it.\n\nRun the focused tests.","codex_message_items":[{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"The edit is in; I’m checking it."}]}],"tool_calls":[{"id":"test-a","function":{"name":"terminal","arguments":"{\"command\":\"./gradlew focusedTest\"}"}}]},
+                    {"row_id":5,"role":"tool","tool_call_id":"test-a","tool_name":"terminal","content":"Tests passed"},
+                    {"row_id":6,"role":"assistant","reasoning":"Verify the diff.","tool_calls":[{"id":"read-a","function":{"name":"read_file","arguments":"{\"path\":\"App.kt\"}"}}]},
+                    {"row_id":7,"role":"tool","tool_call_id":"read-a","tool_name":"read_file","content":"Read App.kt"},
+                    {"row_id":8,"role":"assistant","text":"Everything checks out."}
+                ]""".trimIndent(),
+            ).jsonArray,
+        )
+
+        assertEquals(
+            listOf("user", "steps", "assistant", "steps", "assistant", "changes"),
+            messages.map { it.role },
+        )
+        assertEquals("The edit is in; I’m checking it.", messages[2].text)
+        assertEquals("Everything checks out.", messages[4].text)
+        val thinking = messages.filter { it.role == "steps" }
+        assertEquals(2, thinking.size)
+        assertEquals(
+            listOf(ConversationStepKind.Reasoning, ConversationStepKind.Tool, ConversationStepKind.Reasoning, ConversationStepKind.Tool),
+            thinking[1].steps.map { it.kind },
+        )
+        assertEquals(listOf("App.kt"), messages.last().changedFiles().map { it.path })
+    }
+
+    @Test
     fun restoredCodexSidecarOnlyProjectsCommentaryPhase() {
         val messages = decodeGatewayMessages(
             buildJsonArray {

--- a/docs/design.md
+++ b/docs/design.md
@@ -38,7 +38,7 @@ Other conversational products are composition references, not identities to copy
 - Render canonical Markdown natively. Code and tables use raised surfaces and scroll internally within message width.
 - Pause automatic transcript following when the reader scrolls up; resume at the bottom or through the jump-to-latest control.
 - Keep tool and system activity labeled and contained; keep ordinary assistant prose conversational.
-- Represent a turn’s file edits once with a compact filled Changes pill that opens bounded per-file detail.
+- Represent a turn’s file edits once at the end with a compact filled Changes pill that opens bounded per-file detail while preserving transcript activity order.
 - Keep active task progress in one compact filled pill, left-aligned immediately above the composer; acknowledge completion briefly, then clear it.
 - Present pending clarifications inline with nearby choices and actions, then collapse answered or skipped requests into compact transcript content.
 - Present active work with concise copy and restrained motion that stops when inactive or not visible.


### PR DESCRIPTION
## Summary
- keep each turn's Changes pill at the end while preserving Thinking and transcript chronology
- preserve real commentary boundaries while grouping uninterrupted reasoning and tool cycles into one Thinking block
- apply the same ordering rule to live events and restored conversation history

## Verification
- `scripts/celeste-env ./gradlew --no-daemon :app:testDebugUnitTest --tests 'dev.hazydreams.hermesceleste.ConversationEventReducerTest' --tests 'dev.hazydreams.hermesceleste.network.HermesGatewayTest' --tests 'dev.hazydreams.hermesceleste.network.BackgroundProcessResultTest'`
- `scripts/celeste-env ./gradlew --no-daemon :app:lintDebug`
- `git diff --check`
