### PR TITLE
Redirect follow-ups into active turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install the APK, open **Hermes Celeste**, and connect to a Hermes dashboard that
 - Read rich Markdown, code, links, checklists, quotes, and tables in the transcript
 - Answer agent clarification questions inline
 - Send selected images and files through Android’s system pickers
-- Queue follow-up prompts during active turns and send them automatically in order
+- Redirect text follow-ups into active turns and queue payloads that need the next turn
 - Stop active work and recover the current conversation after connection changes
 
 ## One Hermes, another surface

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -21,8 +21,10 @@ import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.GatewayRpcException
 import dev.hazydreams.hermesceleste.network.ResumedSession
 import dev.hazydreams.hermesceleste.network.SessionCatalogPage
+import dev.hazydreams.hermesceleste.network.SessionRedirectStatus
 import dev.hazydreams.hermesceleste.network.StoredSession
 import dev.hazydreams.hermesceleste.network.TaskProgress
+import dev.hazydreams.hermesceleste.network.UserMessagePlacement
 import dev.hazydreams.hermesceleste.network.bindClarificationRequest
 import dev.hazydreams.hermesceleste.network.boolean
 import dev.hazydreams.hermesceleste.network.closeRuntimeSession
@@ -152,6 +154,13 @@ private data class UncertainDirectPrompt(
 private class SubmissionSupersededException : Exception("The attachment submission was cancelled.")
 private class AttachmentSessionChangedException :
     Exception("The conversation changed while Hermes restored its attachment session.")
+private class RedirectSessionChangedException :
+    Exception("The conversation changed while Hermes restored its redirect session.")
+
+private data class ResumedLiveProjection(
+    val messages: List<ConversationMessage>,
+    val streamingText: String,
+)
 
 private class SubmissionLease(
     val gateway: GatewayConnection,
@@ -226,6 +235,7 @@ internal class CelesteController(
     private val submissionsBySession = mutableMapOf<String, SubmissionLease>()
     private val attachmentCleanupBySession = mutableMapOf<String, Deferred<Unit>>()
     private val runtimeRetirementBySession = mutableMapOf<String, String>()
+    private val migratedSessionIds = mutableMapOf<String, String>()
     private val parkedQueueSessions = mutableSetOf<String>()
     private val queueDrainsInFlight = mutableSetOf<String>()
     private var queuedTurnAwaitingActivitySessionId: String? = null
@@ -1140,6 +1150,7 @@ internal class CelesteController(
                     text = text,
                     id = redirectMessageId,
                     pending = true,
+                    userPlacement = UserMessagePlacement.MidTurnCorrection,
                 ),
             ),
             streamingText = "",
@@ -1149,22 +1160,41 @@ internal class CelesteController(
         )
         val redirectConnectionAttempt = connectionAttempt
         controllerScope.launch {
-            val accepted = runCatching {
-                activeGateway.redirectSession(runtimeSessionId, text)
-            }.getOrDefault(false)
+            val status = runCatching {
+                redirectWithSessionRecovery(
+                    activeGateway = activeGateway,
+                    runtimeSessionId = runtimeSessionId,
+                    storedSessionId = storedSessionId,
+                    profile = snapshot.selectedProfile,
+                    expectedConnectionAttempt = redirectConnectionAttempt,
+                    text = text,
+                )
+            }.getOrDefault(SessionRedirectStatus.Rejected)
+            val accepted = status != SessionRedirectStatus.Rejected
             if (
                 gateway !== activeGateway ||
                 connectionAttempt != redirectConnectionAttempt ||
-                currentStoredSessionId != storedSessionId
+                canonicalSessionId(currentStoredSessionId) != canonicalSessionId(storedSessionId)
             ) {
-                if (!accepted) enqueueRedirectFallback(storedSessionId, text)
+                if (!accepted) enqueueRedirectFallback(canonicalSessionId(storedSessionId), text)
                 return@launch
             }
 
             mutableState.value = if (accepted) {
                 mutableState.value.copy(
                     messages = mutableState.value.messages.map { message ->
-                        if (message.id == redirectMessageId) message.copy(pending = false) else message
+                        if (message.id == redirectMessageId) {
+                            message.copy(
+                                pending = false,
+                                userPlacement = when (status) {
+                                    SessionRedirectStatus.Redirected -> UserMessagePlacement.MidTurnCorrection
+                                    SessionRedirectStatus.Queued -> UserMessagePlacement.NextTurn
+                                    SessionRedirectStatus.Rejected -> message.userPlacement
+                                },
+                            )
+                        } else {
+                            message
+                        }
                     },
                 )
             } else {
@@ -1172,18 +1202,57 @@ internal class CelesteController(
                     messages = mutableState.value.messages.filterNot { it.id == redirectMessageId },
                 )
             }
-            if (!accepted) enqueueRedirectFallback(storedSessionId, text)
+            if (!accepted) enqueueRedirectFallback(canonicalSessionId(storedSessionId), text)
         }
     }
 
-    private fun enqueueRedirectFallback(sessionId: String, text: String) {
-        queuedPromptsBySession.getOrPut(sessionId) { mutableListOf() } += QueuedPrompt(
+    private suspend fun redirectWithSessionRecovery(
+        activeGateway: GatewayConnection,
+        runtimeSessionId: String,
+        storedSessionId: String,
+        profile: String,
+        expectedConnectionAttempt: Long,
+        text: String,
+    ): SessionRedirectStatus {
+        var runtimeId = runtimeSessionId
+        var recovered = false
+        while (true) {
+            try {
+                return activeGateway.redirectSession(runtimeId, text)
+            } catch (failure: Throwable) {
+                if (recovered || !failure.isSessionNotFoundFailure()) throw failure
+                val canonicalStoredId = canonicalSessionId(storedSessionId)
+                    ?: throw RedirectSessionChangedException()
+                val resumed = activeGateway.resumeStoredSession(canonicalStoredId, profile, clientSource)
+                currentCoroutineContext().ensureActive()
+                if (
+                    gateway !== activeGateway ||
+                    connectionAttempt != expectedConnectionAttempt ||
+                    canonicalSessionId(currentStoredSessionId) != canonicalStoredId
+                ) {
+                    throw RedirectSessionChangedException()
+                }
+                if (canonicalStoredId != resumed.storedSessionId) {
+                    migrateSessionBoundState(canonicalStoredId, resumed.storedSessionId)
+                }
+                currentRuntimeSessionId = resumed.runtimeSessionId
+                currentStoredSessionId = resumed.storedSessionId
+                currentSessionCanResume = true
+                runtimeId = resumed.runtimeSessionId
+                recovered = true
+            }
+        }
+    }
+
+    private fun enqueueRedirectFallback(sessionId: String?, text: String) {
+        val resolvedSessionId = canonicalSessionId(sessionId) ?: return
+        queuedPromptsBySession.getOrPut(resolvedSessionId) { mutableListOf() } += QueuedPrompt(
             id = nextLocalMessageId("queued"),
             text = text,
         )
-        parkedQueueSessions.remove(sessionId)
-        if (currentStoredSessionId == sessionId) {
-            refreshActiveQueueProjection(sessionId)
+        parkedQueueSessions.remove(resolvedSessionId)
+        if (canonicalSessionId(currentStoredSessionId) == resolvedSessionId) {
+            refreshActiveQueueProjection(resolvedSessionId)
             drainQueuedPromptIfPossible()
         }
     }
@@ -1856,19 +1925,16 @@ internal class CelesteController(
         if (queuedTurnAwaitingActivitySessionId == resumed.storedSessionId) {
             queuedTurnAwaitingActivitySessionId = null
         }
-        val streamingSuffix = unpersistedInflightText(
-            inflight = resumed.inflightAssistantText,
-            messages = resumed.messages,
-        )
+        val liveProjection = resumedLiveProjection(resumed)
         val previousTaskProgress = mutableState.value.taskProgress
         val running = resumed.running == true || resumed.hasLiveProjection
         val restoredTaskProgress = resumed.taskProgress.takeIf { running }
         mutableState.value = mutableState.value.copy(
-            messages = resumed.messages,
+            messages = liveProjection.messages,
             draft = restoredDirectDraft?.let { mutableState.value.draft.ifBlank { it } }
                 ?: mutableState.value.draft,
             taskProgress = restoredTaskProgress,
-            streamingText = streamingSuffix,
+            streamingText = liveProjection.streamingText,
             composerAttachments = composerAttachmentsFor(resumed.storedSessionId),
             queuedPrompts = queuedPromptsFor(resumed.storedSessionId),
             isQueuePaused = resumed.storedSessionId in parkedQueueSessions &&
@@ -1884,6 +1950,70 @@ internal class CelesteController(
         )
         updateTaskProgressClear(previousTaskProgress, restoredTaskProgress)
         publishCurrentSession()
+    }
+
+    private fun resumedLiveProjection(resumed: ResumedSession): ResumedLiveProjection {
+        if (resumed.inflightCorrections.isEmpty()) {
+            return ResumedLiveProjection(
+                messages = resumed.messages,
+                streamingText = unpersistedInflightText(
+                    inflight = resumed.inflightAssistantText,
+                    messages = resumed.messages,
+                ),
+            )
+        }
+
+        var messages = resumed.messages
+        val assistant = resumed.inflightAssistantText
+        val offsetsUsable = resumed.inflightCorrections.all { correction ->
+            correction.assistantOffset?.let { it in 0..assistant.length } == true
+        }
+        var cursor = 0
+        resumed.inflightCorrections.forEachIndexed { index, correction ->
+            if (offsetsUsable) {
+                val boundary = correction.assistantOffset!!.coerceIn(cursor, assistant.length)
+                val segment = assistant.substring(cursor, boundary)
+                val missingSegment = unpersistedInflightText(segment, messages)
+                if (missingSegment.isNotBlank()) {
+                    messages = appendCurrentTurnMessage(
+                        messages = messages,
+                        message = ConversationMessage(
+                            role = "assistant",
+                            text = missingSegment,
+                            id = "inflight-assistant-segment-$index-${resumed.runtimeSessionId}",
+                            interim = true,
+                        ),
+                    )
+                }
+                cursor = boundary
+            } else if (index == 0) {
+                val missingAssistant = unpersistedInflightText(assistant, messages)
+                if (missingAssistant.isNotBlank()) {
+                    messages = appendCurrentTurnMessage(
+                        messages = messages,
+                        message = ConversationMessage(
+                            role = "assistant",
+                            text = missingAssistant,
+                            id = "inflight-assistant-${resumed.runtimeSessionId}",
+                            interim = true,
+                        ),
+                    )
+                }
+            }
+            messages = appendCurrentTurnMessage(
+                messages = messages,
+                message = ConversationMessage(
+                    role = "user",
+                    text = correction.text,
+                    id = "inflight-correction-$index-${resumed.runtimeSessionId}",
+                    userPlacement = UserMessagePlacement.MidTurnCorrection,
+                ),
+            )
+        }
+        return ResumedLiveProjection(
+            messages = messages,
+            streamingText = if (offsetsUsable) assistant.substring(cursor).trimStart() else "",
+        )
     }
 
     private fun isActiveSession(submitted: SubmittedSession): Boolean =
@@ -2464,6 +2594,10 @@ internal class CelesteController(
 
     private fun migrateSessionBoundState(fromSessionId: String, toSessionId: String) {
         if (fromSessionId == toSessionId) return
+        migratedSessionIds.entries.forEach { entry ->
+            if (entry.value == fromSessionId) entry.setValue(toSessionId)
+        }
+        migratedSessionIds[fromSessionId] = toSessionId
         migrateQueuedSessionState(fromSessionId, toSessionId)
         migrateComposerAttachmentSessionState(fromSessionId, toSessionId)
         submissionsBySession.remove(fromSessionId)?.let { submission ->
@@ -2489,6 +2623,15 @@ internal class CelesteController(
                 sessions = migratedSessions,
             )
         }
+    }
+
+    private fun canonicalSessionId(sessionId: String?): String? {
+        var current = sessionId ?: return null
+        val visited = mutableSetOf<String>()
+        while (visited.add(current)) {
+            current = migratedSessionIds[current] ?: return current
+        }
+        return current
     }
 
     private fun markQueuedPromptDeliveryUncertain(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -8,6 +8,7 @@ import dev.hazydreams.hermesceleste.connection.SavedConnectionDescriptor
 import dev.hazydreams.hermesceleste.connection.connectionBootstrapDecision
 import dev.hazydreams.hermesceleste.network.AuthenticationRejected
 import dev.hazydreams.hermesceleste.network.AuthenticationMaterial
+import dev.hazydreams.hermesceleste.network.appendCurrentTurnMessage
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.CreatedSession
 import dev.hazydreams.hermesceleste.network.DashboardProfile
@@ -31,8 +32,10 @@ import dev.hazydreams.hermesceleste.network.interruptSession
 import dev.hazydreams.hermesceleste.network.markClarificationSubmitting
 import dev.hazydreams.hermesceleste.network.resetClarificationSubmission
 import dev.hazydreams.hermesceleste.network.respondToClarification
+import dev.hazydreams.hermesceleste.network.redirectSession
 import dev.hazydreams.hermesceleste.network.resumeStoredSession
 import dev.hazydreams.hermesceleste.network.settleClarificationLocally
+import dev.hazydreams.hermesceleste.network.settleCurrentTurnSteps
 import dev.hazydreams.hermesceleste.network.stageAttachment
 import dev.hazydreams.hermesceleste.network.submitPrompt
 import dev.hazydreams.hermesceleste.network.string
@@ -1066,6 +1069,13 @@ internal class CelesteController(
         val attachments = snapshot.composerAttachments
         if (text.isBlank() && attachments.isEmpty()) return
         when {
+            snapshot.turnState == TurnState.Running &&
+                attachments.isEmpty() &&
+                !snapshot.isCompacting &&
+                snapshot.messages.none { it.role == "clarification" && it.pending } -> {
+                redirectRunningDraft(snapshot, text)
+                return
+            }
             snapshot.turnState == TurnState.Running || snapshot.turnState == TurnState.Reconnecting -> {
                 enqueueDraft(snapshot, text, attachments)
                 return
@@ -1097,6 +1107,85 @@ internal class CelesteController(
             submittedDraft = snapshot.draft,
             queuedPrompt = null,
         )
+    }
+
+    private fun redirectRunningDraft(snapshot: CelesteUiState, text: String) {
+        val activeGateway = gateway
+        val runtimeSessionId = currentRuntimeSessionId
+        val storedSessionId = currentStoredSessionId ?: snapshot.activeSummary?.id
+        if (activeGateway == null || runtimeSessionId == null || storedSessionId == null) {
+            enqueueDraft(snapshot, text, emptyList())
+            return
+        }
+
+        val redirectMessageId = nextLocalMessageId("redirect")
+        val settledMessages = settleCurrentTurnSteps(snapshot.messages)
+        val messagesWithStream = if (snapshot.streamingText.isBlank()) {
+            settledMessages
+        } else {
+            appendCurrentTurnMessage(
+                messages = settledMessages,
+                message = ConversationMessage(
+                    role = "assistant",
+                    text = snapshot.streamingText.trimEnd(),
+                    interim = true,
+                ),
+            )
+        }
+        mutableState.value = snapshot.copy(
+            messages = appendCurrentTurnMessage(
+                messages = messagesWithStream,
+                message = ConversationMessage(
+                    role = "user",
+                    text = text,
+                    id = redirectMessageId,
+                    pending = true,
+                ),
+            ),
+            streamingText = "",
+            draft = "",
+            composerAttachmentGeneration = nextComposerAttachmentGeneration(),
+            errorMessage = null,
+        )
+        val redirectConnectionAttempt = connectionAttempt
+        controllerScope.launch {
+            val accepted = runCatching {
+                activeGateway.redirectSession(runtimeSessionId, text)
+            }.getOrDefault(false)
+            if (
+                gateway !== activeGateway ||
+                connectionAttempt != redirectConnectionAttempt ||
+                currentStoredSessionId != storedSessionId
+            ) {
+                if (!accepted) enqueueRedirectFallback(storedSessionId, text)
+                return@launch
+            }
+
+            mutableState.value = if (accepted) {
+                mutableState.value.copy(
+                    messages = mutableState.value.messages.map { message ->
+                        if (message.id == redirectMessageId) message.copy(pending = false) else message
+                    },
+                )
+            } else {
+                mutableState.value.copy(
+                    messages = mutableState.value.messages.filterNot { it.id == redirectMessageId },
+                )
+            }
+            if (!accepted) enqueueRedirectFallback(storedSessionId, text)
+        }
+    }
+
+    private fun enqueueRedirectFallback(sessionId: String, text: String) {
+        queuedPromptsBySession.getOrPut(sessionId) { mutableListOf() } += QueuedPrompt(
+            id = nextLocalMessageId("queued"),
+            text = text,
+        )
+        parkedQueueSessions.remove(sessionId)
+        if (currentStoredSessionId == sessionId) {
+            refreshActiveQueueProjection(sessionId)
+            drainQueuedPromptIfPossible()
+        }
     }
 
     fun removeQueuedPrompt(promptId: String) {

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -216,6 +216,7 @@ internal class CelesteController(
     )
 
     private var localMessageCounter = 0L
+    private var turnSettlementGeneration = 0L
     private var composerAttachmentGenerationCounter = 0L
     private var credential: GatewayCredential? = null
     private var gateway: GatewayConnection? = null
@@ -1166,6 +1167,7 @@ internal class CelesteController(
         )
         val redirectConnectionAttempt = connectionAttempt
         val redirectStopGeneration = redirectStopGenerationBySession.getOrDefault(storedSessionId, 0L)
+        val redirectTurnSettlementGeneration = turnSettlementGeneration
         val userMessageCountBeforeRedirect = snapshot.messages.count { it.role == "user" }
         controllerScope.launch {
             val attempt = try {
@@ -1211,21 +1213,11 @@ internal class CelesteController(
             }
 
             if (accepted) {
-                mutableState.value = mutableState.value.copy(
-                    messages = mutableState.value.messages.map { message ->
-                        if (message.id == redirectMessageId) {
-                            message.copy(
-                                pending = false,
-                                userPlacement = when (attempt.status) {
-                                    SessionRedirectStatus.Redirected -> UserMessagePlacement.MidTurnCorrection
-                                    SessionRedirectStatus.Queued -> UserMessagePlacement.NextTurn
-                                    SessionRedirectStatus.Rejected -> message.userPlacement
-                                },
-                            )
-                        } else {
-                            message
-                        }
-                    },
+                mutableState.value = projectAcceptedRedirect(
+                    snapshot = mutableState.value,
+                    redirectMessageId = redirectMessageId,
+                    status = attempt.status,
+                    crossedTurnBoundary = turnSettlementGeneration != redirectTurnSettlementGeneration,
                 )
             } else {
                 mutableState.value = mutableState.value.copy(
@@ -1238,6 +1230,49 @@ internal class CelesteController(
                 )
             }
         }
+    }
+
+    private fun projectAcceptedRedirect(
+        snapshot: CelesteUiState,
+        redirectMessageId: String,
+        status: SessionRedirectStatus,
+        crossedTurnBoundary: Boolean,
+    ): CelesteUiState {
+        val markerIndex = snapshot.messages.indexOfFirst { it.id == redirectMessageId }
+        val marker = snapshot.messages.getOrNull(markerIndex) ?: return snapshot
+        if (status != SessionRedirectStatus.Queued) {
+            return snapshot.copy(
+                messages = snapshot.messages.map { message ->
+                    if (message.id == redirectMessageId) {
+                        message.copy(
+                            pending = false,
+                            userPlacement = UserMessagePlacement.MidTurnCorrection,
+                        )
+                    } else {
+                        message
+                    }
+                },
+            )
+        }
+
+        val withoutMarker = snapshot.messages.filterNot { it.id == redirectMessageId }
+        val withCurrentStream = snapshot.streamingText.trimEnd().takeIf(String::isNotBlank)?.let { text ->
+            appendCurrentTurnMessage(
+                messages = withoutMarker,
+                message = ConversationMessage(role = "assistant", text = text, interim = true),
+            )
+        } ?: withoutMarker
+        return snapshot.copy(
+            messages = withCurrentStream + marker.copy(
+                pending = false,
+                userPlacement = if (crossedTurnBoundary) {
+                    UserMessagePlacement.Prompt
+                } else {
+                    UserMessagePlacement.NextTurn
+                },
+            ),
+            streamingText = "",
+        )
     }
 
     private suspend fun redirectWithSessionRecovery(
@@ -2103,66 +2138,93 @@ internal class CelesteController(
     }
 
     private fun resumedLiveProjection(resumed: ResumedSession): ResumedLiveProjection {
-        if (resumed.inflightCorrections.isEmpty()) {
-            return ResumedLiveProjection(
+        val inflightProjection = if (resumed.inflightCorrections.isEmpty()) {
+            ResumedLiveProjection(
                 messages = resumed.messages,
                 streamingText = unpersistedInflightText(
                     inflight = resumed.inflightAssistantText,
                     messages = resumed.messages,
                 ),
             )
-        }
-
-        var messages = resumed.messages
-        val assistant = resumed.inflightAssistantText
-        val offsetsUsable = resumed.inflightCorrections.all { correction ->
-            correction.assistantOffset?.let { it in 0..assistant.length } == true
-        }
-        var cursor = 0
-        resumed.inflightCorrections.forEachIndexed { index, correction ->
-            if (offsetsUsable) {
-                val boundary = correction.assistantOffset!!.coerceIn(cursor, assistant.length)
-                val segment = assistant.substring(cursor, boundary)
-                val missingSegment = unpersistedInflightText(segment, messages)
-                if (missingSegment.isNotBlank()) {
-                    messages = appendCurrentTurnMessage(
-                        messages = messages,
-                        message = ConversationMessage(
-                            role = "assistant",
-                            text = missingSegment,
-                            id = "inflight-assistant-segment-$index-${resumed.runtimeSessionId}",
-                            interim = true,
-                        ),
-                    )
-                }
-                cursor = boundary
-            } else if (index == 0) {
-                val missingAssistant = unpersistedInflightText(assistant, messages)
-                if (missingAssistant.isNotBlank()) {
-                    messages = appendCurrentTurnMessage(
-                        messages = messages,
-                        message = ConversationMessage(
-                            role = "assistant",
-                            text = missingAssistant,
-                            id = "inflight-assistant-${resumed.runtimeSessionId}",
-                            interim = true,
-                        ),
-                    )
-                }
+        } else {
+            var messages = resumed.messages
+            val assistant = resumed.inflightAssistantText
+            val offsetsUsable = resumed.inflightCorrections.all { correction ->
+                correction.assistantOffset?.let { it in 0..assistant.length } == true
             }
-            messages = appendCurrentTurnMessage(
+            var persistedPrefixAvailable = true
+            fun missingSegment(segment: String): String {
+                val text = segment.trim()
+                if (text.isEmpty() || !persistedPrefixAvailable) return text
+                persistedPrefixAvailable = false
+                return unpersistedInflightText(segment, resumed.messages)
+            }
+            var cursor = 0
+            resumed.inflightCorrections.forEachIndexed { index, correction ->
+                if (offsetsUsable) {
+                    val boundary = correction.assistantOffset!!.coerceIn(cursor, assistant.length)
+                    val segment = missingSegment(assistant.substring(cursor, boundary))
+                    if (segment.isNotBlank()) {
+                        messages = appendCurrentTurnMessage(
+                            messages = messages,
+                            message = ConversationMessage(
+                                role = "assistant",
+                                text = segment,
+                                id = "inflight-assistant-segment-$index-${resumed.runtimeSessionId}",
+                                interim = true,
+                            ),
+                        )
+                    }
+                    cursor = boundary
+                } else if (index == 0) {
+                    val missingAssistant = missingSegment(assistant)
+                    if (missingAssistant.isNotBlank()) {
+                        messages = appendCurrentTurnMessage(
+                            messages = messages,
+                            message = ConversationMessage(
+                                role = "assistant",
+                                text = missingAssistant,
+                                id = "inflight-assistant-${resumed.runtimeSessionId}",
+                                interim = true,
+                            ),
+                        )
+                    }
+                }
+                messages = appendCurrentTurnMessage(
+                    messages = messages,
+                    message = ConversationMessage(
+                        role = "user",
+                        text = correction.text,
+                        id = "inflight-correction-$index-${resumed.runtimeSessionId}",
+                        userPlacement = UserMessagePlacement.MidTurnCorrection,
+                    ),
+                )
+            }
+            ResumedLiveProjection(
                 messages = messages,
-                message = ConversationMessage(
-                    role = "user",
-                    text = correction.text,
-                    id = "inflight-correction-$index-${resumed.runtimeSessionId}",
-                    userPlacement = UserMessagePlacement.MidTurnCorrection,
-                ),
+                streamingText = if (offsetsUsable) assistant.substring(cursor).trimStart() else "",
             )
         }
+
+        val queuedText = resumed.queuedUserText.trim()
+        if (queuedText.isEmpty()) return inflightProjection
+        val messagesWithInflightTail = inflightProjection.streamingText.trimEnd()
+            .takeIf(String::isNotBlank)
+            ?.let { text ->
+                appendCurrentTurnMessage(
+                    messages = inflightProjection.messages,
+                    message = ConversationMessage(role = "assistant", text = text, interim = true),
+                )
+            }
+            ?: inflightProjection.messages
         return ResumedLiveProjection(
-            messages = messages,
-            streamingText = if (offsetsUsable) assistant.substring(cursor).trimStart() else "",
+            messages = messagesWithInflightTail + ConversationMessage(
+                role = "user",
+                text = queuedText,
+                id = "queued-user-${resumed.runtimeSessionId}",
+                userPlacement = UserMessagePlacement.NextTurn,
+            ),
+            streamingText = "",
         )
     }
 
@@ -2239,6 +2301,7 @@ internal class CelesteController(
         if (awaitingQueuedActivity && !startsQueuedTurn && event.settlesTurn()) {
             queuedTurnAwaitingActivitySessionId = null
         }
+        if (event.settlesTurn()) turnSettlementGeneration += 1
         val reduction = reduceConversationEvent(
             projection = ConversationProjection(
                 messages = current.messages,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -1144,7 +1144,7 @@ internal class CelesteController(
                 messages = settledMessages,
                 message = ConversationMessage(
                     role = "assistant",
-                    text = snapshot.streamingText.trimEnd(),
+                    text = snapshot.streamingText,
                     interim = true,
                 ),
             )
@@ -1256,7 +1256,7 @@ internal class CelesteController(
         }
 
         val withoutMarker = snapshot.messages.filterNot { it.id == redirectMessageId }
-        val withCurrentStream = snapshot.streamingText.trimEnd().takeIf(String::isNotBlank)?.let { text ->
+        val withCurrentStream = snapshot.streamingText.takeIf(String::isNotBlank)?.let { text ->
             appendCurrentTurnMessage(
                 messages = withoutMarker,
                 message = ConversationMessage(role = "assistant", text = text, interim = true),
@@ -1354,7 +1354,7 @@ internal class CelesteController(
                 messages = settledMessages,
                 message = ConversationMessage(
                     role = "assistant",
-                    text = snapshot.streamingText.trimEnd(),
+                    text = snapshot.streamingText,
                     interim = true,
                 ),
             )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -2154,8 +2154,8 @@ internal class CelesteController(
             }
             var persistedPrefixAvailable = true
             fun missingSegment(segment: String): String {
-                val text = segment.trim()
-                if (text.isEmpty() || !persistedPrefixAvailable) return text
+                if (segment.isBlank()) return ""
+                if (!persistedPrefixAvailable) return segment
                 persistedPrefixAvailable = false
                 return unpersistedInflightText(segment, resumed.messages)
             }
@@ -2202,13 +2202,13 @@ internal class CelesteController(
             }
             ResumedLiveProjection(
                 messages = messages,
-                streamingText = if (offsetsUsable) assistant.substring(cursor).trimStart() else "",
+                streamingText = if (offsetsUsable) assistant.substring(cursor) else "",
             )
         }
 
         val queuedText = resumed.queuedUserText.trim()
         if (queuedText.isEmpty()) return inflightProjection
-        val messagesWithInflightTail = inflightProjection.streamingText.trimEnd()
+        val messagesWithInflightTail = inflightProjection.streamingText
             .takeIf(String::isNotBlank)
             ?.let { text ->
                 appendCurrentTurnMessage(
@@ -3053,15 +3053,15 @@ internal class CelesteController(
             inflight: String,
             messages: List<ConversationMessage>,
         ): String {
-            val recovered = inflight.trim()
-            if (recovered.isEmpty()) return ""
+            if (inflight.isBlank()) return ""
             val persisted = messages.lastOrNull {
                 it.role == "assistant" && it.text.isNotBlank()
             }?.text?.trim().orEmpty()
+            val recovered = inflight.trimStart()
             return if (persisted.isNotEmpty() && recovered.startsWith(persisted)) {
-                recovered.removePrefix(persisted).trimStart()
+                recovered.removePrefix(persisted)
             } else {
-                recovered
+                inflight
             }
         }
     }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -157,6 +157,11 @@ private class AttachmentSessionChangedException :
 private class RedirectSessionChangedException :
     Exception("The conversation changed while Hermes restored its redirect session.")
 
+private data class RedirectAttempt(
+    val status: SessionRedirectStatus,
+    val fallbackCanDrain: Boolean = true,
+)
+
 private data class ResumedLiveProjection(
     val messages: List<ConversationMessage>,
     val streamingText: String,
@@ -237,6 +242,7 @@ internal class CelesteController(
     private val runtimeRetirementBySession = mutableMapOf<String, String>()
     private val migratedSessionIds = mutableMapOf<String, String>()
     private val parkedQueueSessions = mutableSetOf<String>()
+    private val redirectStopGenerationBySession = mutableMapOf<String, Long>()
     private val queueDrainsInFlight = mutableSetOf<String>()
     private var queuedTurnAwaitingActivitySessionId: String? = null
     private var resourcesReleased = false
@@ -1159,34 +1165,58 @@ internal class CelesteController(
             errorMessage = null,
         )
         val redirectConnectionAttempt = connectionAttempt
+        val redirectStopGeneration = redirectStopGenerationBySession.getOrDefault(storedSessionId, 0L)
+        val userMessageCountBeforeRedirect = snapshot.messages.count { it.role == "user" }
         controllerScope.launch {
-            val status = runCatching {
+            val attempt = try {
                 redirectWithSessionRecovery(
                     activeGateway = activeGateway,
                     runtimeSessionId = runtimeSessionId,
                     storedSessionId = storedSessionId,
-                    profile = snapshot.selectedProfile,
                     expectedConnectionAttempt = redirectConnectionAttempt,
+                    redirectMessageId = redirectMessageId,
                     text = text,
                 )
-            }.getOrDefault(SessionRedirectStatus.Rejected)
-            val accepted = status != SessionRedirectStatus.Rejected
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                preserveUncertainRedirect(
+                    activeGateway = activeGateway,
+                    storedSessionId = storedSessionId,
+                    expectedConnectionAttempt = redirectConnectionAttempt,
+                    redirectMessageId = redirectMessageId,
+                    text = text,
+                    userMessageCountBeforeRedirect = userMessageCountBeforeRedirect,
+                )
+                return@launch
+            }
+            val accepted = attempt.status != SessionRedirectStatus.Rejected
+            val resolvedSessionId = canonicalSessionId(storedSessionId)
+            val stopped = resolvedSessionId?.let { sessionId ->
+                redirectStopGenerationBySession.getOrDefault(sessionId, 0L) != redirectStopGeneration
+            } == true
             if (
                 gateway !== activeGateway ||
                 connectionAttempt != redirectConnectionAttempt ||
-                canonicalSessionId(currentStoredSessionId) != canonicalSessionId(storedSessionId)
+                canonicalSessionId(currentStoredSessionId) != resolvedSessionId
             ) {
-                if (!accepted) enqueueRedirectFallback(canonicalSessionId(storedSessionId), text)
+                if (!accepted) {
+                    enqueueRedirectFallback(
+                        sessionId = resolvedSessionId,
+                        text = text,
+                        paused = stopped || !attempt.fallbackCanDrain,
+                    )
+                }
                 return@launch
             }
 
-            mutableState.value = if (accepted) {
-                mutableState.value.copy(
+            if (accepted) {
+                mutableState.value = mutableState.value.copy(
                     messages = mutableState.value.messages.map { message ->
                         if (message.id == redirectMessageId) {
                             message.copy(
                                 pending = false,
-                                userPlacement = when (status) {
+                                userPlacement = when (attempt.status) {
                                     SessionRedirectStatus.Redirected -> UserMessagePlacement.MidTurnCorrection
                                     SessionRedirectStatus.Queued -> UserMessagePlacement.NextTurn
                                     SessionRedirectStatus.Rejected -> message.userPlacement
@@ -1198,11 +1228,15 @@ internal class CelesteController(
                     },
                 )
             } else {
-                mutableState.value.copy(
+                mutableState.value = mutableState.value.copy(
                     messages = mutableState.value.messages.filterNot { it.id == redirectMessageId },
                 )
+                enqueueRedirectFallback(
+                    sessionId = resolvedSessionId,
+                    text = text,
+                    paused = stopped || !attempt.fallbackCanDrain,
+                )
             }
-            if (!accepted) enqueueRedirectFallback(canonicalSessionId(storedSessionId), text)
         }
     }
 
@@ -1210,50 +1244,164 @@ internal class CelesteController(
         activeGateway: GatewayConnection,
         runtimeSessionId: String,
         storedSessionId: String,
-        profile: String,
         expectedConnectionAttempt: Long,
+        redirectMessageId: String,
         text: String,
-    ): SessionRedirectStatus {
+    ): RedirectAttempt {
         var runtimeId = runtimeSessionId
         var recovered = false
         while (true) {
             try {
-                return activeGateway.redirectSession(runtimeId, text)
+                val status = activeGateway.redirectSession(runtimeId, text)
+                if (status != SessionRedirectStatus.Rejected) return RedirectAttempt(status)
+                if (!hasPostRedirectProjection(redirectMessageId)) return RedirectAttempt(status)
+                val canonicalStoredId = canonicalSessionId(storedSessionId)
+                val reconciled = if (
+                    canonicalStoredId != null &&
+                    gateway === activeGateway &&
+                    connectionAttempt == expectedConnectionAttempt
+                ) {
+                    try {
+                        reconcile(activeGateway, canonicalStoredId)
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (_: Throwable) {
+                        null
+                    }
+                } else {
+                    null
+                }
+                return RedirectAttempt(
+                    status = status,
+                    fallbackCanDrain = reconciled != null,
+                )
             } catch (failure: Throwable) {
+                if (failure is CancellationException) throw failure
                 if (recovered || !failure.isSessionNotFoundFailure()) throw failure
                 val canonicalStoredId = canonicalSessionId(storedSessionId)
                     ?: throw RedirectSessionChangedException()
-                val resumed = activeGateway.resumeStoredSession(canonicalStoredId, profile, clientSource)
+                val resumed = reconcile(activeGateway, canonicalStoredId)
+                    ?: throw RedirectSessionChangedException()
                 currentCoroutineContext().ensureActive()
                 if (
                     gateway !== activeGateway ||
                     connectionAttempt != expectedConnectionAttempt ||
-                    canonicalSessionId(currentStoredSessionId) != canonicalStoredId
+                    canonicalSessionId(currentStoredSessionId) != canonicalSessionId(resumed.storedSessionId)
                 ) {
                     throw RedirectSessionChangedException()
                 }
-                if (canonicalStoredId != resumed.storedSessionId) {
-                    migrateSessionBoundState(canonicalStoredId, resumed.storedSessionId)
+                if (mutableState.value.turnState != TurnState.Running) {
+                    return RedirectAttempt(SessionRedirectStatus.Rejected)
                 }
-                currentRuntimeSessionId = resumed.runtimeSessionId
-                currentStoredSessionId = resumed.storedSessionId
-                currentSessionCanResume = true
+                ensurePendingRedirectMarker(redirectMessageId, text)
                 runtimeId = resumed.runtimeSessionId
                 recovered = true
             }
         }
     }
 
-    private fun enqueueRedirectFallback(sessionId: String?, text: String) {
+    private fun hasPostRedirectProjection(redirectMessageId: String): Boolean {
+        val snapshot = mutableState.value
+        val markerIndex = snapshot.messages.indexOfFirst { it.id == redirectMessageId }
+        return markerIndex >= 0 && (
+            snapshot.streamingText.isNotBlank() || markerIndex < snapshot.messages.lastIndex
+        )
+    }
+
+    private fun ensurePendingRedirectMarker(redirectMessageId: String, text: String) {
+        val snapshot = mutableState.value
+        if (snapshot.messages.any { it.id == redirectMessageId }) return
+        val settledMessages = settleCurrentTurnSteps(snapshot.messages)
+        val messagesWithStream = if (snapshot.streamingText.isBlank()) {
+            settledMessages
+        } else {
+            appendCurrentTurnMessage(
+                messages = settledMessages,
+                message = ConversationMessage(
+                    role = "assistant",
+                    text = snapshot.streamingText.trimEnd(),
+                    interim = true,
+                ),
+            )
+        }
+        mutableState.value = snapshot.copy(
+            messages = appendCurrentTurnMessage(
+                messages = messagesWithStream,
+                message = ConversationMessage(
+                    role = "user",
+                    text = text,
+                    id = redirectMessageId,
+                    pending = true,
+                    userPlacement = UserMessagePlacement.MidTurnCorrection,
+                ),
+            ),
+            streamingText = "",
+        )
+    }
+
+    private suspend fun preserveUncertainRedirect(
+        activeGateway: GatewayConnection,
+        storedSessionId: String,
+        expectedConnectionAttempt: Long,
+        redirectMessageId: String,
+        text: String,
+        userMessageCountBeforeRedirect: Int,
+    ) {
+        val resolvedSessionId = canonicalSessionId(storedSessionId) ?: return
+        queuedPromptsBySession.getOrPut(resolvedSessionId) { mutableListOf() } += QueuedPrompt(
+            id = nextLocalMessageId("queued"),
+            text = text,
+            deliveryUncertain = true,
+            userMessageCountBeforeSubmit = userMessageCountBeforeRedirect,
+        )
+        parkedQueueSessions += resolvedSessionId
+        if (canonicalSessionId(currentStoredSessionId) == resolvedSessionId) {
+            mutableState.value = mutableState.value.copy(
+                messages = mutableState.value.messages.filterNot { it.id == redirectMessageId },
+            )
+            refreshActiveQueueProjection(resolvedSessionId)
+        }
+        val reconciled = if (
+            gateway === activeGateway &&
+            connectionAttempt == expectedConnectionAttempt &&
+            canonicalSessionId(currentStoredSessionId) == resolvedSessionId
+        ) {
+            try {
+                reconcile(activeGateway, resolvedSessionId)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                null
+            }
+        } else {
+            null
+        }
+        val currentSessionId = canonicalSessionId(resolvedSessionId) ?: resolvedSessionId
+        if (
+            reconciled == null &&
+            canonicalSessionId(currentStoredSessionId) == currentSessionId &&
+            queuedPromptsFor(currentSessionId).any { it.deliveryUncertain }
+        ) {
+            mutableState.value = mutableState.value.copy(
+                errorMessage = "Delivery could not be confirmed. Review the paused message before retrying.",
+            )
+        }
+    }
+
+    private fun enqueueRedirectFallback(sessionId: String?, text: String, paused: Boolean = false) {
         val resolvedSessionId = canonicalSessionId(sessionId) ?: return
         queuedPromptsBySession.getOrPut(resolvedSessionId) { mutableListOf() } += QueuedPrompt(
             id = nextLocalMessageId("queued"),
             text = text,
         )
-        parkedQueueSessions.remove(resolvedSessionId)
+        if (paused) {
+            parkedQueueSessions += resolvedSessionId
+        } else {
+            parkedQueueSessions.remove(resolvedSessionId)
+        }
         if (canonicalSessionId(currentStoredSessionId) == resolvedSessionId) {
             refreshActiveQueueProjection(resolvedSessionId)
-            drainQueuedPromptIfPossible()
+            if (!paused) drainQueuedPromptIfPossible()
         }
     }
 
@@ -1697,6 +1845,8 @@ internal class CelesteController(
         val runtimeId = currentRuntimeSessionId ?: return
         val sessionId = currentStoredSessionId ?: return
         if (mutableState.value.turnState != TurnState.Running) return
+        redirectStopGenerationBySession[sessionId] =
+            redirectStopGenerationBySession.getOrDefault(sessionId, 0L) + 1L
         if (queuedPromptsFor(sessionId).isNotEmpty()) parkedQueueSessions += sessionId
         submissionsBySession[sessionId]
             ?.takeIf { !it.promptSubmitAttempted }
@@ -1837,7 +1987,7 @@ internal class CelesteController(
         }
     }
 
-    private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String) {
+    private suspend fun reconcile(activeGateway: GatewayConnection, storedSessionId: String): ResumedSession? {
         reconciling = true
         bufferedEvents.clear()
         try {
@@ -1870,7 +2020,7 @@ internal class CelesteController(
                 }
                 runtime to persisted?.await()
             }
-            if (gateway !== activeGateway) return
+            if (gateway !== activeGateway) return null
             if (resumedResult.isFailure && persistedHistory?.messages?.isNotEmpty() == true) {
                 mutableState.value = mutableState.value.copy(
                     messages = preserveLocalAttachmentPresentation(
@@ -1894,21 +2044,21 @@ internal class CelesteController(
             if (storedSessionId != resumed.storedSessionId) {
                 migrateSessionBoundState(storedSessionId, resumed.storedSessionId)
             }
-            applyResumedSession(
-                resumed.copy(
-                    messages = reconciledMessages,
-                    taskProgress = when {
-                        !running -> null
-                        persistedTaskSnapshot != null -> persistedTaskSnapshot.progress
-                        else -> resumed.taskProgress
-                    },
-                ),
+            val reconciled = resumed.copy(
+                messages = reconciledMessages,
+                taskProgress = when {
+                    !running -> null
+                    persistedTaskSnapshot != null -> persistedTaskSnapshot.progress
+                    else -> resumed.taskProgress
+                },
             )
+            applyResumedSession(reconciled)
             val events = bufferedEvents.toList()
             bufferedEvents.clear()
             reconciling = false
             events.forEach(::applyEvent)
             drainQueuedPromptIfPossible()
+            return reconciled
         } catch (error: Throwable) {
             bufferedEvents.clear()
             reconciling = false
@@ -2586,6 +2736,12 @@ internal class CelesteController(
                 .toMutableList()
         }
         if (parkedQueueSessions.remove(fromSessionId)) parkedQueueSessions += toSessionId
+        redirectStopGenerationBySession.remove(fromSessionId)?.let { generation ->
+            redirectStopGenerationBySession[toSessionId] = maxOf(
+                generation,
+                redirectStopGenerationBySession.getOrDefault(toSessionId, 0L),
+            )
+        }
         if (queueDrainsInFlight.remove(fromSessionId)) queueDrainsInFlight += toSessionId
         if (queuedTurnAwaitingActivitySessionId == fromSessionId) {
             queuedTurnAwaitingActivitySessionId = toSessionId
@@ -2669,9 +2825,9 @@ internal class CelesteController(
                 prompt
             }
         }
-        val representedLiveUserText = sequenceOf(
-            resumed.inflightUserText,
-            resumed.queuedUserText,
+        val representedLiveUserText = (
+            sequenceOf(resumed.inflightUserText, resumed.queuedUserText) +
+                resumed.inflightCorrections.asSequence().map { it.text }
         ).map(::normalizedPromptText).filter(String::isNotEmpty).toSet()
         val resumedUserMessages = resumed.messages.filter { it.role == "user" }
         val latestResumedUserText = resumedUserMessages.lastOrNull()?.text?.let(::normalizedPromptText).orEmpty()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -439,15 +439,16 @@ private fun finalizeAssistantBeforeNextTurn(
     val previousAssistantIndex = (nextTurnUserIndex - 1 downTo previousUserIndex + 1)
         .firstOrNull { messages[it].role == "assistant" }
     val previous = previousAssistantIndex?.let(messages::get)
+    val finalContinuesInterim = previous?.takeIf { it.interim }?.text?.let { interimText ->
+        finalText == interimText ||
+            finalText.startsWith(interimText) ||
+            interimText.startsWith(finalText)
+    } == true
     val nextMessages = when {
         finalText.isBlank() -> messages
-        previous?.interim == true -> messages.toMutableList().also { next ->
+        finalContinuesInterim -> messages.toMutableList().also { next ->
             next[previousAssistantIndex] = previous.copy(
-                text = when {
-                    finalText.startsWith(previous.text) -> finalText
-                    previous.text.startsWith(finalText) -> previous.text
-                    else -> finalText
-                },
+                text = if (finalText.length >= previous.text.length) finalText else previous.text,
                 interim = false,
             )
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -419,7 +419,7 @@ private fun redirectedAssistantSuffix(
         message.role == "user" && message.userPlacement == UserMessagePlacement.Prompt
     }
     val sealedPrefix = messages.subList(turnStart + 1, correctionIndex)
-        .filter { it.role == "assistant" && it.interim }
+        .filter { it.role == "assistant" }
         .joinToString(separator = "", transform = ConversationMessage::text)
     return if (sealedPrefix.isNotBlank() && suppliedContent.startsWith(sealedPrefix)) {
         suppliedContent.removePrefix(sealedPrefix).trimStart()

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -136,6 +136,9 @@ internal fun reduceConversationEvent(
             val echoedStreamingAnswer = next.streamingText.trimEnd().let { streamed ->
                 streamed.isNotBlank() && streamed == content.trimEnd()
             } || next.hasInterimAssistantEcho(content)
+            if (echoedStreamingAnswer) {
+                next = next.removeTrailingReasoningEcho(content)
+            }
             next = next.finalizeAssistant(content, keepRunning = false)
             next = next.removeReasoningEchoOfFinalAnswer(echoedStreamingAnswer)
             next.copy(
@@ -430,12 +433,14 @@ private fun finalizeAssistantBeforeNextTurn(
     nextTurnUserIndex: Int,
     finalText: String,
 ): List<ConversationMessage> {
-    if (nextTurnUserIndex < 0 || finalText.isBlank()) return messages
+    if (nextTurnUserIndex < 0) return messages
+    val markerId = messages[nextTurnUserIndex].id
     val previousUserIndex = messages.subList(0, nextTurnUserIndex).indexOfLast { it.role == "user" }
     val previousAssistantIndex = (nextTurnUserIndex - 1 downTo previousUserIndex + 1)
         .firstOrNull { messages[it].role == "assistant" }
     val previous = previousAssistantIndex?.let(messages::get)
-    return when {
+    val nextMessages = when {
+        finalText.isBlank() -> messages
         previous?.interim == true -> messages.toMutableList().also { next ->
             next[previousAssistantIndex] = previous.copy(
                 text = when {
@@ -454,13 +459,23 @@ private fun finalizeAssistantBeforeNextTurn(
             )
         }
     }
+    val markerIndex = nextMessages.indexOfFirst { message ->
+        markerId != null && message.id == markerId
+    }.takeIf { it >= 0 } ?: nextMessages.indexOfLast { message ->
+        message.role == "user" && message.userPlacement == UserMessagePlacement.NextTurn
+    }
+    if (markerIndex < 0) return nextMessages
+    return nextMessages.toMutableList().also { next ->
+        next[markerIndex] = next[markerIndex].copy(userPlacement = UserMessagePlacement.Prompt)
+    }
 }
 
 private fun currentTurnLastAssistantIndex(messages: List<ConversationMessage>): Int {
     val userIndex = messages.indexOfLast { it.role == "user" }
-    return messages.indices.reversed().firstOrNull { index ->
+    val contentTail = currentTurnContentTailIndex(messages)
+    return contentTail.takeIf { index ->
         index > userIndex && messages[index].role == "assistant"
-    } ?: currentTurnContentTailIndex(messages)
+    } ?: -1
 }
 
 private fun ConversationProjection.removeReasoningEchoOfFinalAnswer(
@@ -479,11 +494,10 @@ private fun ConversationProjection.removeReasoningEchoOfFinalAnswer(
         .firstOrNull { messages[it].role == "steps" }
         ?: return this
     val stepsMessage = messages[stepsIndex]
-    val echoedStep = stepsMessage.steps.lastOrNull()
-        ?.takeIf { step ->
-            step.kind == ConversationStepKind.Reasoning && step.detail.trimEnd() == finalText
-        }
-        ?: return this
+    val hasEcho = stepsMessage.steps.lastOrNull()?.let { step ->
+        step.kind == ConversationStepKind.Reasoning && step.detail.trimEnd() == finalText
+    } == true
+    if (!hasEcho) return this
     val nextSteps = stepsMessage.steps.dropLast(1)
     val nextMessages = messages.toMutableList().also { next ->
         if (nextSteps.isEmpty()) {
@@ -493,4 +507,28 @@ private fun ConversationProjection.removeReasoningEchoOfFinalAnswer(
         }
     }
     return copy(messages = nextMessages)
+}
+
+private fun ConversationProjection.removeTrailingReasoningEcho(finalAnswer: String): ConversationProjection {
+    val finalText = finalAnswer.trimEnd()
+    if (finalText.isBlank()) return this
+    val userIndex = messages.indexOfLast { it.role == "user" }
+    val stepsIndex = currentTurnContentTailIndex(messages)
+        .takeIf { index -> index > userIndex && messages[index].role == "steps" }
+        ?: return this
+    val stepsMessage = messages[stepsIndex]
+    val hasEcho = stepsMessage.steps.lastOrNull()?.let { step ->
+        step.kind == ConversationStepKind.Reasoning && step.detail.trimEnd() == finalText
+    } == true
+    if (!hasEcho) return this
+    val nextSteps = stepsMessage.steps.dropLast(1)
+    return copy(
+        messages = messages.toMutableList().also { next ->
+            if (nextSteps.isEmpty()) {
+                next.removeAt(stepsIndex)
+            } else {
+                next[stepsIndex] = stepsMessage.copy(steps = nextSteps)
+            }
+        },
+    )
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -4,6 +4,7 @@ import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.network.ConversationStepKind
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.TaskProgress
+import dev.hazydreams.hermesceleste.network.UserMessagePlacement
 import dev.hazydreams.hermesceleste.network.appendCurrentTurnMessage
 import dev.hazydreams.hermesceleste.network.appendReasoningToCurrentTurn
 import dev.hazydreams.hermesceleste.network.bindClarificationRequest
@@ -132,8 +133,11 @@ internal fun reduceConversationEvent(
                 ?: event.payload.string("content")
                 ?: event.payload.string("rendered")
                 ?: ""
+            val echoedStreamingAnswer = next.streamingText.trimEnd().let { streamed ->
+                streamed.isNotBlank() && streamed == content.trimEnd()
+            } || next.hasInterimAssistantEcho(content)
             next = next.finalizeAssistant(content, keepRunning = false)
-            next = next.removeReasoningEchoOfFinalAnswer()
+            next = next.removeReasoningEchoOfFinalAnswer(echoedStreamingAnswer)
             next.copy(
                 messages = clearUnansweredClarifications(settleCurrentTurnSteps(next.messages)),
                 turnState = TurnState.Idle,
@@ -333,48 +337,123 @@ internal fun reduceConversationEvent(
 private fun ConversationProjection.clearActiveTaskProgress(): ConversationProjection =
     if (taskProgress?.isActive == true) copy(taskProgress = null) else this
 
+private fun ConversationProjection.hasInterimAssistantEcho(content: String): Boolean {
+    val finalText = content.trimEnd()
+    if (finalText.isBlank()) return false
+    val turnStart = messages.indexOfLast { it.role == "user" }
+    return messages.indices.any { index ->
+        index > turnStart &&
+            messages[index].role == "assistant" &&
+            messages[index].interim &&
+            messages[index].text.trimEnd() == finalText
+    }
+}
+
 private fun ConversationProjection.finalizeAssistant(
     suppliedContent: String = "",
     keepRunning: Boolean = turnState == TurnState.Running,
     interim: Boolean = false,
 ): ConversationProjection {
-    val finalText = when {
-        suppliedContent.isBlank() -> streamingText
-        streamingText.isBlank() -> suppliedContent
-        suppliedContent.startsWith(streamingText) -> suppliedContent
-        streamingText.startsWith(suppliedContent) -> streamingText
-        else -> suppliedContent
-    }.trimEnd()
-    val previousIndex = currentTurnLastAssistantIndex(messages)
-    val previous = messages.getOrNull(previousIndex)
-    val continuesInterim = !interim &&
-        previous?.role == "assistant" &&
-        previous.interim &&
-        finalText.isNotBlank() &&
-        (finalText.startsWith(previous.text) || previous.text.startsWith(finalText))
-    val nextMessages = when {
-        continuesInterim -> messages.toMutableList().also { next ->
-            next[previousIndex] = previous.copy(
-                text = if (finalText.length >= previous.text.length) finalText else previous.text,
-                interim = false,
-            )
+    val latestUserIndex = messages.indexOfLast { it.role == "user" }
+    val latestUserPlacement = messages.getOrNull(latestUserIndex)?.userPlacement
+    val adjustedSupplied = if (latestUserPlacement == UserMessagePlacement.MidTurnCorrection) {
+        redirectedAssistantSuffix(suppliedContent, messages, latestUserIndex)
+    } else {
+        suppliedContent
+    }
+    val finalText = mergedFinalText(adjustedSupplied, streamingText)
+    val nextMessages = if (latestUserPlacement == UserMessagePlacement.NextTurn) {
+        finalizeAssistantBeforeNextTurn(messages, latestUserIndex, finalText)
+    } else {
+        val previousIndex = currentTurnLastAssistantIndex(messages)
+        val previous = messages.getOrNull(previousIndex)
+        val continuesInterim = !interim &&
+            previous?.role == "assistant" &&
+            previous.interim &&
+            finalText.isNotBlank() &&
+            (finalText.startsWith(previous.text) || previous.text.startsWith(finalText))
+        when {
+            continuesInterim -> messages.toMutableList().also { next ->
+                next[previousIndex] = previous.copy(
+                    text = if (finalText.length >= previous.text.length) finalText else previous.text,
+                    interim = false,
+                )
+            }
+            finalText.isNotBlank() && previous?.let { it.role == "assistant" && it.text == finalText } != true ->
+                appendCurrentTurnMessage(
+                    messages = messages,
+                    message = ConversationMessage(
+                        role = "assistant",
+                        text = finalText,
+                        interim = interim,
+                    ),
+                )
+            else -> messages
         }
-        finalText.isNotBlank() && previous?.let { it.role == "assistant" && it.text == finalText } != true ->
-            appendCurrentTurnMessage(
-                messages = messages,
-                message = ConversationMessage(
-                    role = "assistant",
-                    text = finalText,
-                    interim = interim,
-                ),
-            )
-        else -> messages
     }
     return copy(
         messages = nextMessages,
         streamingText = "",
         turnState = if (keepRunning) TurnState.Running else TurnState.Idle,
     )
+}
+
+private fun mergedFinalText(suppliedContent: String, streamingText: String): String = when {
+    suppliedContent.isBlank() -> streamingText
+    streamingText.isBlank() -> suppliedContent
+    suppliedContent.startsWith(streamingText) -> suppliedContent
+    streamingText.startsWith(suppliedContent) -> streamingText
+    else -> suppliedContent
+}.trimEnd()
+
+private fun redirectedAssistantSuffix(
+    suppliedContent: String,
+    messages: List<ConversationMessage>,
+    correctionIndex: Int,
+): String {
+    if (suppliedContent.isBlank() || correctionIndex < 0) return suppliedContent
+    val turnStart = messages.subList(0, correctionIndex).indexOfLast { message ->
+        message.role == "user" && message.userPlacement == UserMessagePlacement.Prompt
+    }
+    val sealedPrefix = messages.subList(turnStart + 1, correctionIndex)
+        .filter { it.role == "assistant" && it.interim }
+        .joinToString(separator = "", transform = ConversationMessage::text)
+    return if (sealedPrefix.isNotBlank() && suppliedContent.startsWith(sealedPrefix)) {
+        suppliedContent.removePrefix(sealedPrefix).trimStart()
+    } else {
+        suppliedContent
+    }
+}
+
+private fun finalizeAssistantBeforeNextTurn(
+    messages: List<ConversationMessage>,
+    nextTurnUserIndex: Int,
+    finalText: String,
+): List<ConversationMessage> {
+    if (nextTurnUserIndex < 0 || finalText.isBlank()) return messages
+    val previousUserIndex = messages.subList(0, nextTurnUserIndex).indexOfLast { it.role == "user" }
+    val previousAssistantIndex = (nextTurnUserIndex - 1 downTo previousUserIndex + 1)
+        .firstOrNull { messages[it].role == "assistant" }
+    val previous = previousAssistantIndex?.let(messages::get)
+    return when {
+        previous?.interim == true -> messages.toMutableList().also { next ->
+            next[previousAssistantIndex] = previous.copy(
+                text = when {
+                    finalText.startsWith(previous.text) -> finalText
+                    previous.text.startsWith(finalText) -> previous.text
+                    else -> finalText
+                },
+                interim = false,
+            )
+        }
+        previous?.text == finalText -> messages
+        else -> messages.toMutableList().also { next ->
+            next.add(
+                nextTurnUserIndex,
+                ConversationMessage(role = "assistant", text = finalText),
+            )
+        }
+    }
 }
 
 private fun currentTurnLastAssistantIndex(messages: List<ConversationMessage>): Int {
@@ -384,24 +463,34 @@ private fun currentTurnLastAssistantIndex(messages: List<ConversationMessage>): 
     } ?: currentTurnContentTailIndex(messages)
 }
 
-private fun ConversationProjection.removeReasoningEchoOfFinalAnswer(): ConversationProjection {
-    val finalText = messages.getOrNull(currentTurnLastAssistantIndex(messages))
+private fun ConversationProjection.removeReasoningEchoOfFinalAnswer(
+    echoedStreamingAnswer: Boolean,
+): ConversationProjection {
+    if (!echoedStreamingAnswer) return this
+    val finalIndex = currentTurnLastAssistantIndex(messages)
+    val finalText = messages.getOrNull(finalIndex)
         ?.takeIf { it.role == "assistant" }
         ?.text
         ?.trimEnd()
         .orEmpty()
     if (finalText.isBlank()) return this
     val userIndex = messages.indexOfLast { it.role == "user" }
-    var changed = false
-    val nextMessages = messages.mapIndexedNotNull { index, message ->
-        if (index <= userIndex || message.role != "steps") return@mapIndexedNotNull message
-        val nextSteps = message.steps.filterNot { step ->
-            step.kind == ConversationStepKind.Reasoning &&
-                step.detail.trimEnd() == finalText
+    val stepsIndex = (messages.lastIndex downTo userIndex + 1)
+        .firstOrNull { messages[it].role == "steps" }
+        ?: return this
+    val stepsMessage = messages[stepsIndex]
+    val echoedStep = stepsMessage.steps.lastOrNull()
+        ?.takeIf { step ->
+            step.kind == ConversationStepKind.Reasoning && step.detail.trimEnd() == finalText
         }
-        if (nextSteps.size == message.steps.size) return@mapIndexedNotNull message
-        changed = true
-        message.copy(steps = nextSteps).takeIf { nextSteps.isNotEmpty() }
+        ?: return this
+    val nextSteps = stepsMessage.steps.dropLast(1)
+    val nextMessages = messages.toMutableList().also { next ->
+        if (nextSteps.isEmpty()) {
+            next.removeAt(stepsIndex)
+        } else {
+            next[stepsIndex] = stepsMessage.copy(steps = nextSteps)
+        }
     }
-    return if (changed) copy(messages = nextMessages) else this
+    return copy(messages = nextMessages)
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -1,6 +1,7 @@
 package dev.hazydreams.hermesceleste
 
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.ConversationStepKind
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.TaskProgress
 import dev.hazydreams.hermesceleste.network.appendCurrentTurnMessage
@@ -132,6 +133,7 @@ internal fun reduceConversationEvent(
                 ?: event.payload.string("rendered")
                 ?: ""
             next = next.finalizeAssistant(content, keepRunning = false)
+            next = next.removeReasoningEchoOfFinalAnswer()
             next.copy(
                 messages = clearUnansweredClarifications(settleCurrentTurnSteps(next.messages)),
                 turnState = TurnState.Idle,
@@ -343,7 +345,7 @@ private fun ConversationProjection.finalizeAssistant(
         streamingText.startsWith(suppliedContent) -> streamingText
         else -> suppliedContent
     }.trimEnd()
-    val previousIndex = currentTurnContentTailIndex(messages)
+    val previousIndex = currentTurnLastAssistantIndex(messages)
     val previous = messages.getOrNull(previousIndex)
     val continuesInterim = !interim &&
         previous?.role == "assistant" &&
@@ -373,4 +375,33 @@ private fun ConversationProjection.finalizeAssistant(
         streamingText = "",
         turnState = if (keepRunning) TurnState.Running else TurnState.Idle,
     )
+}
+
+private fun currentTurnLastAssistantIndex(messages: List<ConversationMessage>): Int {
+    val userIndex = messages.indexOfLast { it.role == "user" }
+    return messages.indices.reversed().firstOrNull { index ->
+        index > userIndex && messages[index].role == "assistant"
+    } ?: currentTurnContentTailIndex(messages)
+}
+
+private fun ConversationProjection.removeReasoningEchoOfFinalAnswer(): ConversationProjection {
+    val finalText = messages.getOrNull(currentTurnLastAssistantIndex(messages))
+        ?.takeIf { it.role == "assistant" }
+        ?.text
+        ?.trimEnd()
+        .orEmpty()
+    if (finalText.isBlank()) return this
+    val userIndex = messages.indexOfLast { it.role == "user" }
+    var changed = false
+    val nextMessages = messages.mapIndexedNotNull { index, message ->
+        if (index <= userIndex || message.role != "steps") return@mapIndexedNotNull message
+        val nextSteps = message.steps.filterNot { step ->
+            step.kind == ConversationStepKind.Reasoning &&
+                step.detail.trimEnd() == finalText
+        }
+        if (nextSteps.size == message.steps.size) return@mapIndexedNotNull message
+        changed = true
+        message.copy(steps = nextSteps).takeIf { nextSteps.isNotEmpty() }
+    }
+    return if (changed) copy(messages = nextMessages) else this
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -439,6 +439,7 @@ private fun finalizeAssistantBeforeNextTurn(
     val previousAssistantIndex = (nextTurnUserIndex - 1 downTo previousUserIndex + 1)
         .firstOrNull { messages[it].role == "assistant" }
     val previous = previousAssistantIndex?.let(messages::get)
+    val completionInsertionIndex = currentTurnContentTailIndex(messages.subList(0, nextTurnUserIndex)) + 1
     val finalContinuesInterim = previous?.takeIf { it.interim }?.text?.let { interimText ->
         finalText == interimText ||
             finalText.startsWith(interimText) ||
@@ -455,7 +456,7 @@ private fun finalizeAssistantBeforeNextTurn(
         previous?.text == finalText -> messages
         else -> messages.toMutableList().also { next ->
             next.add(
-                nextTurnUserIndex,
+                completionInsertionIndex,
                 ConversationMessage(role = "assistant", text = finalText),
             )
         }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -104,7 +104,7 @@ internal fun reduceConversationEvent(
                 next
             } else {
                 next.copy(
-                    messages = settleCurrentReasoning(next.messages),
+                    messages = settleCurrentTurnSteps(next.messages),
                     streamingText = next.streamingText + delta,
                     turnState = TurnState.Running,
                 )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ConversationEventReducer.kt
@@ -359,8 +359,13 @@ private fun ConversationProjection.finalizeAssistant(
 ): ConversationProjection {
     val latestUserIndex = messages.indexOfLast { it.role == "user" }
     val latestUserPlacement = messages.getOrNull(latestUserIndex)?.userPlacement
-    val adjustedSupplied = if (latestUserPlacement == UserMessagePlacement.MidTurnCorrection) {
-        redirectedAssistantSuffix(suppliedContent, messages, latestUserIndex)
+    val correctionIndex = when (latestUserPlacement) {
+        UserMessagePlacement.MidTurnCorrection -> latestUserIndex
+        UserMessagePlacement.NextTurn -> latestMidTurnCorrectionIndex(messages, latestUserIndex)
+        else -> -1
+    }
+    val adjustedSupplied = if (correctionIndex >= 0) {
+        redirectedAssistantSuffix(suppliedContent, messages, correctionIndex)
     } else {
         suppliedContent
     }
@@ -408,6 +413,20 @@ private fun mergedFinalText(suppliedContent: String, streamingText: String): Str
     streamingText.startsWith(suppliedContent) -> streamingText
     else -> suppliedContent
 }.trimEnd()
+
+private fun latestMidTurnCorrectionIndex(
+    messages: List<ConversationMessage>,
+    beforeUserIndex: Int,
+): Int {
+    if (beforeUserIndex <= 0) return -1
+    val turnStart = messages.subList(0, beforeUserIndex).indexOfLast { message ->
+        message.role == "user" && message.userPlacement == UserMessagePlacement.Prompt
+    }
+    return (beforeUserIndex - 1 downTo turnStart + 1).firstOrNull { index ->
+        messages[index].role == "user" &&
+            messages[index].userPlacement == UserMessagePlacement.MidTurnCorrection
+    } ?: -1
+}
 
 private fun redirectedAssistantSuffix(
     suppliedContent: String,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
@@ -110,33 +110,68 @@ internal fun completeToolInCurrentTurn(
     result: String,
     fallbackStepId: String,
     stepsMessageId: String,
-): List<ConversationMessage> = updateCurrentTurnSteps(messages, stepsMessageId) { current ->
-    val existingIndex = current.indexOfFirst { step ->
-        step.kind == ConversationStepKind.Tool && when {
-            !id.isNullOrBlank() -> step.id == id
-            else -> step.toolName == name && step.pending
+): List<ConversationMessage> {
+    if (!id.isNullOrBlank()) {
+        val promptStart = messages.indexOfLast { message ->
+            message.role == "user" && message.userPlacement == UserMessagePlacement.Prompt
         }
-    }
-    if (existingIndex < 0) {
-        current + ConversationStep(
-            id = id?.takeIf(String::isNotBlank) ?: fallbackStepId,
-            kind = ConversationStepKind.Tool,
-            toolName = name,
-            context = context,
-            summary = summary,
-            result = result,
-            pending = false,
-        )
-    } else {
-        current.toMutableList().also { steps ->
-            val previous = steps[existingIndex]
-            steps[existingIndex] = previous.copy(
+        val stepsMessageIndex = (messages.lastIndex downTo (promptStart + 1)).firstOrNull { messageIndex ->
+            messages[messageIndex].steps.any { step ->
+                step.kind == ConversationStepKind.Tool && step.id == id
+            }
+        }
+        if (stepsMessageIndex != null) {
+            val previousMessage = messages[stepsMessageIndex]
+            val steps = previousMessage.steps.toMutableList()
+            val stepIndex = steps.indexOfFirst { step ->
+                step.kind == ConversationStepKind.Tool && step.id == id
+            }
+            val previous = steps[stepIndex]
+            steps[stepIndex] = previous.copy(
                 toolName = name,
                 context = previous.context.ifBlank { context },
                 summary = summary,
                 result = result,
                 pending = false,
             )
+            return messages.toMutableList().also { next ->
+                val latestUserIndex = messages.indexOfLast { it.role == "user" }
+                next[stepsMessageIndex] = previousMessage.copy(
+                    steps = steps,
+                    pending = stepsMessageIndex > latestUserIndex || steps.any(ConversationStep::pending),
+                )
+            }
+        }
+    }
+
+    return updateCurrentTurnSteps(messages, stepsMessageId) { current ->
+        val existingIndex = current.indexOfFirst { step ->
+            step.kind == ConversationStepKind.Tool && when {
+                !id.isNullOrBlank() -> step.id == id
+                else -> step.toolName == name && step.pending
+            }
+        }
+        if (existingIndex < 0) {
+            current + ConversationStep(
+                id = id?.takeIf(String::isNotBlank) ?: fallbackStepId,
+                kind = ConversationStepKind.Tool,
+                toolName = name,
+                context = context,
+                summary = summary,
+                result = result,
+                pending = false,
+            )
+        } else {
+            current.toMutableList().also { steps ->
+                val previous = steps[existingIndex]
+                steps[existingIndex] = previous.copy(
+                    toolName = name,
+                    context = previous.context.ifBlank { context },
+                    summary = summary,
+                    result = result,
+                    pending = false,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
@@ -7,6 +7,12 @@ enum class ConversationStepKind {
     Tool,
 }
 
+enum class UserMessagePlacement {
+    Prompt,
+    MidTurnCorrection,
+    NextTurn,
+}
+
 data class ConversationStep(
     val id: String,
     val kind: ConversationStepKind,
@@ -24,6 +30,7 @@ data class ConversationMessage(
     val id: String? = null,
     val pending: Boolean = false,
     val interim: Boolean = false,
+    val userPlacement: UserMessagePlacement = UserMessagePlacement.Prompt,
     val steps: List<ConversationStep> = emptyList(),
     val processResult: BackgroundProcessResult? = null,
     val fileEdits: List<FileEditOperation> = emptyList(),

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -99,8 +99,20 @@ data class ResumedSession(
     val inflightUserText: String = "",
     val queuedUserText: String = "",
     val inflightAssistantText: String = "",
+    val inflightCorrections: List<InflightCorrection> = emptyList(),
     val hasLiveProjection: Boolean = false,
 )
+
+data class InflightCorrection(
+    val text: String,
+    val assistantOffset: Int? = null,
+)
+
+enum class SessionRedirectStatus {
+    Redirected,
+    Queued,
+    Rejected,
+}
 
 data class ConversationHistory(
     val messages: List<ConversationMessage>,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -126,6 +126,20 @@ suspend fun GatewayConnection.submitPrompt(
     ).asObject("Hermes returned no prompt status.")
 }
 
+suspend fun GatewayConnection.redirectSession(runtimeSessionId: String, text: String): Boolean {
+    require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }
+    require(text.isNotBlank()) { "A correction is required." }
+    val result = request(
+        method = "session.redirect",
+        params = buildJsonObject {
+            put("session_id", runtimeSessionId)
+            put("text", text)
+        },
+        timeoutMillis = 30_000,
+    ).asObject("Hermes returned no redirect status.")
+    return result.string("status") in setOf("redirected", "queued")
+}
+
 suspend fun GatewayConnection.stageAttachment(
     runtimeSessionId: String,
     attachment: ComposerAttachment,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.put
 
 data class CreatedSession(
@@ -92,6 +93,18 @@ suspend fun GatewayConnection.resumeStoredSession(
     val resumedMessages = pendingClarification
         ?.let { bindClarificationRequest(decoded.messages, it) }
         ?: decoded.messages
+    val inflightObject = inflight as? JsonObject
+    val correctionOffsets = (inflightObject?.get("correction_offsets") as? JsonArray)
+        ?.map { it.jsonPrimitive.intOrNull }
+        .orEmpty()
+    val inflightCorrections = (inflightObject?.get("corrections") as? JsonArray)
+        ?.mapIndexedNotNull { index, correction ->
+            correction.jsonPrimitive.contentOrNull
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
+                ?.let { text -> InflightCorrection(text, correctionOffsets.getOrNull(index)) }
+        }
+        .orEmpty()
     return ResumedSession(
         runtimeSessionId = runtimeId,
         storedSessionId = result.string("resumed")
@@ -105,6 +118,7 @@ suspend fun GatewayConnection.resumeStoredSession(
         inflightUserText = (inflight as? JsonObject)?.string("user").orEmpty(),
         queuedUserText = (queued as? JsonObject)?.string("user").orEmpty(),
         inflightAssistantText = inflightAssistantText(inflight),
+        inflightCorrections = inflightCorrections,
         hasLiveProjection = inflight.isTruthy() || queued.isTruthy() || pendingClarification != null,
     )
 }
@@ -126,7 +140,7 @@ suspend fun GatewayConnection.submitPrompt(
     ).asObject("Hermes returned no prompt status.")
 }
 
-suspend fun GatewayConnection.redirectSession(runtimeSessionId: String, text: String): Boolean {
+suspend fun GatewayConnection.redirectSession(runtimeSessionId: String, text: String): SessionRedirectStatus {
     require(runtimeSessionId.isNotBlank()) { "No Hermes conversation is open." }
     require(text.isNotBlank()) { "A correction is required." }
     val result = request(
@@ -137,7 +151,11 @@ suspend fun GatewayConnection.redirectSession(runtimeSessionId: String, text: St
         },
         timeoutMillis = 30_000,
     ).asObject("Hermes returned no redirect status.")
-    return result.string("status") in setOf("redirected", "queued")
+    return when (result.string("status")) {
+        "redirected" -> SessionRedirectStatus.Redirected
+        "queued" -> SessionRedirectStatus.Queued
+        else -> SessionRedirectStatus.Rejected
+    }
 }
 
 suspend fun GatewayConnection.stageAttachment(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -94,6 +94,7 @@ suspend fun GatewayConnection.resumeStoredSession(
         ?.let { bindClarificationRequest(decoded.messages, it) }
         ?: decoded.messages
     val inflightObject = inflight as? JsonObject
+    val inflightAssistant = inflightAssistantText(inflight)
     val correctionOffsets = (inflightObject?.get("correction_offsets") as? JsonArray)
         ?.map { it.jsonPrimitive.intOrNull }
         .orEmpty()
@@ -102,7 +103,13 @@ suspend fun GatewayConnection.resumeStoredSession(
             correction.jsonPrimitive.contentOrNull
                 ?.trim()
                 ?.takeIf(String::isNotEmpty)
-                ?.let { text -> InflightCorrection(text, correctionOffsets.getOrNull(index)) }
+                ?.let { text ->
+                    InflightCorrection(
+                        text = text,
+                        assistantOffset = correctionOffsets.getOrNull(index)
+                            ?.let { offset -> codePointOffsetToUtf16Index(inflightAssistant, offset) },
+                    )
+                }
         }
         .orEmpty()
     return ResumedSession(
@@ -117,7 +124,7 @@ suspend fun GatewayConnection.resumeStoredSession(
         status = status,
         inflightUserText = (inflight as? JsonObject)?.string("user").orEmpty(),
         queuedUserText = (queued as? JsonObject)?.string("user").orEmpty(),
-        inflightAssistantText = inflightAssistantText(inflight),
+        inflightAssistantText = inflightAssistant,
         inflightCorrections = inflightCorrections,
         hasLiveProjection = inflight.isTruthy() || queued.isTruthy() || pendingClarification != null,
     )
@@ -584,6 +591,22 @@ private fun cleanedRestoredReasoning(reasoning: String): String = reasoning
 
 private fun JsonElement?.scalarIdentity(): String? =
     (this as? JsonPrimitive)?.contentOrNull?.takeIf(String::isNotBlank)
+
+internal fun codePointOffsetToUtf16Index(text: String, codePointOffset: Int): Int? {
+    if (codePointOffset < 0) return null
+    var codePoints = 0
+    var utf16Index = 0
+    while (codePoints < codePointOffset) {
+        if (utf16Index >= text.length) return null
+        val current = text[utf16Index].code
+        val hasLowSurrogate = current in 0xD800..0xDBFF &&
+            utf16Index + 1 < text.length &&
+            text[utf16Index + 1].code in 0xDC00..0xDFFF
+        utf16Index += if (hasLowSurrogate) 2 else 1
+        codePoints += 1
+    }
+    return utf16Index
+}
 
 private fun inflightAssistantText(element: JsonElement?): String {
     val row = element as? JsonObject ?: return ""

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -24,6 +24,7 @@ import dev.hazydreams.hermesceleste.network.TaskItemStatus
 import dev.hazydreams.hermesceleste.network.TaskProgress
 import dev.hazydreams.hermesceleste.network.TaskProgressItem
 import dev.hazydreams.hermesceleste.network.TaskProgressSnapshot
+import dev.hazydreams.hermesceleste.network.UserMessagePlacement
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -1065,6 +1066,132 @@ class CelesteViewModelTest {
         assertEquals("Working on it", viewModel.state.value.messages[1].text)
         assertFalse(viewModel.state.value.messages.last().pending)
         assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun redirectedCompletionKeepsArrivalOrderWithoutRepeatingPreCorrectionProse() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "redirected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        gateway.emit("message.delta", """{"text":"Before."}""")
+        viewModel.updateDraft("Change direction")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        gateway.emit("message.delta", """{"text":"After."}""")
+        gateway.emit("message.complete", """{"content":"Before.After.","status":"complete"}""")
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Before.", "Change direction", "After."),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals(
+            UserMessagePlacement.MidTurnCorrection,
+            viewModel.state.value.messages[2].userPlacement,
+        )
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun gatewayQueuedRedirectKeepsTheCurrentReplyBeforeTheNextTurn() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "queued" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Run this next")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        gateway.emit("message.complete", """{"content":"First answer","status":"complete"}""")
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "First answer", "Run this next"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals(UserMessagePlacement.NextTurn, viewModel.state.value.messages.last().userPlacement)
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun resumeRestoresAcceptedRedirectAtItsAssistantOffset() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+                running = true,
+                inflightJson = """{"user":"First","assistant":"Before.After.","streaming":true,"corrections":["Change direction"],"correction_offsets":[7]}""",
+            )
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Before.", "Change direction"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals("After.", viewModel.state.value.streamingText)
+        assertEquals(
+            UserMessagePlacement.MidTurnCorrection,
+            viewModel.state.value.messages.last().userPlacement,
+        )
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun staleRuntimeRedirectResumesAndRetriesOnce() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "redirected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        gateway.redirectFailure = GatewayRpcException(4001, "session not found")
+        gateway.redirectFailureOnce = true
+        gateway.resumePayload = resumePayload(
+            messages = emptyList(),
+            running = true,
+            runtimeSessionId = "runtime-recovered",
+        )
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Use recovered runtime")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("runtime-7", "runtime-recovered"),
+            gateway.requests.filter { it.first == "session.redirect" }
+                .map { it.second["session_id"]?.jsonPrimitive?.content },
+        )
+        assertTrue(viewModel.state.value.queuedPrompts.isEmpty())
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun rejectedRedirectFallbackFollowsRecoveredStoredSessionIdentity() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "rejected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        gateway.redirectFailure = GatewayRpcException(4001, "session not found")
+        gateway.redirectFailureOnce = true
+        gateway.resumePayload = resumePayload(
+            messages = emptyList(),
+            running = true,
+            runtimeSessionId = "runtime-recovered",
+            storedSessionId = "stored-recovered",
+        )
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Keep this correction")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals("stored-recovered", viewModel.state.value.activeSummary?.id)
+        assertEquals(listOf("Keep this correction"), viewModel.state.value.queuedPrompts.map { it.text })
         viewModel.controller.close()
     }
 
@@ -2651,6 +2778,8 @@ class CelesteViewModelTest {
         var createFailure: Throwable? = null
         var promptFailure: Throwable? = null
         var redirectStatus = "rejected"
+        var redirectFailure: Throwable? = null
+        var redirectFailureOnce = false
         var attachmentFailure: Throwable? = null
         var attachmentFailureOnce = false
         val attachmentFailuresByCall = mutableMapOf<Int, Throwable>()
@@ -2716,7 +2845,13 @@ class CelesteViewModelTest {
                     promptFailure?.let { throw it }
                     buildJsonObject { put("status", "streaming") }
                 }
-                "session.redirect" -> buildJsonObject { put("status", redirectStatus) }
+                "session.redirect" -> {
+                    redirectFailure?.let { failure ->
+                        if (redirectFailureOnce) redirectFailure = null
+                        throw failure
+                    }
+                    buildJsonObject { put("status", redirectStatus) }
+                }
                 "image.attach_bytes" -> {
                     attachmentGate?.await()
                     throwAttachmentFailureIfPresent()
@@ -2778,12 +2913,13 @@ class CelesteViewModelTest {
             running: Boolean,
             runtimeSessionId: String = "runtime-7",
             storedSessionId: String = "stored-42",
+            inflightJson: String = "null",
         ): JsonObject {
             val encodedMessages = messages.joinToString(",") { message ->
                 """{"id":${Json.encodeToString(message.id ?: "")},"role":${Json.encodeToString(message.role)},"text":${Json.encodeToString(message.text)}}"""
             }
             return Json.parseToJsonElement(
-                """{"session_id":"$runtimeSessionId","resumed":"$storedSessionId","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":null,"messages":[$encodedMessages]}""",
+                """{"session_id":"$runtimeSessionId","resumed":"$storedSessionId","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":$inflightJson,"messages":[$encodedMessages]}""",
             ) as JsonObject
         }
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -412,6 +412,7 @@ class CelesteViewModelTest {
 
         assertEquals(listOf("later.pdf"), viewModel.state.value.queuedPrompts.single().attachments.map { it.name })
         assertTrue(viewModel.state.value.composerAttachments.isEmpty())
+        assertEquals(0, gateway.methods.count { it == "session.redirect" })
 
         gateway.emit("message.complete", """{"content":"First done","status":"complete"}""")
         advanceUntilIdle()
@@ -1036,6 +1037,52 @@ class CelesteViewModelTest {
         gateway.emit("message.complete", """{"content":"Third done","status":"complete"}""")
         advanceUntilIdle()
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun textOnlyBusySendRedirectsTheRunningTurnInsteadOfWaitingInTheQueue() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "redirected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        gateway.emit("message.delta", """{"text":"Working on it"}""")
+        viewModel.updateDraft("Actually, use the simpler path")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        val redirect = gateway.requests.single { it.first == "session.redirect" }.second
+        assertEquals("runtime-7", redirect["session_id"]?.jsonPrimitive?.content)
+        assertEquals("Actually, use the simpler path", redirect["text"]?.jsonPrimitive?.content)
+        assertTrue(viewModel.state.value.queuedPrompts.isEmpty())
+        assertEquals("", viewModel.state.value.draft)
+        assertEquals(
+            listOf("user", "assistant", "user"),
+            viewModel.state.value.messages.map { it.role },
+        )
+        assertEquals("Working on it", viewModel.state.value.messages[1].text)
+        assertFalse(viewModel.state.value.messages.last().pending)
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun rejectedBusyRedirectFallsBackToTheClientQueue() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "rejected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Keep this correction")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(1, gateway.methods.count { it == "session.redirect" })
+        assertEquals(listOf("Keep this correction"), viewModel.state.value.queuedPrompts.map { it.text })
+        assertEquals(listOf("user"), viewModel.state.value.messages.map { it.role })
         viewModel.controller.close()
     }
 
@@ -2603,6 +2650,7 @@ class CelesteViewModelTest {
         var resumeFailure: Throwable? = null
         var createFailure: Throwable? = null
         var promptFailure: Throwable? = null
+        var redirectStatus = "rejected"
         var attachmentFailure: Throwable? = null
         var attachmentFailureOnce = false
         val attachmentFailuresByCall = mutableMapOf<Int, Throwable>()
@@ -2668,6 +2716,7 @@ class CelesteViewModelTest {
                     promptFailure?.let { throw it }
                     buildJsonObject { put("status", "streaming") }
                 }
+                "session.redirect" -> buildJsonObject { put("status", redirectStatus) }
                 "image.attach_bytes" -> {
                     attachmentGate?.await()
                     throwAttachmentFailureIfPresent()

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -1114,7 +1114,17 @@ class CelesteViewModelTest {
             listOf("First", "First answer", "Run this next"),
             viewModel.state.value.messages.map { it.text },
         )
-        assertEquals(UserMessagePlacement.NextTurn, viewModel.state.value.messages.last().userPlacement)
+        assertEquals(UserMessagePlacement.Prompt, viewModel.state.value.messages.last().userPlacement)
+
+        gateway.emit("message.start")
+        gateway.emit("message.complete", """{"content":"Second answer","status":"complete"}""")
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "First answer", "Run this next", "Second answer"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals(UserMessagePlacement.Prompt, viewModel.state.value.messages[2].userPlacement)
         viewModel.controller.close()
     }
 
@@ -1143,6 +1153,26 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun resumeConvertsHermesCodePointOffsetsBeforeEmoji() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+                running = true,
+                inflightJson = """{"user":"First","assistant":"A😀B","streaming":true,"corrections":["Change direction"],"correction_offsets":[2]}""",
+            )
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "A😀", "Change direction"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals("B", viewModel.state.value.streamingText)
+        viewModel.controller.close()
+    }
+
+    @Test
     fun staleRuntimeRedirectResumesAndRetriesOnce() = runTest {
         val gateway = FakeGateway().apply { redirectStatus = "redirected" }
         val viewModel = openConversation(gateway)
@@ -1167,6 +1197,128 @@ class CelesteViewModelTest {
                 .map { it.second["session_id"]?.jsonPrimitive?.content },
         )
         assertTrue(viewModel.state.value.queuedPrompts.isEmpty())
+        assertEquals("Use recovered runtime", viewModel.state.value.messages.last().text)
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun staleRuntimeRedirectAppliesCompletedResumeBeforeSendingTheCorrectionNormally() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "redirected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        gateway.redirectFailure = GatewayRpcException(4001, "session not found")
+        gateway.redirectFailureOnce = true
+        gateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "user", text = "First", id = "server-user"),
+                ConversationMessage(
+                    role = "assistant",
+                    text = "Finished while reconnecting",
+                    id = "server-assistant",
+                ),
+            ),
+            running = false,
+            runtimeSessionId = "runtime-recovered",
+        )
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Use this next")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertEquals(1, gateway.methods.count { it == "session.redirect" })
+        assertEquals(
+            listOf("First", "Finished while reconnecting", "Use this next"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals(2, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun uncertainRedirectReconcilesAcceptedCorrectionWithoutQueueingItAgain() = runTest {
+        val gateway = FakeGateway().apply {
+            redirectFailure = IOException("response lost")
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        gateway.resumePayload = resumePayload(
+            messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+            running = true,
+            inflightJson = """{"user":"First","assistant":"","streaming":true,"corrections":["Change direction"],"correction_offsets":[0]}""",
+        )
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Change direction")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.queuedPrompts.isEmpty())
+        assertEquals("", viewModel.state.value.draft)
+        assertEquals(1, viewModel.state.value.messages.count { it.text == "Change direction" })
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun rejectedRedirectReconcilesOutputBeforeQueueingTheCorrection() = runTest {
+        val redirectGate = CompletableDeferred<Unit>()
+        val gateway = FakeGateway().apply {
+            redirectStatus = "rejected"
+            this.redirectGate = redirectGate
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+        gateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "user", text = "First", id = "server-user"),
+                ConversationMessage(role = "assistant", text = "Before. After.", id = "server-assistant"),
+            ),
+            running = false,
+        )
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        gateway.emit("message.delta", """{"text":"Before."}""")
+        viewModel.updateDraft("Change direction")
+        viewModel.sendMessage()
+        runCurrent()
+        gateway.emit("message.delta", """{"text":" After."}""")
+        gateway.emit("message.complete", """{"content":"Before. After.","status":"complete"}""")
+        redirectGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(1, viewModel.state.value.messages.count { it.role == "assistant" })
+        assertEquals("Before. After.", viewModel.state.value.messages.single { it.role == "assistant" }.text)
+        assertEquals(2, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun stopWhileRedirectIsPendingKeepsRejectedFallbackPaused() = runTest {
+        val redirectGate = CompletableDeferred<Unit>()
+        val gateway = FakeGateway().apply {
+            redirectStatus = "rejected"
+            this.redirectGate = redirectGate
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Wait for me")
+        viewModel.sendMessage()
+        runCurrent()
+        viewModel.interrupt()
+        runCurrent()
+        redirectGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.state.value.isQueuePaused)
+        assertEquals(listOf("Wait for me"), viewModel.state.value.queuedPrompts.map { it.text })
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
         viewModel.controller.close()
     }
 
@@ -2780,6 +2932,7 @@ class CelesteViewModelTest {
         var redirectStatus = "rejected"
         var redirectFailure: Throwable? = null
         var redirectFailureOnce = false
+        var redirectGate: CompletableDeferred<Unit>? = null
         var attachmentFailure: Throwable? = null
         var attachmentFailureOnce = false
         val attachmentFailuresByCall = mutableMapOf<Int, Throwable>()
@@ -2846,6 +2999,7 @@ class CelesteViewModelTest {
                     buildJsonObject { put("status", "streaming") }
                 }
                 "session.redirect" -> {
+                    redirectGate?.await()
                     redirectFailure?.let { failure ->
                         if (redirectFailureOnce) redirectFailure = null
                         throw failure

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -1097,6 +1097,33 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun successiveRedirectsPreserveAssistantWhitespaceBoundaries() = runTest {
+        val gateway = FakeGateway().apply { redirectStatus = "redirected" }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        gateway.emit("message.delta", """{"text":"First. "}""")
+        viewModel.updateDraft("First correction")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        gateway.emit("message.delta", """{"text":"Second. "}""")
+        viewModel.updateDraft("Second correction")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        gateway.emit("message.delta", """{"text":"Final."}""")
+        gateway.emit("message.complete", """{"content":"First. Second. Final.","status":"complete"}""")
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "First. ", "First correction", "Second. ", "Second correction", "Final."),
+            viewModel.state.value.messages.map { it.text },
+        )
+        viewModel.controller.close()
+    }
+
+    @Test
     fun gatewayQueuedRedirectKeepsTheCurrentReplyBeforeTheNextTurn() = runTest {
         val gateway = FakeGateway().apply { redirectStatus = "queued" }
         val viewModel = openConversation(gateway)

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -1237,6 +1237,41 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun resumePreservesWhitespaceBetweenPersistedAndInflightRedirectSegments() = runTest {
+        val preCorrection = "Before. More. "
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(
+                    ConversationMessage(role = "user", text = "First", id = "server-user"),
+                    ConversationMessage(role = "assistant", text = "Before.", id = "server-assistant"),
+                ),
+                running = true,
+                inflightJson = """{"user":"First","assistant":"${preCorrection}After.","streaming":true,"corrections":["Change direction"],"correction_offsets":[${preCorrection.length}]}""",
+            )
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Before.", " More. ", "Change direction"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals("After.", viewModel.state.value.streamingText)
+
+        gateway.emit(
+            "message.complete",
+            """{"content":"${preCorrection}After.","status":"complete"}""",
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Before.", " More. ", "Change direction", "After."),
+            viewModel.state.value.messages.map { it.text },
+        )
+        viewModel.controller.close()
+    }
+
+    @Test
     fun resumeRestoresServerQueuedCorrectionAfterTheInflightReply() = runTest {
         val gateway = FakeGateway().apply {
             resumePayload = resumePayload(
@@ -2834,7 +2869,7 @@ class CelesteViewModelTest {
             messages = listOf(ConversationMessage(role = "assistant", text = "Already stored")),
         )
 
-        assertEquals("and still arriving", suffix)
+        assertEquals(" and still arriving", suffix)
     }
 
     private fun pickedAttachment(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -1129,6 +1129,63 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun queuedRedirectResponseMovesAnAlreadyCompletedReplyBeforeTheCorrection() = runTest {
+        val redirectGate = CompletableDeferred<Unit>()
+        val gateway = FakeGateway().apply {
+            redirectStatus = "queued"
+            this.redirectGate = redirectGate
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Run this next")
+        viewModel.sendMessage()
+        runCurrent()
+        gateway.emit("message.complete", """{"content":"First answer","status":"complete"}""")
+        runCurrent()
+        redirectGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "First answer", "Run this next"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals(UserMessagePlacement.Prompt, viewModel.state.value.messages.last().userPlacement)
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun queuedRedirectResponseSealsCurrentStreamingTextBeforeTheCorrection() = runTest {
+        val redirectGate = CompletableDeferred<Unit>()
+        val gateway = FakeGateway().apply {
+            redirectStatus = "queued"
+            this.redirectGate = redirectGate
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Run this next")
+        viewModel.sendMessage()
+        runCurrent()
+        gateway.emit("message.delta", """{"text":"Still finishing the first answer"}""")
+        runCurrent()
+        redirectGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Still finishing the first answer", "Run this next"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals("", viewModel.state.value.streamingText)
+        assertEquals(UserMessagePlacement.NextTurn, viewModel.state.value.messages.last().userPlacement)
+        viewModel.controller.close()
+    }
+
+    @Test
     fun resumeRestoresAcceptedRedirectAtItsAssistantOffset() = runTest {
         val gateway = FakeGateway().apply {
             resumePayload = resumePayload(
@@ -1149,6 +1206,48 @@ class CelesteViewModelTest {
             UserMessagePlacement.MidTurnCorrection,
             viewModel.state.value.messages.last().userPlacement,
         )
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun resumeRestoresServerQueuedCorrectionAfterTheInflightReply() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+                running = true,
+                inflightJson = """{"user":"First","assistant":"Before.","streaming":true}""",
+                queuedJson = """{"user":"Run this next"}""",
+            )
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Before.", "Run this next"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals("", viewModel.state.value.streamingText)
+        assertEquals(UserMessagePlacement.NextTurn, viewModel.state.value.messages.last().userPlacement)
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun resumePreservesRepeatedAssistantSegmentsBetweenCorrections() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+                running = true,
+                inflightJson = """{"user":"First","assistant":"OkayOkayTail","streaming":true,"corrections":["First change","Second change"],"correction_offsets":[4,8]}""",
+            )
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Okay", "First change", "Okay", "Second change"),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals("Tail", viewModel.state.value.streamingText)
         viewModel.controller.close()
     }
 
@@ -3068,12 +3167,13 @@ class CelesteViewModelTest {
             runtimeSessionId: String = "runtime-7",
             storedSessionId: String = "stored-42",
             inflightJson: String = "null",
+            queuedJson: String = "null",
         ): JsonObject {
             val encodedMessages = messages.joinToString(",") { message ->
                 """{"id":${Json.encodeToString(message.id ?: "")},"role":${Json.encodeToString(message.role)},"text":${Json.encodeToString(message.text)}}"""
             }
             return Json.parseToJsonElement(
-                """{"session_id":"$runtimeSessionId","resumed":"$storedSessionId","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":$inflightJson,"messages":[$encodedMessages]}""",
+                """{"session_id":"$runtimeSessionId","resumed":"$storedSessionId","running":$running,"status":"${if (running) "streaming" else "idle"}","inflight":$inflightJson,"queued":$queuedJson,"messages":[$encodedMessages]}""",
             ) as JsonObject
         }
     }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -217,6 +217,20 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun finalAnswerEchoedThroughReasoningSettlesToOneAssistantMessage() {
+        val answer = "hello from inside the little app we built"
+        val result = reduceEvents(
+            event("message.start"),
+            event("message.delta", """{"text":"$answer"}"""),
+            event("reasoning.delta", """{"text":"$answer"}"""),
+            event("message.complete", """{"content":"$answer","status":"complete"}"""),
+        )
+
+        assertEquals(listOf("user", "assistant"), result.projection.messages.map { it.role })
+        assertEquals(answer, result.projection.messages.single { it.role == "assistant" }.text)
+    }
+
+    @Test
     fun assistantInterimEndsTheCurrentStepsCapsuleAndKeepsItsMessageVisible() {
         val result = reduceEvents(
             event("message.start"),

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -217,6 +217,20 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun streamedAssistantProseCompletesTheThinkingCapsuleItFollows() {
+        val result = reduceEvents(
+            event("message.start"),
+            event("reasoning.delta", """{"text":"Prepare the issue."}"""),
+            event("message.delta", """{"text":"I’ll create one focused issue."}"""),
+        )
+
+        val thinking = result.projection.messages.single { it.role == "steps" }
+        assertFalse(thinking.pending)
+        assertTrue(thinking.steps.none { it.pending })
+        assertEquals("I’ll create one focused issue.", result.projection.streamingText)
+    }
+
+    @Test
     fun finalAnswerEchoedThroughReasoningSettlesToOneAssistantMessage() {
         val answer = "hello from inside the little app we built"
         val result = reduceEvents(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -1,9 +1,11 @@
 package dev.hazydreams.hermesceleste
 
 import dev.hazydreams.hermesceleste.network.ConversationMessage
+import dev.hazydreams.hermesceleste.network.ConversationStep
 import dev.hazydreams.hermesceleste.network.ConversationStepKind
 import dev.hazydreams.hermesceleste.network.GatewayEvent
 import dev.hazydreams.hermesceleste.network.TaskItemStatus
+import dev.hazydreams.hermesceleste.network.UserMessagePlacement
 import dev.hazydreams.hermesceleste.network.changedFiles
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -278,6 +280,71 @@ class ConversationEventReducerTest {
         val thinkingCapsules = messages.filter { it.role == "steps" }
         assertTrue(thinkingCapsules.none { it.pending })
         assertTrue(thinkingCapsules.flatMap { it.steps }.none { it.pending })
+    }
+
+    @Test
+    fun finalCompletionExtendingInterimStaysAfterInterveningThinking() {
+        val interim = "I checked the first part."
+        val result = reduceEvents(
+            event("message.start"),
+            event("message.interim", """{"text":"$interim"}"""),
+            event("reasoning.delta", """{"text":"Verify the remaining details."}"""),
+            event("message.complete", """{"content":"$interim Everything is ready.","status":"complete"}"""),
+        )
+
+        assertEquals(
+            listOf("user", "assistant", "steps", "assistant"),
+            result.projection.messages.map { it.role },
+        )
+        assertEquals(interim, result.projection.messages[1].text)
+        assertEquals("$interim Everything is ready.", result.projection.messages.last().text)
+    }
+
+    @Test
+    fun redirectedToolCompletionUpdatesItsOriginalStableIdentity() {
+        val initial = ConversationEventReduction(
+            projection = projection().copy(
+                messages = listOf(
+                    ConversationMessage(role = "user", text = "Prompt", id = "user-1"),
+                    ConversationMessage(
+                        role = "steps",
+                        text = "",
+                        id = "steps-1",
+                        steps = listOf(
+                            ConversationStep(
+                                id = "tool-1",
+                                kind = ConversationStepKind.Tool,
+                                toolName = "terminal",
+                                context = "./gradlew focusedTest",
+                                pending = false,
+                            ),
+                        ),
+                    ),
+                    ConversationMessage(
+                        role = "user",
+                        text = "Use the focused suite",
+                        id = "redirect-1",
+                        userPlacement = UserMessagePlacement.MidTurnCorrection,
+                    ),
+                ),
+                turnState = TurnState.Running,
+            ),
+            localMessageCounter = 0L,
+        )
+
+        val result = initial.reduce(
+            event(
+                "tool.complete",
+                """{"tool_id":"tool-1","name":"terminal","summary":"Tests passed","result":"ok"}""",
+            ),
+        )
+
+        val toolSteps = result.projection.messages.flatMap { it.steps }
+            .filter { it.kind == ConversationStepKind.Tool && it.id == "tool-1" }
+        assertEquals(1, toolSteps.size)
+        assertEquals("Tests passed", toolSteps.single().summary)
+        assertEquals("ok", toolSteps.single().result)
+        assertEquals(listOf("user", "steps", "user"), result.projection.messages.map { it.role })
     }
 
     @Test

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -245,6 +245,18 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun matchingFinalAnswerDoesNotDeleteUnstreamedReasoning() {
+        val result = reduceEvents(
+            event("message.start"),
+            event("reasoning.delta", """{"text":"Done"}"""),
+            event("message.complete", """{"content":"Done","status":"complete"}"""),
+        )
+
+        assertEquals(listOf("user", "steps", "assistant"), result.projection.messages.map { it.role })
+        assertEquals("Done", result.projection.messages.single { it.role == "steps" }.steps.single().detail)
+    }
+
+    @Test
     fun assistantInterimEndsTheCurrentStepsCapsuleAndKeepsItsMessageVisible() {
         val result = reduceEvents(
             event("message.start"),

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -348,6 +348,48 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun redirectedCompletionDoesNotRepeatToolSeparatedProse() {
+        val initial = ConversationEventReduction(
+            projection = projection().copy(
+                messages = listOf(
+                    ConversationMessage(role = "user", text = "Prompt", id = "user-1"),
+                    ConversationMessage(role = "assistant", text = "Before.", interim = false),
+                    ConversationMessage(
+                        role = "steps",
+                        text = "",
+                        id = "steps-1",
+                        steps = listOf(
+                            ConversationStep(
+                                id = "tool-1",
+                                kind = ConversationStepKind.Tool,
+                                toolName = "terminal",
+                                pending = false,
+                            ),
+                        ),
+                    ),
+                    ConversationMessage(
+                        role = "user",
+                        text = "Change direction",
+                        id = "redirect-1",
+                        userPlacement = UserMessagePlacement.MidTurnCorrection,
+                    ),
+                ),
+                turnState = TurnState.Running,
+            ),
+            localMessageCounter = 0L,
+        )
+
+        val result = initial.reduce(
+            event("message.complete", """{"content":"Before.After.","status":"complete"}"""),
+        )
+
+        assertEquals(
+            listOf("Prompt", "Before.", "", "Change direction", "After."),
+            result.projection.messages.map { it.text },
+        )
+    }
+
+    @Test
     fun changedFilesStayAtTheEndWithoutReorderingCommentaryAndLaterActivity() {
         val result = reduceEvents(
             event("message.start"),

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -339,6 +339,41 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun queuedTurnCompletionStaysBeforeThePriorTurnsChangesCapsule() {
+        val initial = ConversationEventReduction(
+            projection = projection().copy(
+                messages = listOf(
+                    ConversationMessage(
+                        role = "user",
+                        text = "First",
+                        userPlacement = UserMessagePlacement.Prompt,
+                    ),
+                    ConversationMessage(role = "changes", text = "", id = "changes-1"),
+                    ConversationMessage(
+                        role = "user",
+                        text = "Run this next",
+                        id = "queued-1",
+                        userPlacement = UserMessagePlacement.NextTurn,
+                    ),
+                ),
+                turnState = TurnState.Running,
+            ),
+            localMessageCounter = 0L,
+        )
+
+        val result = initial.reduce(
+            event("message.complete", """{"content":"Finished.","status":"complete"}"""),
+        )
+
+        assertEquals(
+            listOf("user", "assistant", "changes", "user"),
+            result.projection.messages.map { it.role },
+        )
+        assertEquals("Finished.", result.projection.messages[1].text)
+        assertEquals(UserMessagePlacement.Prompt, result.projection.messages.last().userPlacement)
+    }
+
+    @Test
     fun redirectedToolCompletionUpdatesItsOriginalStableIdentity() {
         val initial = ConversationEventReduction(
             projection = projection().copy(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -301,6 +301,44 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun queuedTurnPreservesDistinctInterimAndFinalAssistantSegments() {
+        val initial = ConversationEventReduction(
+            projection = projection().copy(
+                messages = listOf(
+                    ConversationMessage(
+                        role = "user",
+                        text = "First",
+                        userPlacement = UserMessagePlacement.Prompt,
+                    ),
+                    ConversationMessage(
+                        role = "assistant",
+                        text = "I checked the first part.",
+                        interim = true,
+                    ),
+                    ConversationMessage(
+                        role = "user",
+                        text = "Run this next",
+                        id = "queued-1",
+                        userPlacement = UserMessagePlacement.NextTurn,
+                    ),
+                ),
+                turnState = TurnState.Running,
+            ),
+            localMessageCounter = 0L,
+        )
+
+        val result = initial.reduce(
+            event("message.complete", """{"content":"Finished.","status":"complete"}"""),
+        )
+
+        assertEquals(
+            listOf("First", "I checked the first part.", "Finished.", "Run this next"),
+            result.projection.messages.map { it.text },
+        )
+        assertEquals(UserMessagePlacement.Prompt, result.projection.messages.last().userPlacement)
+    }
+
+    @Test
     fun redirectedToolCompletionUpdatesItsOriginalStableIdentity() {
         val initial = ConversationEventReduction(
             projection = projection().copy(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/ConversationEventReducerTest.kt
@@ -339,6 +339,47 @@ class ConversationEventReducerTest {
     }
 
     @Test
+    fun redirectedCompletionBeforeQueuedTurnDoesNotRepeatEarlierAssistantSegments() {
+        val initial = ConversationEventReduction(
+            projection = projection().copy(
+                messages = listOf(
+                    ConversationMessage(
+                        role = "user",
+                        text = "First",
+                        userPlacement = UserMessagePlacement.Prompt,
+                    ),
+                    ConversationMessage(role = "assistant", text = "Before. "),
+                    ConversationMessage(
+                        role = "user",
+                        text = "Change direction",
+                        id = "redirect-1",
+                        userPlacement = UserMessagePlacement.MidTurnCorrection,
+                    ),
+                    ConversationMessage(role = "assistant", text = "After. ", interim = true),
+                    ConversationMessage(
+                        role = "user",
+                        text = "Run this next",
+                        id = "queued-1",
+                        userPlacement = UserMessagePlacement.NextTurn,
+                    ),
+                ),
+                turnState = TurnState.Running,
+            ),
+            localMessageCounter = 0L,
+        )
+
+        val result = initial.reduce(
+            event("message.complete", """{"content":"Before. After. Final.","status":"complete"}"""),
+        )
+
+        assertEquals(
+            listOf("First", "Before. ", "Change direction", "After. Final.", "Run this next"),
+            result.projection.messages.map { it.text },
+        )
+        assertEquals(UserMessagePlacement.Prompt, result.projection.messages.last().userPlacement)
+    }
+
+    @Test
     fun queuedTurnCompletionStaysBeforeThePriorTurnsChangesCapsule() {
         val initial = ConversationEventReduction(
             projection = projection().copy(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -139,6 +139,18 @@ class HermesGatewayTest {
     }
 
     @Test
+    fun redirectsAConversationThatIsAlreadyRunning() = runBlocking {
+        server.enqueue(chatWebSocket())
+        val gateway = gateway()
+        gateway.connect()
+
+        val accepted = gateway.redirectSession("runtime-7", "Use the simpler path")
+
+        assertTrue(accepted)
+        gateway.close()
+    }
+
+    @Test
     fun imageDetachRequiresConfirmedStatus() = runBlocking {
         server.enqueue(chatWebSocket())
         val gateway = gateway()
@@ -762,6 +774,10 @@ One test failed
 
                             "image.detach" -> webSocket.send(
                                 """{"jsonrpc":"2.0","id":$id,"result":{"detached":false,"count":1}}""",
+                            )
+
+                            "session.redirect" -> webSocket.send(
+                                """{"jsonrpc":"2.0","id":$id,"result":{"status":"redirected"}}""",
                             )
 
                             "prompt.submit" -> {

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -112,6 +112,7 @@ class HermesGatewayTest {
         val resumed = gateway.resumeStoredSession("stored-42", "work", "android")
         assertEquals("runtime-7", resumed.runtimeSessionId)
         assertTrue(resumed.running == false)
+        assertEquals(listOf(InflightCorrection("Change direction", 7)), resumed.inflightCorrections)
 
         val eventCollector = async(start = CoroutineStart.UNDISPATCHED) {
             withTimeout(5_000) { gateway.events.take(3).toList() }
@@ -146,7 +147,7 @@ class HermesGatewayTest {
 
         val accepted = gateway.redirectSession("runtime-7", "Use the simpler path")
 
-        assertTrue(accepted)
+        assertEquals(SessionRedirectStatus.Redirected, accepted)
         gateway.close()
     }
 
@@ -769,7 +770,7 @@ One test failed
                         val id = request["id"].toString()
                         when (request["method"]?.jsonPrimitive?.content) {
                             "session.resume" -> webSocket.send(
-                                """{"jsonrpc":"2.0","id":$id,"result":{"session_id":"runtime-7","resumed":"stored-42","running":false,"status":"idle","inflight":null,"messages":[{"id":"u1","role":"user","text":"Earlier message"}]}}""",
+                                """{"jsonrpc":"2.0","id":$id,"result":{"session_id":"runtime-7","resumed":"stored-42","running":false,"status":"idle","inflight":{"user":"Earlier message","assistant":"Before.After.","streaming":true,"corrections":["Change direction"],"correction_offsets":[7]},"messages":[{"id":"u1","role":"user","text":"Earlier message"}]}}""",
                             )
 
                             "image.detach" -> webSocket.send(

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -54,13 +54,14 @@ Persisted history loads with `order=latest` and `include_compacted=true`. The tr
 | `file.attach` | runtime session ID | Stage file bytes and return a model-facing file reference |
 | `image.detach` | runtime session ID | Remove an image staged for the next prompt |
 | `prompt.submit` | runtime session ID | Persist and begin a user turn |
+| `session.redirect` | runtime session ID | Correct a live turn with a text-only follow-up |
 | `session.interrupt` | runtime session ID | Stop work before reconciliation |
 | `session.close` | runtime session ID | Retire a runtime that cannot be safely reused |
 | `clarify.respond` | clarification request ID | Answer or skip a pending clarification |
 
 Creation and resume include `source: "android"` and terminal columns. Hermes creates the durable session row lazily on first prompt submission, so an untouched local draft stays out of the catalog.
 
-Image and file bytes are staged into the current runtime before `prompt.submit`. File references returned by Hermes are prepended only to the model-facing prompt; the local transcript keeps the user’s natural text and attachment summaries. Queue drains stage their own attachments first and submit with `queued: true`.
+Image and file bytes are staged into the current runtime before `prompt.submit`. File references returned by Hermes are prepended only to the model-facing prompt; the local transcript keeps the user’s natural text and attachment summaries. A text-only Send during live work uses `session.redirect`; attachments, reconnecting sessions, compaction, pending clarification, and rejected redirects use the per-session queue. Queue drains stage their own attachments first and submit with `queued: true`.
 
 ## Event projection
 

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -78,7 +78,7 @@ Celeste recognizes message lifecycle, interim assistant prose, reasoning, tools,
 - Background-process completion produces one compact result row with details available on demand.
 - Notifications with a blank session ID apply to the active conversation; nonblank mismatched runtime IDs are ignored.
 
-`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order. Hermes reports those offsets as Unicode code-point positions; Celeste translates them to Kotlin string indices at the protocol boundary. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
+`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order; a server-queued next turn is projected after the current inflight assistant output. Hermes reports correction offsets as Unicode code-point positions, and Celeste translates them to Kotlin string indices at the protocol boundary. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
 
 ## Update workflow
 

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -61,7 +61,7 @@ Persisted history loads with `order=latest` and `include_compacted=true`. The tr
 
 Creation and resume include `source: "android"` and terminal columns. Hermes creates the durable session row lazily on first prompt submission, so an untouched local draft stays out of the catalog.
 
-Image and file bytes are staged into the current runtime before `prompt.submit`. File references returned by Hermes are prepended only to the model-facing prompt; the local transcript keeps the user’s natural text and attachment summaries. A text-only Send during live work uses `session.redirect`; attachments, reconnecting sessions, compaction, pending clarification, and rejected redirects use the per-session queue. Queue drains stage their own attachments first and submit with `queued: true`.
+Image and file bytes are staged into the current runtime before `prompt.submit`. File references returned by Hermes are prepended only to the model-facing prompt; the local transcript keeps the user’s natural text and attachment summaries. A text-only Send during live work uses `session.redirect`; attachments, reconnecting sessions, compaction, pending clarification, and rejected redirects use the per-session queue. A redirect with an uncertain transport outcome remains paused until authoritative reconciliation determines whether Hermes accepted it. Queue drains stage their own attachments first and submit with `queued: true`.
 
 ## Event projection
 
@@ -78,7 +78,7 @@ Celeste recognizes message lifecycle, interim assistant prose, reasoning, tools,
 - Background-process completion produces one compact result row with details available on demand.
 - Notifications with a blank session ID apply to the active conversation; nonblank mismatched runtime IDs are ignored.
 
-`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
+`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order. Hermes reports those offsets as Unicode code-point positions; Celeste translates them to Kotlin string indices at the protocol boundary. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
 
 ## Update workflow
 

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -78,7 +78,7 @@ Celeste recognizes message lifecycle, interim assistant prose, reasoning, tools,
 - Background-process completion produces one compact result row with details available on demand.
 - Notifications with a blank session ID apply to the active conversation; nonblank mismatched runtime IDs are ignored.
 
-`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
+`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
 
 ## Update workflow
 


### PR DESCRIPTION
## Summary
- send text-only follow-ups through Hermes session.redirect while a turn is running
- keep attachments, reconnecting sessions, compaction, clarification blocks, and rejected redirects on the existing per-session FIFO queue
- collapse an exact final-answer echo that briefly arrived as both reasoning and assistant prose
- document the redirect-versus-queue contract

## Verification
- scripts/celeste-env ./gradlew --no-daemon :app:testDebugUnitTest --tests 'dev.hazydreams.hermesceleste.ConversationEventReducerTest' --tests 'dev.hazydreams.hermesceleste.CelesteViewModelTest' --tests 'dev.hazydreams.hermesceleste.network.HermesGatewayTest'
- git diff --check