### PR TITLE
Preserve image-bearing user prompts after compaction

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -527,7 +527,29 @@ private fun visiblePersistedText(row: JsonObject, role: String, text: String): S
 
     if (flaggedAsSummary || isKnownStandaloneCompactionCarrier(text)) return null
     if (role != "user") return text
-    return text.takeUnless(::isKnownAsyncDelegationCarrier)
+    val visibleUserText = text.withoutInjectedTodoSnapshot() ?: return null
+    return visibleUserText.takeUnless(::isKnownAsyncDelegationCarrier)
+}
+
+private fun String.withoutInjectedTodoSnapshot(): String? {
+    val markerIndex = lastIndexOf(TODO_INJECTION_HEADER)
+    if (markerIndex < 0) return this
+
+    val prefix = substring(0, markerIndex)
+    val startsInjectedBlock = markerIndex == 0 ||
+        prefix.endsWith("\n\n") ||
+        prefix.endsWith("\r\n\r\n")
+    if (!startsInjectedBlock) return this
+
+    var itemStart = markerIndex + TODO_INJECTION_HEADER.length
+    if (itemStart >= length || (this[itemStart] != '\n' && this[itemStart] != '\r')) return this
+    while (itemStart < length && (this[itemStart] == '\n' || this[itemStart] == '\r')) itemStart += 1
+
+    val startsTodoItem = regionMatches(itemStart, "- [>] ", 0, 6) ||
+        regionMatches(itemStart, "- [ ] ", 0, 6)
+    if (!startsTodoItem) return this
+
+    return prefix.trimEnd().takeIf(String::isNotBlank)
 }
 
 private fun isKnownStandaloneCompactionCarrier(text: String): Boolean {
@@ -590,6 +612,8 @@ private const val CONTEXT_COMPACTION_REFERENCE_HEADER =
     "[CONTEXT COMPACTION — REFERENCE ONLY]"
 private const val ASYNC_DELEGATION_BATCH_HEADER =
     "[ASYNC DELEGATION BATCH COMPLETE —"
+private const val TODO_INJECTION_HEADER =
+    "[Your active task list was preserved across context compression]"
 
 private const val MIN_COMMENTARY_STRIP_LENGTH = 12
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -331,9 +331,9 @@ internal fun decodeGatewayConversation(elements: List<JsonElement>): DecodedGate
         val sourceIdentity = row["row_id"].scalarIdentity()?.let { "row-$it" }
             ?: row["id"].scalarIdentity()
             ?: row["message_id"].scalarIdentity()
-        val persistedText = row.string("text")
-            ?: row.string("content")
-            ?: row.string("context")
+        val persistedText = persistedContentText(row["text"])
+            ?: persistedContentText(row["content"])
+            ?: persistedContentText(row["context"])
             ?: ""
         val text = visiblePersistedText(row, role, persistedText) ?: return@forEachIndexed
 
@@ -490,6 +490,21 @@ internal fun decodeGatewayConversation(elements: List<JsonElement>): DecodedGate
         messages = messages.map(ConversationMessage::settledSteps),
         taskProgressSnapshot = taskProgressSnapshot,
     )
+}
+
+private fun persistedContentText(element: JsonElement?): String? = when (element) {
+    is JsonPrimitive -> element.contentOrNull
+    is JsonArray -> element.joinToString(separator = "", transform = ::persistedContentPartText)
+    else -> null
+}
+
+private fun persistedContentPartText(element: JsonElement): String = when (element) {
+    is JsonPrimitive -> element.contentOrNull.orEmpty()
+    is JsonObject -> {
+        val type = element.string("type")
+        if (type == null || type == "text") element.string("text").orEmpty() else ""
+    }
+    else -> ""
 }
 
 private fun visiblePersistedText(row: JsonObject, role: String, text: String): String? {

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -62,7 +62,10 @@ class HermesGatewayTest {
                     {"row_id":10,"role":"tool","content":"[CONTEXT SUMMARY]: legitimate tool output"},
                     {"row_id":11,"role":"user","text":"I saw [CONTEXT SUMMARY]: in an ordinary message"},
                     {"row_id":12,"role":"user","text":"[CONTEXT SUMMARY]: quoted literally by the user"},
-                    {"row_id":13,"role":"user","text":"Code sample\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\nKeep this too"}
+                    {"row_id":13,"role":"user","text":"Code sample\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\nKeep this too"},
+                    {"row_id":14,"role":"user","text":"what happened\n\n[Your active task list was preserved across context compression]\n- [>] image-scope. Inspect issue #94 (in_progress)\n- [ ] image-tests. Add focused coverage (pending)\n\n[Skills pruned during compression — reload before acting on these tasks]\nprivate reload instructions"},
+                    {"row_id":15,"role":"user","text":"I saw [Your active task list was preserved across context compression] in the transcript"},
+                    {"row_id":16,"role":"user","text":"Quoted marker:\n[Your active task list was preserved across context compression]\nThis is documentation, not a task snapshot"}
                 ]""".trimIndent(),
             ).jsonArray,
         )
@@ -75,6 +78,9 @@ class HermesGatewayTest {
                 "I saw [CONTEXT SUMMARY]: in an ordinary message",
                 "[CONTEXT SUMMARY]: quoted literally by the user",
                 "Code sample\n[END OF PRIOR CONTEXT — COMPACTION SUMMARY BELOW]\nKeep this too",
+                "what happened",
+                "I saw [Your active task list was preserved across context compression] in the transcript",
+                "Quoted marker:\n[Your active task list was preserved across context compression]\nThis is documentation, not a task snapshot",
             ),
             messages.filter { it.role == "user" || it.role == "assistant" }.map { it.text },
         )

--- a/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/network/HermesGatewayTest.kt
@@ -85,6 +85,26 @@ class HermesGatewayTest {
     }
 
     @Test
+    fun resumedHistoryPreservesTextFromMultimodalUserContent() {
+        val messages = decodeGatewayMessages(
+            Json.parseToJsonElement(
+                """[
+                    {
+                        "row_id":14,
+                        "role":"user",
+                        "content":[
+                            {"type":"text","text":"Which presentation looks better?"},
+                            {"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}
+                        ]
+                    }
+                ]""".trimIndent(),
+            ).jsonArray,
+        )
+
+        assertEquals("Which presentation looks better?", messages.single().text)
+    }
+
+    @Test
     fun websocketOpenDoesNotReportConnectedUntilGatewayReady() = runBlocking {
         lateinit var serverSocket: WebSocket
         val upgraded = CompletableDeferred<Unit>()

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -41,7 +41,7 @@ Session catalog pages use recent server ordering, 15-row windows, and response p
 
 Pin and read changes may update the projection optimistically, then accept Hermes as authoritative. Rename keeps the existing title until Hermes accepts a trimmed nonblank replacement.
 
-Persisted history loads with `order=latest` and `include_compacted=true`. The transcript decoder combines assistant prose, reasoning, tool calls/results, and structured process markers into the same projection used by live events. Gateway display metadata and reserved runtime markers keep hidden compaction handoffs and asynchronous delegation payloads outside the human transcript. Compatibility projection preserves genuine user content from older merged compaction carriers while removing only their internal summary suffix.
+Persisted history loads with `order=latest` and `include_compacted=true`. The transcript decoder combines assistant prose, reasoning, tool calls/results, and structured process markers into the same projection used by live events. Structured user content arrays contribute their text parts to transcript prose while image parts remain attachment data. Gateway display metadata and reserved runtime markers keep hidden compaction handoffs and asynchronous delegation payloads outside the human transcript. Compatibility projection preserves genuine user content from older merged compaction carriers while removing only their internal summary suffix.
 
 ## JSON-RPC surface
 

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -41,7 +41,7 @@ Session catalog pages use recent server ordering, 15-row windows, and response p
 
 Pin and read changes may update the projection optimistically, then accept Hermes as authoritative. Rename keeps the existing title until Hermes accepts a trimmed nonblank replacement.
 
-Persisted history loads with `order=latest` and `include_compacted=true`. The transcript decoder combines assistant prose, reasoning, tool calls/results, and structured process markers into the same projection used by live events. Structured user content arrays contribute their text parts to transcript prose while image parts remain attachment data. Gateway display metadata and reserved runtime markers keep hidden compaction handoffs and asynchronous delegation payloads outside the human transcript. Compatibility projection preserves genuine user content from older merged compaction carriers while removing only their internal summary suffix.
+Persisted history loads with `order=latest` and `include_compacted=true`. The transcript decoder combines assistant prose, reasoning, tool calls/results, and structured process markers into the same projection used by live events. Structured user content arrays contribute their text parts to transcript prose while image parts remain attachment data. Gateway display metadata and reserved runtime markers keep hidden compaction handoffs and asynchronous delegation payloads outside the human transcript. Compatibility projection preserves genuine user content from merged compaction carriers while removing their internal summary and injected task-snapshot suffixes.
 
 ## JSON-RPC surface
 


### PR DESCRIPTION
## Summary
- decode structured persisted user content arrays during history reconciliation
- preserve only textual parts in transcript prose while keeping embedded image payloads out of text
- add a regression matching the current Hermes text-plus-image message shape

## Verification
- `scripts/celeste-env ./gradlew --no-daemon :app:testDebugUnitTest --tests 'dev.hazydreams.hermesceleste.network.HermesGatewayTest'`
- `git diff --check`

Hermes Desktop uses the same text-part projection for structured message content.