### PR TITLE
Surface missed turn failures after reconnect

### DIFF
--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -2167,7 +2167,9 @@ internal class CelesteController(
     }
 
     private fun resumedLiveProjection(resumed: ResumedSession): ResumedLiveProjection {
-        val inflightProjection = if (resumed.inflightCorrections.isEmpty()) {
+        val inflightProjection = resumed.retainedFailureMessage?.let { failureMessage ->
+            resumedFailureProjection(resumed, failureMessage)
+        } ?: if (resumed.inflightCorrections.isEmpty()) {
             ResumedLiveProjection(
                 messages = resumed.messages,
                 streamingText = unpersistedInflightText(
@@ -2255,6 +2257,51 @@ internal class CelesteController(
             ),
             streamingText = "",
         )
+    }
+
+    private fun resumedFailureProjection(
+        resumed: ResumedSession,
+        failureMessage: String,
+    ): ResumedLiveProjection {
+        var messages = settleCurrentTurnSteps(resumed.messages)
+        val missingAssistant = unpersistedInflightText(
+            inflight = resumed.inflightAssistantText,
+            messages = messages,
+        )
+        if (missingAssistant.isNotBlank()) {
+            messages = appendCurrentTurnMessage(
+                messages = messages,
+                message = ConversationMessage(
+                    role = "assistant",
+                    text = missingAssistant,
+                    id = "retained-failure-${resumed.runtimeSessionId}",
+                    errorMessage = failureMessage,
+                ),
+            )
+        } else {
+            val promptStart = messages.indexOfLast { message ->
+                message.role == "user" && message.userPlacement == UserMessagePlacement.Prompt
+            }
+            val assistantIndex = (messages.lastIndex downTo (promptStart + 1)).firstOrNull { index ->
+                messages[index].role == "assistant"
+            }
+            if (assistantIndex != null) {
+                messages = messages.toMutableList().also { next ->
+                    next[assistantIndex] = next[assistantIndex].copy(errorMessage = failureMessage)
+                }
+            } else {
+                messages = appendCurrentTurnMessage(
+                    messages = messages,
+                    message = ConversationMessage(
+                        role = "assistant",
+                        text = "",
+                        id = "retained-failure-${resumed.runtimeSessionId}",
+                        errorMessage = failureMessage,
+                    ),
+                )
+            }
+        }
+        return ResumedLiveProjection(messages = messages, streamingText = "")
     }
 
     private fun isActiveSession(submitted: SubmittedSession): Boolean =

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -2167,9 +2167,7 @@ internal class CelesteController(
     }
 
     private fun resumedLiveProjection(resumed: ResumedSession): ResumedLiveProjection {
-        val inflightProjection = resumed.retainedFailureMessage?.let { failureMessage ->
-            resumedFailureProjection(resumed, failureMessage)
-        } ?: if (resumed.inflightCorrections.isEmpty()) {
+        val reconstructedInflight = if (resumed.inflightCorrections.isEmpty()) {
             ResumedLiveProjection(
                 messages = resumed.messages,
                 streamingText = unpersistedInflightText(
@@ -2236,6 +2234,13 @@ internal class CelesteController(
                 streamingText = if (offsetsUsable) assistant.substring(cursor) else "",
             )
         }
+        val inflightProjection = resumed.retainedFailureMessage?.let { failureMessage ->
+            resumedFailureProjection(
+                projection = reconstructedInflight,
+                failureMessage = failureMessage,
+                runtimeSessionId = resumed.runtimeSessionId,
+            )
+        } ?: reconstructedInflight
 
         val queuedText = resumed.queuedUserText.trim()
         if (queuedText.isEmpty()) return inflightProjection
@@ -2260,21 +2265,18 @@ internal class CelesteController(
     }
 
     private fun resumedFailureProjection(
-        resumed: ResumedSession,
+        projection: ResumedLiveProjection,
         failureMessage: String,
+        runtimeSessionId: String,
     ): ResumedLiveProjection {
-        var messages = settleCurrentTurnSteps(resumed.messages)
-        val missingAssistant = unpersistedInflightText(
-            inflight = resumed.inflightAssistantText,
-            messages = messages,
-        )
-        if (missingAssistant.isNotBlank()) {
+        var messages = settleCurrentTurnSteps(projection.messages)
+        if (projection.streamingText.isNotBlank()) {
             messages = appendCurrentTurnMessage(
                 messages = messages,
                 message = ConversationMessage(
                     role = "assistant",
-                    text = missingAssistant,
-                    id = "retained-failure-${resumed.runtimeSessionId}",
+                    text = projection.streamingText,
+                    id = "retained-failure-$runtimeSessionId",
                     errorMessage = failureMessage,
                 ),
             )
@@ -2285,7 +2287,10 @@ internal class CelesteController(
             val assistantIndex = (messages.lastIndex downTo (promptStart + 1)).firstOrNull { index ->
                 messages[index].role == "assistant"
             }
-            if (assistantIndex != null) {
+            val latestCorrectionIndex = (messages.lastIndex downTo (promptStart + 1)).firstOrNull { index ->
+                messages[index].userPlacement == UserMessagePlacement.MidTurnCorrection
+            }
+            if (assistantIndex != null && (latestCorrectionIndex == null || assistantIndex > latestCorrectionIndex)) {
                 messages = messages.toMutableList().also { next ->
                     next[assistantIndex] = next[assistantIndex].copy(errorMessage = failureMessage)
                 }
@@ -2295,7 +2300,7 @@ internal class CelesteController(
                     message = ConversationMessage(
                         role = "assistant",
                         text = "",
-                        id = "retained-failure-${resumed.runtimeSessionId}",
+                        id = "retained-failure-$runtimeSessionId",
                         errorMessage = failureMessage,
                     ),
                 )

--- a/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/CelesteController.kt
@@ -2167,16 +2167,21 @@ internal class CelesteController(
     }
 
     private fun resumedLiveProjection(resumed: ResumedSession): ResumedLiveProjection {
+        val baseMessages = if (resumed.retainedFailureMessage != null) {
+            settleCurrentTurnSteps(resumed.messages)
+        } else {
+            resumed.messages
+        }
         val reconstructedInflight = if (resumed.inflightCorrections.isEmpty()) {
             ResumedLiveProjection(
-                messages = resumed.messages,
+                messages = baseMessages,
                 streamingText = unpersistedInflightText(
                     inflight = resumed.inflightAssistantText,
-                    messages = resumed.messages,
+                    messages = baseMessages,
                 ),
             )
         } else {
-            var messages = resumed.messages
+            var messages = baseMessages
             val assistant = resumed.inflightAssistantText
             val offsetsUsable = resumed.inflightCorrections.all { correction ->
                 correction.assistantOffset?.let { it in 0..assistant.length } == true
@@ -2186,7 +2191,7 @@ internal class CelesteController(
                 if (segment.isBlank()) return ""
                 if (!persistedPrefixAvailable) return segment
                 persistedPrefixAvailable = false
-                return unpersistedInflightText(segment, resumed.messages)
+                return unpersistedInflightText(segment, baseMessages)
             }
             var cursor = 0
             resumed.inflightCorrections.forEachIndexed { index, correction ->

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/ConversationMessage.kt
@@ -30,6 +30,7 @@ data class ConversationMessage(
     val id: String? = null,
     val pending: Boolean = false,
     val interim: Boolean = false,
+    val errorMessage: String? = null,
     val userPlacement: UserMessagePlacement = UserMessagePlacement.Prompt,
     val steps: List<ConversationStep> = emptyList(),
     val processResult: BackgroundProcessResult? = null,

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/DashboardClient.kt
@@ -104,6 +104,7 @@ data class ResumedSession(
     val queuedUserText: String = "",
     val inflightAssistantText: String = "",
     val inflightCorrections: List<InflightCorrection> = emptyList(),
+    val retainedFailureMessage: String? = null,
     val hasLiveProjection: Boolean = false,
 )
 

--- a/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/network/GatewaySessionApi.kt
@@ -95,6 +95,8 @@ suspend fun GatewayConnection.resumeStoredSession(
         ?: decoded.messages
     val inflightObject = inflight as? JsonObject
     val inflightAssistant = inflightAssistantText(inflight)
+    // Top-level status describes runtime liveness; a missed terminal outcome is retained here.
+    val retainedFailureMessage = inflightObject?.retainedTurnFailureMessage()
     val correctionOffsets = (inflightObject?.get("correction_offsets") as? JsonArray)
         ?.map { it.jsonPrimitive.intOrNull }
         .orEmpty()
@@ -126,8 +128,18 @@ suspend fun GatewayConnection.resumeStoredSession(
         queuedUserText = (queued as? JsonObject)?.string("user").orEmpty(),
         inflightAssistantText = inflightAssistant,
         inflightCorrections = inflightCorrections,
-        hasLiveProjection = inflight.isTruthy() || queued.isTruthy() || pendingClarification != null,
+        retainedFailureMessage = retainedFailureMessage,
+        hasLiveProjection = (inflight.isTruthy() && retainedFailureMessage == null) ||
+            queued.isTruthy() || pendingClarification != null,
     )
+}
+
+private fun JsonObject.retainedTurnFailureMessage(): String? {
+    if (string("status") != "error") return null
+    return string("error")
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?: "Hermes could not finish that response."
 }
 
 suspend fun GatewayConnection.submitPrompt(

--- a/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
+++ b/app/src/main/java/dev/hazydreams/hermesceleste/ui/conversation/TranscriptItem.kt
@@ -40,9 +40,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.hazydreams.hermesceleste.network.ConversationMessage
 import dev.hazydreams.hermesceleste.ui.CelesteAccent
+import dev.hazydreams.hermesceleste.ui.CelesteError
 import dev.hazydreams.hermesceleste.ui.CelesteTextMuted
 import dev.hazydreams.hermesceleste.ui.CelesteSurfaceSelected
 import dev.hazydreams.hermesceleste.ui.CelestePanel
+import dev.hazydreams.hermesceleste.ui.StatusMessage
 
 internal const val STREAMING_TRANSCRIPT_KEY = "streaming:assistant"
 
@@ -220,6 +222,9 @@ private fun AssistantMessage(
                     gatewayImageScope = gatewayImageScope,
                 )
             }
+        }
+        message.errorMessage?.let { error ->
+            StatusMessage(error, CelesteError)
         }
     }
 }

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -2274,9 +2274,10 @@ class CelesteViewModelTest {
     fun reconnectFailurePreservesAcceptedRedirectAtItsAssistantOffset() = runTest {
         val gateway = FakeGateway().apply {
             resumePayload = resumePayload(
-                messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+                messages = emptyList(),
                 running = false,
                 inflightJson = """{"user":"First","assistant":"Before.After.","streaming":false,"corrections":["Change direction"],"correction_offsets":[7],"status":"error","error":"Codex response remained incomplete."}""",
+                messageRowsJson = """{"id":"server-user","role":"user","text":"First"},{"id":"server-reasoning","role":"assistant","text":"","reasoning":"Working through it."}""",
             )
         }
         val viewModel = openConversation(gateway)
@@ -2284,11 +2285,14 @@ class CelesteViewModelTest {
 
         assertEquals(
             listOf("First", "Before.", "Change direction", "After."),
-            viewModel.state.value.messages.map { it.text },
+            viewModel.state.value.messages.filterNot { it.role == "steps" }.map { it.text },
         )
+        val steps = viewModel.state.value.messages.single { it.role == "steps" }
+        assertFalse(steps.pending)
+        assertTrue(steps.steps.none(ConversationStep::pending))
         assertEquals(
             UserMessagePlacement.MidTurnCorrection,
-            viewModel.state.value.messages[2].userPlacement,
+            viewModel.state.value.messages.single { it.text == "Change direction" }.userPlacement,
         )
         assertEquals("Codex response remained incomplete.", viewModel.state.value.messages.last().errorMessage)
         assertEquals(TurnState.Idle, viewModel.state.value.turnState)
@@ -3410,8 +3414,9 @@ class CelesteViewModelTest {
             storedSessionId: String = "stored-42",
             inflightJson: String = "null",
             queuedJson: String = "null",
+            messageRowsJson: String? = null,
         ): JsonObject {
-            val encodedMessages = messages.joinToString(",") { message ->
+            val encodedMessages = messageRowsJson ?: messages.joinToString(",") { message ->
                 """{"id":${Json.encodeToString(message.id ?: "")},"role":${Json.encodeToString(message.role)},"text":${Json.encodeToString(message.text)}}"""
             }
             return Json.parseToJsonElement(

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -2271,6 +2271,33 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun reconnectFailurePreservesAcceptedRedirectAtItsAssistantOffset() = runTest {
+        val gateway = FakeGateway().apply {
+            resumePayload = resumePayload(
+                messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+                running = false,
+                inflightJson = """{"user":"First","assistant":"Before.After.","streaming":false,"corrections":["Change direction"],"correction_offsets":[7],"status":"error","error":"Codex response remained incomplete."}""",
+            )
+        }
+        val viewModel = openConversation(gateway)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("First", "Before.", "Change direction", "After."),
+            viewModel.state.value.messages.map { it.text },
+        )
+        assertEquals(
+            UserMessagePlacement.MidTurnCorrection,
+            viewModel.state.value.messages[2].userPlacement,
+        )
+        assertEquals("Codex response remained incomplete.", viewModel.state.value.messages.last().errorMessage)
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertEquals("", viewModel.state.value.streamingText)
+        assertEquals(0, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
     fun retainedTerminalFailureSurvivesAutomaticQueuedPromptDrain() = runTest {
         val gateway = FakeGateway()
         val viewModel = openConversation(gateway)

--- a/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
+++ b/app/src/test/java/dev/hazydreams/hermesceleste/CelesteViewModelTest.kt
@@ -2225,6 +2225,85 @@ class CelesteViewModelTest {
     }
 
     @Test
+    fun reconnectSurfacesRetainedTerminalFailureAndSettlesTheTurn() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        viewModel.updateDraft("Do this once")
+        viewModel.sendMessage()
+        gateway.emit("message.start")
+        gateway.emit("message.delta", """{"text":"Half"}""")
+        gateway.emit("status.update", """{"kind":"compacting"}""")
+        advanceUntilIdle()
+
+        gateway.resumePayload = resumePayload(
+            messages = listOf(ConversationMessage(role = "user", text = "Do this once", id = "server-user")),
+            running = false,
+            inflightJson = """{"user":"Do this once","assistant":"Half","streaming":false,"status":"error","error":"Provider connection closed.","recoverable":true}""",
+        )
+        gateway.disconnect("dashboard restarted")
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        val failedReply = state.messages.single { it.role == "assistant" }
+        assertEquals(TurnState.Idle, state.turnState)
+        assertFalse(state.isCompacting)
+        assertNull(state.taskProgress)
+        assertEquals("Half", failedReply.text)
+        assertEquals("Provider connection closed.", failedReply.errorMessage)
+        assertNull(state.errorMessage)
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+
+        gateway.resumePayload = resumePayload(
+            messages = listOf(
+                ConversationMessage(role = "user", text = "Do this once", id = "server-user"),
+                ConversationMessage(role = "assistant", text = "Recovered", id = "server-assistant"),
+            ),
+            running = false,
+        )
+        gateway.disconnect("dashboard restarted again")
+        advanceUntilIdle()
+
+        assertEquals(TurnState.Idle, viewModel.state.value.turnState)
+        assertTrue(viewModel.state.value.messages.none { it.errorMessage != null })
+        assertNull(viewModel.state.value.errorMessage)
+        assertEquals(1, gateway.methods.count { it == "prompt.submit" })
+        viewModel.controller.close()
+    }
+
+    @Test
+    fun retainedTerminalFailureSurvivesAutomaticQueuedPromptDrain() = runTest {
+        val gateway = FakeGateway()
+        val viewModel = openConversation(gateway)
+        viewModel.updateDraft("First")
+        viewModel.sendMessage()
+        viewModel.updateDraft("Second")
+        viewModel.sendMessage()
+        advanceUntilIdle()
+        assertEquals(listOf("Second"), viewModel.state.value.queuedPrompts.map { it.text })
+
+        gateway.resumePayload = resumePayload(
+            messages = listOf(ConversationMessage(role = "user", text = "First", id = "server-user")),
+            running = false,
+            inflightJson = """{"user":"First","assistant":"Partial","streaming":false,"status":"error","error":"The first turn failed.","recoverable":true}""",
+        )
+        gateway.disconnect("dashboard restarted")
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals(
+            listOf("First", "Second"),
+            gateway.requests.filter { it.first == "prompt.submit" }
+                .map { it.second["text"]?.jsonPrimitive?.content },
+        )
+        assertTrue(state.queuedPrompts.isEmpty())
+        assertEquals(TurnState.Running, state.turnState)
+        assertEquals("The first turn failed.", state.messages.single { it.role == "assistant" }.errorMessage)
+        assertEquals(1, state.messages.count { it.role == "user" && it.text == "First" })
+        assertEquals(1, state.messages.count { it.role == "user" && it.text == "Second" })
+        viewModel.controller.close()
+    }
+
+    @Test
     fun transientReconnectKeepsTheDraftAndTransportDetailsOutOfTheConversation() = runTest {
         val gateway = FakeGateway()
         val dashboard = FakeDashboard(gateway)

--- a/docs/hermes-protocol.md
+++ b/docs/hermes-protocol.md
@@ -82,7 +82,7 @@ Celeste recognizes message lifecycle, interim assistant prose, reasoning, tools,
 - Background-process completion produces one compact result row with details available on demand.
 - Notifications with a blank session ID apply to the active conversation; nonblank mismatched runtime IDs are ignored.
 
-`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order; a server-queued next turn is projected after the current inflight assistant output. Hermes reports correction offsets as Unicode code-point positions, and Celeste translates them to Kotlin string indices at the protocol boundary. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
+`session.resume` binds runtime state while the dashboard history route supplies persisted display history. Accepted mid-turn corrections are rebuilt from the inflight correction list and assistant-text offsets so reconnect preserves their arrival order; a server-queued next turn is projected after the current inflight assistant output. A retained inflight terminal failure settles the runtime and remains attached to its assistant reply while local queued work continues from the authoritative idle state. Hermes reports correction offsets as Unicode code-point positions, and Celeste translates them to Kotlin string indices at the protocol boundary. Resume retries are bounded, preserve readable history, and end in an explicit Retry surface.
 
 ## Update workflow
 


### PR DESCRIPTION
Closes #99

## Summary

- decode retained terminal failures from `session.resume.inflight` without treating them as live work
- attach a recovered failure to its assistant transcript entry while settling the runtime and clearing transient activity
- preserve automatic local queue drain without replaying the uncertain failed prompt, and remove the recovered state on a later clean resume

## Reference behavior

Hermes Desktop projects retained inflight failures onto the authoritative assistant tail during resume. Celeste now follows that protocol contract while keeping its existing mobile-native transcript and client-owned queue behavior.

## Verification

- focused reconnect/missed-failure reconciliation tests
- focused queued-drain/no-replay test
- `git diff --check`
- Android lint
